### PR TITLE
[TEST] Add CLI output, telemetry hasher, and LLM unit tests

### DIFF
--- a/src/GauntletCI.Tests/CliOutputTests.cs
+++ b/src/GauntletCI.Tests/CliOutputTests.cs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Cli.Output;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+
+namespace GauntletCI.Tests;
+
+public class ConsoleReporterTests
+{
+    [Fact]
+    public void MaskEvidenceSnippet_WithSnippet_RedactsAfterColon()
+    {
+        var result = ConsoleReporter.MaskEvidenceSnippet("Line 42: _logger.Log(user.Email)");
+        Assert.Equal("Line 42: [REDACTED]", result);
+    }
+
+    [Fact]
+    public void MaskEvidenceSnippet_NoColon_ReturnsUnchanged()
+    {
+        var result = ConsoleReporter.MaskEvidenceSnippet("src/Auth.cs:42");
+        Assert.Equal("src/Auth.cs:42", result);
+    }
+
+    [Fact]
+    public void MaskEvidenceSnippet_Empty_ReturnsEmpty()
+    {
+        var result = ConsoleReporter.MaskEvidenceSnippet(string.Empty);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void MaskEvidenceSnippet_PreservesFileAndLine()
+    {
+        var result = ConsoleReporter.MaskEvidenceSnippet("src/Service.cs:99: secretToken = \"abc\"");
+        Assert.StartsWith("src/Service.cs:99: ", result);
+        Assert.EndsWith("[REDACTED]", result);
+        Assert.DoesNotContain("secretToken", result);
+    }
+}
+
+public class GitHubAnnotationWriterTests
+{
+    private static EvaluationResult MakeResult(params Finding[] findings) =>
+        new() { Findings = [.. findings], RulesEvaluated = 1 };
+
+    private static Finding MakeFinding(
+        string ruleId = "GCI0001",
+        string ruleName = "Diff Integrity",
+        string summary = "Something risky",
+        string evidence = "Line 10: bad code",
+        Confidence confidence = Confidence.High) =>
+        new()
+        {
+            RuleId = ruleId, RuleName = ruleName,
+            Summary = summary, Evidence = evidence,
+            WhyItMatters = "It matters.", SuggestedAction = "Fix it.",
+            Confidence = confidence,
+        };
+
+    private static string CaptureAnnotations(EvaluationResult result)
+    {
+        var sw = new StringWriter();
+        var original = Console.Out;
+        Console.SetOut(sw);
+        try { GitHubAnnotationWriter.Write(result); }
+        finally { Console.SetOut(original); }
+        return sw.ToString();
+    }
+
+    [Fact]
+    public void Write_HighConfidence_EmitsErrorLevel()
+    {
+        var output = CaptureAnnotations(MakeResult(MakeFinding(confidence: Confidence.High)));
+        Assert.Contains("::error", output);
+    }
+
+    [Fact]
+    public void Write_MediumConfidence_EmitsWarningLevel()
+    {
+        var output = CaptureAnnotations(MakeResult(MakeFinding(confidence: Confidence.Medium)));
+        Assert.Contains("::warning", output);
+    }
+
+    [Fact]
+    public void Write_LowConfidence_EmitsNoticeLevel()
+    {
+        var output = CaptureAnnotations(MakeResult(MakeFinding(confidence: Confidence.Low)));
+        Assert.Contains("::notice", output);
+    }
+
+    [Fact]
+    public void Write_IncludesRuleIdInTitle()
+    {
+        var output = CaptureAnnotations(MakeResult(MakeFinding(ruleId: "GCI0042")));
+        Assert.Contains("GCI0042", output);
+    }
+
+    [Fact]
+    public void Write_EvidenceWithLineNumber_ExtractsLine()
+    {
+        var output = CaptureAnnotations(MakeResult(MakeFinding(evidence: "Line 77: x = secret")));
+        Assert.Contains("line=77", output);
+    }
+
+    [Fact]
+    public void Write_NoFindings_ProducesNoOutput()
+    {
+        var output = CaptureAnnotations(MakeResult());
+        Assert.Equal(string.Empty, output.Trim());
+    }
+
+    [Fact]
+    public void Write_SummaryNewlines_AreEscaped()
+    {
+        var f = MakeFinding(summary: "line one\nline two");
+        var output = CaptureAnnotations(MakeResult(f));
+        Assert.DoesNotContain("\n", output.Split("::error").Last().Split("::").First());
+        Assert.Contains("%0A", output);
+    }
+}

--- a/src/GauntletCI.Tests/LlmTests.cs
+++ b/src/GauntletCI.Tests/LlmTests.cs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Model;
+using GauntletCI.Llm;
+
+namespace GauntletCI.Tests;
+
+public class NullLlmEngineTests
+{
+    private readonly NullLlmEngine _engine = new();
+
+    [Fact]
+    public void IsAvailable_ReturnsFalse()
+    {
+        Assert.False(_engine.IsAvailable);
+    }
+
+    [Fact]
+    public async Task EnrichFindingAsync_ReturnsEmpty()
+    {
+        var finding = new Finding
+        {
+            RuleId = "GCI0001", RuleName = "Diff Integrity",
+            Summary = "Mixed concerns", Evidence = "Line 1: x",
+            WhyItMatters = "Risk.", SuggestedAction = "Fix.",
+        };
+        var result = await _engine.EnrichFindingAsync(finding);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task SummarizeReportAsync_ReturnsEmpty()
+    {
+        var result = await _engine.SummarizeReportAsync([]);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var engine = new NullLlmEngine();
+        var ex = Record.Exception(() => engine.Dispose());
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ImplementsILlmEngine()
+    {
+        Assert.IsAssignableFrom<ILlmEngine>(_engine);
+    }
+}
+
+public class PromptTemplatesTests
+{
+    [Fact]
+    public void EnrichFinding_ContainsRuleId()
+    {
+        var prompt = PromptTemplates.EnrichFinding("GCI0007", "Error Handling", "Log removed", "Line 5: x");
+        Assert.Contains("GCI0007", prompt);
+    }
+
+    [Fact]
+    public void EnrichFinding_ContainsRuleName()
+    {
+        var prompt = PromptTemplates.EnrichFinding("GCI0007", "Error Handling Integrity", "Log removed", "Line 5: x");
+        Assert.Contains("Error Handling Integrity", prompt);
+    }
+
+    [Fact]
+    public void EnrichFinding_ContainsSummaryAndEvidence()
+    {
+        var prompt = PromptTemplates.EnrichFinding("GCI0001", "Diff Integrity", "Mixed concerns", "Line 42: x");
+        Assert.Contains("Mixed concerns", prompt);
+        Assert.Contains("Line 42: x", prompt);
+    }
+
+    [Fact]
+    public void EnrichFinding_StartsWithUserToken()
+    {
+        var prompt = PromptTemplates.EnrichFinding("GCI0001", "Test", "Summary", "Evidence");
+        Assert.StartsWith("<|user|>", prompt);
+    }
+
+    [Fact]
+    public void EnrichFinding_EndsWithAssistantToken()
+    {
+        var prompt = PromptTemplates.EnrichFinding("GCI0001", "Test", "Summary", "Evidence");
+        Assert.EndsWith("<|assistant|>\n", prompt);
+    }
+
+    [Fact]
+    public void SummarizeReport_NumbersFindings()
+    {
+        var prompt = PromptTemplates.SummarizeReport(["Missing tests", "Log removed"]);
+        Assert.Contains("1.", prompt);
+        Assert.Contains("2.", prompt);
+        Assert.Contains("Missing tests", prompt);
+        Assert.Contains("Log removed", prompt);
+    }
+
+    [Fact]
+    public void SummarizeReport_StartsWithUserToken()
+    {
+        var prompt = PromptTemplates.SummarizeReport(["finding"]);
+        Assert.StartsWith("<|user|>", prompt);
+    }
+
+    [Fact]
+    public void SummarizeReport_EmptyFindings_StillProducesValidPrompt()
+    {
+        var prompt = PromptTemplates.SummarizeReport([]);
+        Assert.StartsWith("<|user|>", prompt);
+        Assert.EndsWith("<|assistant|>\n", prompt);
+    }
+}

--- a/src/GauntletCI.Tests/TelemetryHasherTests.cs
+++ b/src/GauntletCI.Tests/TelemetryHasherTests.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Cli.Telemetry;
+
+namespace GauntletCI.Tests;
+
+public class TelemetryHasherTests
+{
+    [Fact]
+    public void Hash8_EmptyInput_Returns8Zeros()
+    {
+        Assert.Equal("00000000", TelemetryHasher.Hash8(string.Empty));
+    }
+
+    [Fact]
+    public void Hash8_NullInput_Returns8Zeros()
+    {
+        Assert.Equal("00000000", TelemetryHasher.Hash8(null!));
+    }
+
+    [Fact]
+    public void Hash8_ReturnsExactly8Characters()
+    {
+        var result = TelemetryHasher.Hash8("https://github.com/owner/repo");
+        Assert.Equal(8, result.Length);
+    }
+
+    [Fact]
+    public void Hash8_IsLowerCase()
+    {
+        var result = TelemetryHasher.Hash8("https://github.com/owner/repo");
+        Assert.Equal(result, result.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Hash8_IsOnlyHexCharacters()
+    {
+        var result = TelemetryHasher.Hash8("some-input");
+        Assert.Matches("^[0-9a-f]{8}$", result);
+    }
+
+    [Fact]
+    public void Hash8_IsDeterministic()
+    {
+        const string input = "https://github.com/EricCogen/GauntletCI";
+        Assert.Equal(TelemetryHasher.Hash8(input), TelemetryHasher.Hash8(input));
+    }
+
+    [Fact]
+    public void Hash8_DifferentInputs_ProduceDifferentHashes()
+    {
+        var a = TelemetryHasher.Hash8("https://github.com/owner/repo-a");
+        var b = TelemetryHasher.Hash8("https://github.com/owner/repo-b");
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Hash8_CaseAndWhitespaceNormalized()
+    {
+        // Internally does Trim().ToLowerInvariant() before hashing
+        Assert.Equal(
+            TelemetryHasher.Hash8("GitHub.com/Owner/Repo"),
+            TelemetryHasher.Hash8("  github.com/owner/repo  "));
+    }
+
+    [Fact]
+    public async Task HashRepoAsync_InvalidPath_ReturnsLocal()
+    {
+        var result = await TelemetryHasher.HashRepoAsync(Path.GetTempPath() + "nonexistent-" + Guid.NewGuid());
+        Assert.Equal("local", result);
+    }
+
+    [Fact]
+    public async Task HashRepoAsync_ValidGitRepo_Returns8CharHexOrLocal()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
+        var result = await TelemetryHasher.HashRepoAsync(repoRoot);
+        // Either a valid 8-char hex hash or "local" (no remote configured)
+        Assert.True(result == "local" || System.Text.RegularExpressions.Regex.IsMatch(result, "^[0-9a-f]{8}$"),
+            $"Unexpected result: {result}");
+    }
+}


### PR DESCRIPTION
- ConsoleReporterTests: MaskEvidenceSnippet (with/without snippet, empty, preserves prefix)
- GitHubAnnotationWriterTests: error/warning/notice levels, title, line extraction, no-findings, newline escaping
- TelemetryHasherTests: empty input, length, lowercase, hex, determinism, diff inputs, normalization, HashRepoAsync
- NullLlmEngineTests: IsAvailable, EnrichFindingAsync, SummarizeReportAsync, Dispose, interface check
- PromptTemplatesTests: ruleId/name/summary/evidence embedding, Phi-3 tokens, SummarizeReport numbering

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update