### PR TITLE
[CORPUS] Add GauntletCI.Corpus: domain models, interfaces, SQLite schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ artifacts/
 
 # GauntletCI model cache (Phi-3 Mini ONNX — ~2.8 GB, never commit)
 .gauntletci/
-models/
 **/*.onnx
 **/*.onnx.data
 **/phi3-mini-4k-instruct-*

--- a/GauntletCI.slnx
+++ b/GauntletCI.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/GauntletCI.Cli/GauntletCI.Cli.csproj" />
     <Project Path="src/GauntletCI.Core/GauntletCI.Core.csproj" />
+    <Project Path="src/GauntletCI.Corpus/GauntletCI.Corpus.csproj" />
     <Project Path="src/GauntletCI.Llm/GauntletCI.Llm.csproj" />
     <Project Path="src/GauntletCI.Tests/GauntletCI.Tests.csproj" />
     <Project Path="src/GauntletCI.BenchmarkReporter/GauntletCI.BenchmarkReporter.csproj" />

--- a/src/GauntletCI.Corpus/GauntletCI.Corpus.csproj
+++ b/src/GauntletCI.Corpus/GauntletCI.Corpus.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/GauntletCI.Corpus/Interfaces/IDiscoveryProvider.cs
+++ b/src/GauntletCI.Corpus/Interfaces/IDiscoveryProvider.cs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+
+namespace GauntletCI.Corpus.Interfaces;
+
+public interface IDiscoveryProvider
+{
+    string GetProviderName();
+    bool SupportsIncrementalSync { get; }
+    Task<IReadOnlyList<PullRequestCandidate>> SearchCandidatesAsync(
+        DiscoveryQuery query, CancellationToken cancellationToken = default);
+}

--- a/src/GauntletCI.Corpus/Interfaces/IFixtureStore.cs
+++ b/src/GauntletCI.Corpus/Interfaces/IFixtureStore.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+
+namespace GauntletCI.Corpus.Interfaces;
+
+public interface IFixtureStore
+{
+    Task SaveMetadataAsync(FixtureMetadata metadata, CancellationToken cancellationToken = default);
+    Task<FixtureMetadata?> GetMetadataAsync(string fixtureId, CancellationToken cancellationToken = default);
+    Task SaveExpectedFindingsAsync(string fixtureId, IReadOnlyList<ExpectedFinding> findings, CancellationToken cancellationToken = default);
+    Task SaveActualFindingsAsync(string fixtureId, string runId, IReadOnlyList<ActualFinding> findings, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<FixtureMetadata>> ListFixturesAsync(FixtureTier? tier = null, CancellationToken cancellationToken = default);
+}

--- a/src/GauntletCI.Corpus/Interfaces/IPullRequestHydrator.cs
+++ b/src/GauntletCI.Corpus/Interfaces/IPullRequestHydrator.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+
+namespace GauntletCI.Corpus.Interfaces;
+
+public interface IPullRequestHydrator
+{
+    Task<HydratedPullRequest> HydrateAsync(
+        PullRequestCandidate candidate, CancellationToken cancellationToken = default);
+
+    Task<HydratedPullRequest> HydrateFromUrlAsync(
+        string url, CancellationToken cancellationToken = default);
+}

--- a/src/GauntletCI.Corpus/Interfaces/IReportExporter.cs
+++ b/src/GauntletCI.Corpus/Interfaces/IReportExporter.cs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Interfaces;
+
+public interface IReportExporter
+{
+    Task<string> ExportMarkdownAsync(CancellationToken cancellationToken = default);
+}

--- a/src/GauntletCI.Corpus/Interfaces/IRuleCorpusRunner.cs
+++ b/src/GauntletCI.Corpus/Interfaces/IRuleCorpusRunner.cs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+
+namespace GauntletCI.Corpus.Interfaces;
+
+public interface IRuleCorpusRunner
+{
+    Task<IReadOnlyList<ActualFinding>> RunAsync(
+        string fixtureId, string diffText, CancellationToken cancellationToken = default);
+}

--- a/src/GauntletCI.Corpus/Interfaces/IScoreAggregator.cs
+++ b/src/GauntletCI.Corpus/Interfaces/IScoreAggregator.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+
+namespace GauntletCI.Corpus.Interfaces;
+
+public sealed record RuleScorecard(
+    string RuleId,
+    FixtureTier Tier,
+    int Fixtures,
+    double TriggerRate,
+    double Precision,
+    double Recall,
+    double InconclusiveRate,
+    double AvgUsefulness,
+    string Notes);
+
+public interface IScoreAggregator
+{
+    Task<IReadOnlyList<RuleScorecard>> ScoreAsync(
+        string? ruleId = null, FixtureTier? tier = null, CancellationToken cancellationToken = default);
+}

--- a/src/GauntletCI.Corpus/Models/ActualFinding.cs
+++ b/src/GauntletCI.Corpus/Models/ActualFinding.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public sealed class ActualFinding
+{
+    public string RuleId { get; init; } = string.Empty;
+    public bool DidTrigger { get; init; }
+    public double ActualConfidence { get; init; }
+    public string Message { get; init; } = string.Empty;
+    public string ChangeImplication { get; init; } = string.Empty;
+    public string Evidence { get; init; } = string.Empty;
+    public long ExecutionTimeMs { get; init; }
+}

--- a/src/GauntletCI.Corpus/Models/ChangedFile.cs
+++ b/src/GauntletCI.Corpus/Models/ChangedFile.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public sealed class ChangedFile
+{
+    public string Path { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+    public int Additions { get; init; }
+    public int Deletions { get; init; }
+    public string Patch { get; init; } = string.Empty;
+    public bool IsTestFile { get; init; }
+    public string LanguageHint { get; init; } = string.Empty;
+}

--- a/src/GauntletCI.Corpus/Models/DiscoveryQuery.cs
+++ b/src/GauntletCI.Corpus/Models/DiscoveryQuery.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public sealed class DiscoveryQuery
+{
+    public IReadOnlyList<string> Languages { get; init; } = [];
+    public IReadOnlyList<string> RepoAllowList { get; init; } = [];
+    public IReadOnlyList<string> RepoBlockList { get; init; } = [];
+    public DateTime? StartDateUtc { get; init; }
+    public DateTime? EndDateUtc { get; init; }
+    public int MinReviewComments { get; init; }
+    public int MinStars { get; init; }
+    public int MaxStars { get; init; } = int.MaxValue;
+    public int MaxCandidates { get; init; } = 100;
+    public bool IncludeDrafts { get; init; }
+    public IReadOnlyList<string> Tags { get; init; } = [];
+}

--- a/src/GauntletCI.Corpus/Models/Enums.cs
+++ b/src/GauntletCI.Corpus/Models/Enums.cs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public enum FixtureTier { Discovery, Silver, Gold }
+
+public enum PrSizeBucket { Tiny, Small, Medium, Large, Huge }
+
+public enum MergeState { Open, Merged, Closed }
+
+public enum HydrationStatus { Pending, InProgress, Completed, Failed }
+
+public enum LabelSource { Heuristic, HumanReview, Seed }

--- a/src/GauntletCI.Corpus/Models/ExpectedFinding.cs
+++ b/src/GauntletCI.Corpus/Models/ExpectedFinding.cs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public sealed class ExpectedFinding
+{
+    public string RuleId { get; init; } = string.Empty;
+    public bool ShouldTrigger { get; init; }
+    public double ExpectedConfidence { get; init; }
+    public string Reason { get; init; } = string.Empty;
+    public LabelSource LabelSource { get; init; }
+    public bool IsInconclusive { get; init; }
+}

--- a/src/GauntletCI.Corpus/Models/FixtureEvaluation.cs
+++ b/src/GauntletCI.Corpus/Models/FixtureEvaluation.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public sealed class FixtureEvaluation
+{
+    public string FixtureId { get; init; } = string.Empty;
+    public string RuleId { get; init; } = string.Empty;
+    public string PrecisionBucket { get; init; } = string.Empty;
+    public string RecallBucket { get; init; } = string.Empty;
+    public double Usefulness { get; init; }
+    public string ReviewerNotes { get; init; } = string.Empty;
+    public DateTime EvaluatedAtUtc { get; init; }
+}

--- a/src/GauntletCI.Corpus/Models/FixtureMetadata.cs
+++ b/src/GauntletCI.Corpus/Models/FixtureMetadata.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public sealed class FixtureMetadata
+{
+    public string FixtureId { get; init; } = string.Empty;
+    public FixtureTier Tier { get; init; }
+    public string Repo { get; init; } = string.Empty;
+    public int PullRequestNumber { get; init; }
+    public string Language { get; init; } = string.Empty;
+    public IReadOnlyList<string> RuleIds { get; init; } = [];
+    public IReadOnlyList<string> Tags { get; init; } = [];
+    public PrSizeBucket PrSizeBucket { get; init; }
+    public int FilesChanged { get; init; }
+    public bool HasTestsChanged { get; init; }
+    public bool HasReviewComments { get; init; }
+    public string BaseSha { get; init; } = string.Empty;
+    public string HeadSha { get; init; } = string.Empty;
+    public string Source { get; init; } = string.Empty;
+    public DateTime CreatedAtUtc { get; init; }
+}

--- a/src/GauntletCI.Corpus/Models/HydratedPullRequest.cs
+++ b/src/GauntletCI.Corpus/Models/HydratedPullRequest.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public sealed class HydratedPullRequest
+{
+    public string RepoOwner { get; init; } = string.Empty;
+    public string RepoName { get; init; } = string.Empty;
+    public int PullRequestNumber { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Body { get; init; } = string.Empty;
+    public string BaseSha { get; init; } = string.Empty;
+    public string HeadSha { get; init; } = string.Empty;
+    public string MergeCommitSha { get; init; } = string.Empty;
+    public int FilesChangedCount { get; init; }
+    public int Additions { get; init; }
+    public int Deletions { get; init; }
+    public IReadOnlyList<ChangedFile> ChangedFiles { get; init; } = [];
+    public IReadOnlyList<ReviewComment> ReviewComments { get; init; } = [];
+    public IReadOnlyList<string> Commits { get; init; } = [];
+    public string DiffText { get; init; } = string.Empty;
+    public string PatchText { get; init; } = string.Empty;
+    public string? RawApiPayloadJson { get; init; }
+    public DateTime HydratedAtUtc { get; init; }
+}

--- a/src/GauntletCI.Corpus/Models/PrSizeBucketClassifier.cs
+++ b/src/GauntletCI.Corpus/Models/PrSizeBucketClassifier.cs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public static class PrSizeBucketClassifier
+{
+    public static PrSizeBucket Classify(int filesChanged) => filesChanged switch
+    {
+        <= 2 => PrSizeBucket.Tiny,
+        <= 7 => PrSizeBucket.Small,
+        <= 20 => PrSizeBucket.Medium,
+        <= 75 => PrSizeBucket.Large,
+        _ => PrSizeBucket.Huge,
+    };
+}

--- a/src/GauntletCI.Corpus/Models/PullRequestCandidate.cs
+++ b/src/GauntletCI.Corpus/Models/PullRequestCandidate.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public sealed class PullRequestCandidate
+{
+    public string Source { get; init; } = string.Empty;
+    public string RepoOwner { get; init; } = string.Empty;
+    public string RepoName { get; init; } = string.Empty;
+    public int PullRequestNumber { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public string Language { get; init; } = string.Empty;
+    public DateTime CreatedAtUtc { get; init; }
+    public DateTime UpdatedAtUtc { get; init; }
+    public string CandidateReason { get; init; } = string.Empty;
+    public int ReviewCommentCount { get; init; }
+    public bool IsDraft { get; init; }
+    public MergeState MergeState { get; init; }
+    public string? RawMetadataJson { get; init; }
+}

--- a/src/GauntletCI.Corpus/Models/ReviewComment.cs
+++ b/src/GauntletCI.Corpus/Models/ReviewComment.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+public sealed class ReviewComment
+{
+    public string Author { get; init; } = string.Empty;
+    public string Body { get; init; } = string.Empty;
+    public string Path { get; init; } = string.Empty;
+    public string DiffHunk { get; init; } = string.Empty;
+    public int Position { get; init; }
+    public DateTime CreatedAtUtc { get; init; }
+    public string Url { get; init; } = string.Empty;
+}

--- a/src/GauntletCI.Corpus/Storage/CorpusDb.cs
+++ b/src/GauntletCI.Corpus/Storage/CorpusDb.cs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Elastic-2.0
+using Microsoft.Data.Sqlite;
+
+namespace GauntletCI.Corpus.Storage;
+
+/// <summary>
+/// Opens (or creates) the corpus SQLite database and applies the schema.
+/// Call <see cref="InitializeAsync"/> once at startup before any other DB access.
+/// </summary>
+public sealed class CorpusDb : IDisposable
+{
+    private readonly string _connectionString;
+    private SqliteConnection? _connection;
+
+    public CorpusDb(string dbPath = "./data/gauntletci-corpus.db")
+    {
+        var dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        _connectionString = $"Data Source={dbPath}";
+    }
+
+    public SqliteConnection Connection => _connection
+        ?? throw new InvalidOperationException("Call InitializeAsync first.");
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        _connection = new SqliteConnection(_connectionString);
+        await _connection.OpenAsync(cancellationToken);
+        await ApplySchemaAsync(cancellationToken);
+    }
+
+    private async Task ApplySchemaAsync(CancellationToken cancellationToken)
+    {
+        using var cmd = Connection.CreateCommand();
+        cmd.CommandText = SchemaInitializer.Ddl;
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public void Dispose() => _connection?.Dispose();
+}
+
+internal static class SchemaInitializer
+{
+    internal const string Ddl = """
+        PRAGMA journal_mode=WAL;
+
+        CREATE TABLE IF NOT EXISTS candidates (
+            id                  TEXT PRIMARY KEY,
+            source              TEXT NOT NULL,
+            repo_owner          TEXT NOT NULL,
+            repo_name           TEXT NOT NULL,
+            pr_number           INTEGER NOT NULL,
+            url                 TEXT NOT NULL,
+            language            TEXT,
+            created_at_utc      TEXT,
+            updated_at_utc      TEXT,
+            review_comment_count INTEGER DEFAULT 0,
+            candidate_reason    TEXT,
+            raw_metadata_json   TEXT,
+            discovered_at_utc   TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(repo_owner, repo_name, pr_number)
+        );
+
+        CREATE TABLE IF NOT EXISTS hydrations (
+            id                  TEXT PRIMARY KEY,
+            candidate_id        TEXT NOT NULL REFERENCES candidates(id),
+            base_sha            TEXT,
+            head_sha            TEXT,
+            files_changed_count INTEGER DEFAULT 0,
+            additions           INTEGER DEFAULT 0,
+            deletions           INTEGER DEFAULT 0,
+            hydrated_at_utc     TEXT,
+            status              TEXT NOT NULL DEFAULT 'Pending',
+            error_message       TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS fixtures (
+            id                  TEXT PRIMARY KEY,
+            fixture_id          TEXT NOT NULL UNIQUE,
+            tier                TEXT NOT NULL,
+            repo                TEXT NOT NULL,
+            pr_number           INTEGER NOT NULL,
+            language            TEXT,
+            path                TEXT,
+            rule_ids_json       TEXT,
+            tags_json           TEXT,
+            pr_size_bucket      TEXT,
+            has_tests_changed   INTEGER DEFAULT 0,
+            has_review_comments INTEGER DEFAULT 0,
+            source              TEXT,
+            created_at_utc      TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS expected_findings (
+            id                  TEXT PRIMARY KEY,
+            fixture_id          TEXT NOT NULL REFERENCES fixtures(fixture_id),
+            rule_id             TEXT NOT NULL,
+            should_trigger      INTEGER NOT NULL DEFAULT 0,
+            expected_confidence REAL DEFAULT 0.0,
+            reason              TEXT,
+            label_source        TEXT,
+            is_inconclusive     INTEGER DEFAULT 0
+        );
+
+        CREATE TABLE IF NOT EXISTS actual_findings (
+            id                  TEXT PRIMARY KEY,
+            fixture_id          TEXT NOT NULL REFERENCES fixtures(fixture_id),
+            run_id              TEXT NOT NULL,
+            rule_id             TEXT NOT NULL,
+            did_trigger         INTEGER NOT NULL DEFAULT 0,
+            actual_confidence   REAL DEFAULT 0.0,
+            message             TEXT,
+            change_implication  TEXT,
+            evidence_json       TEXT,
+            execution_time_ms   INTEGER DEFAULT 0
+        );
+
+        CREATE TABLE IF NOT EXISTS rule_runs (
+            id                  TEXT PRIMARY KEY,
+            fixture_id          TEXT NOT NULL REFERENCES fixtures(fixture_id),
+            started_at_utc      TEXT NOT NULL,
+            completed_at_utc    TEXT,
+            engine_version      TEXT,
+            rule_set_version    TEXT,
+            status              TEXT NOT NULL DEFAULT 'Pending',
+            error_message       TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS evaluations (
+            id                  TEXT PRIMARY KEY,
+            fixture_id          TEXT NOT NULL REFERENCES fixtures(fixture_id),
+            rule_id             TEXT NOT NULL,
+            usefulness          REAL DEFAULT 0.0,
+            reviewer_notes      TEXT,
+            evaluated_at_utc    TEXT NOT NULL DEFAULT (datetime('now')),
+            reviewer            TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS aggregates (
+            rule_id             TEXT NOT NULL,
+            tier                TEXT NOT NULL,
+            trigger_rate        REAL DEFAULT 0.0,
+            precision_score     REAL DEFAULT 0.0,
+            recall_score        REAL DEFAULT 0.0,
+            usefulness_score    REAL DEFAULT 0.0,
+            last_updated_utc    TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (rule_id, tier)
+        );
+        """;
+}


### PR DESCRIPTION
- New project: src/GauntletCI.Corpus (net8.0, Microsoft.Data.Sqlite)
- Domain models: PullRequestCandidate, HydratedPullRequest, ChangedFile, ReviewComment, FixtureMetadata, ExpectedFinding, ActualFinding, FixtureEvaluation, DiscoveryQuery
- Enums: FixtureTier, PrSizeBucket, MergeState, HydrationStatus, LabelSource
- PrSizeBucketClassifier (tiny/small/medium/large/huge thresholds per spec)
- Interfaces: IDiscoveryProvider, IPullRequestHydrator, IFixtureStore, IRuleCorpusRunner, IScoreAggregator, IReportExporter
- CorpusDb: opens/creates SQLite DB, runs CREATE TABLE IF NOT EXISTS for all 8 tables (candidates, hydrations, fixtures, expected_findings, actual_findings, rule_runs, evaluations, aggregates)
- Added Corpus project to GauntletCI.slnx solution
- Fixed .gitignore: removed overly-broad 'models/' pattern (redundant with .gauntletci/ which already covers the ONNX cache directory)
- All 249 unit tests + 6 benchmarks passing