### PR TITLE
[CORPUS] Fixture folder layout, storage implementation, test file cla…

### DIFF
--- a/src/GauntletCI.Corpus/Normalization/TestFileClassifier.cs
+++ b/src/GauntletCI.Corpus/Normalization/TestFileClassifier.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Normalization;
+
+/// <summary>
+/// Classifies source files as test files based on path and naming heuristics.
+/// </summary>
+public static class TestFileClassifier
+{
+    private static readonly string[] PathSegments = ["/test/", "/tests/", "\\test\\", "\\tests\\"];
+    private static readonly string[] NameSuffixes  = [".tests.cs", ".test.cs", "tests.cs", "test.cs"];
+    private static readonly string[] ProjectHints  = ["test", "tests"];
+
+    public static bool IsTestFile(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath)) return false;
+
+        var lower = filePath.ToLowerInvariant();
+
+        foreach (var seg in PathSegments)
+            if (lower.Contains(seg)) return true;
+
+        var fileName = Path.GetFileName(lower);
+        foreach (var suffix in NameSuffixes)
+            if (fileName.EndsWith(suffix, StringComparison.Ordinal)) return true;
+
+        // Project-name hint: any path segment that is purely a test project name
+        var parts = filePath.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+        foreach (var part in parts)
+        {
+            var lp = part.ToLowerInvariant();
+            foreach (var hint in ProjectHints)
+                if (lp == hint || lp.EndsWith('.' + hint) || lp.StartsWith(hint + '.'))
+                    return true;
+        }
+
+        return false;
+    }
+}

--- a/src/GauntletCI.Corpus/Storage/FixtureFolderStore.cs
+++ b/src/GauntletCI.Corpus/Storage/FixtureFolderStore.cs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GauntletCI.Corpus.Interfaces;
+using GauntletCI.Corpus.Models;
+using Microsoft.Data.Sqlite;
+
+namespace GauntletCI.Corpus.Storage;
+
+/// <summary>
+/// Concrete <see cref="IFixtureStore"/> backed by the file system (JSON files) and
+/// a SQLite index (<see cref="CorpusDb"/>).
+/// </summary>
+public sealed class FixtureFolderStore : IFixtureStore
+{
+    private readonly string _basePath;
+    private readonly CorpusDb _db;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public FixtureFolderStore(CorpusDb db, string basePath = "./data/fixtures")
+    {
+        _db = db;
+        _basePath = basePath;
+    }
+
+    // ── IFixtureStore ────────────────────────────────────────────────────────
+
+    public async Task SaveMetadataAsync(FixtureMetadata metadata, CancellationToken ct = default)
+    {
+        var fixturePath = EnsureFixtureDir(metadata.Tier, metadata.FixtureId);
+        var metaPath    = Path.Combine(fixturePath, "metadata.json");
+
+        await File.WriteAllTextAsync(metaPath, JsonSerializer.Serialize(metadata, JsonOpts), ct);
+        EnsureNotesTemplate(fixturePath, metadata);
+        await UpsertFixtureSqliteAsync(metadata, fixturePath, ct);
+    }
+
+    public async Task<FixtureMetadata?> GetMetadataAsync(string fixtureId, CancellationToken ct = default)
+    {
+        // Try each tier in preference order: gold > silver > discovery
+        foreach (var tier in new[] { FixtureTier.Gold, FixtureTier.Silver, FixtureTier.Discovery })
+        {
+            var path = Path.Combine(FixtureIdHelper.GetFixturePath(_basePath, tier, fixtureId), "metadata.json");
+            if (!File.Exists(path)) continue;
+
+            var json = await File.ReadAllTextAsync(path, ct);
+            return JsonSerializer.Deserialize<FixtureMetadata>(json, JsonOpts);
+        }
+        return null;
+    }
+
+    public async Task SaveExpectedFindingsAsync(
+        string fixtureId, IReadOnlyList<ExpectedFinding> findings, CancellationToken ct = default)
+    {
+        var fixturePath = FindExistingFixturePath(fixtureId)
+            ?? throw new InvalidOperationException($"Fixture '{fixtureId}' not found. Call SaveMetadataAsync first.");
+
+        var expectedPath = Path.Combine(fixturePath, "expected.json");
+        await File.WriteAllTextAsync(expectedPath, JsonSerializer.Serialize(findings, JsonOpts), ct);
+    }
+
+    public async Task SaveActualFindingsAsync(
+        string fixtureId, string runId, IReadOnlyList<ActualFinding> findings, CancellationToken ct = default)
+    {
+        var fixturePath = FindExistingFixturePath(fixtureId)
+            ?? throw new InvalidOperationException($"Fixture '{fixtureId}' not found. Call SaveMetadataAsync first.");
+
+        // Actual findings are stored per run so prior runs aren't overwritten.
+        var actualPath = Path.Combine(fixturePath, $"actual.{runId}.json");
+        await File.WriteAllTextAsync(actualPath, JsonSerializer.Serialize(findings, JsonOpts), ct);
+
+        // Also write/overwrite the canonical actual.json with the latest run.
+        var latestPath = Path.Combine(fixturePath, "actual.json");
+        await File.WriteAllTextAsync(latestPath, JsonSerializer.Serialize(findings, JsonOpts), ct);
+    }
+
+    public async Task<IReadOnlyList<FixtureMetadata>> ListFixturesAsync(
+        FixtureTier? tier = null, CancellationToken ct = default)
+    {
+        using var cmd = _db.Connection.CreateCommand();
+
+        if (tier.HasValue)
+        {
+            cmd.CommandText = "SELECT path FROM fixtures WHERE tier = $tier";
+            cmd.Parameters.AddWithValue("$tier", tier.Value.ToString());
+        }
+        else
+        {
+            cmd.CommandText = "SELECT path FROM fixtures";
+        }
+
+        var paths = new List<string>();
+        using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+            paths.Add(reader.GetString(0));
+
+        var results = new List<FixtureMetadata>();
+        foreach (var path in paths)
+        {
+            var metaPath = Path.Combine(path, "metadata.json");
+            if (!File.Exists(metaPath)) continue;
+            var json = await File.ReadAllTextAsync(metaPath, ct);
+            var m = JsonSerializer.Deserialize<FixtureMetadata>(json, JsonOpts);
+            if (m is not null) results.Add(m);
+        }
+        return results;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private string EnsureFixtureDir(FixtureTier tier, string fixtureId)
+    {
+        var path = FixtureIdHelper.GetFixturePath(_basePath, tier, fixtureId);
+        Directory.CreateDirectory(path);
+        Directory.CreateDirectory(FixtureIdHelper.GetRawPath(path));
+        return path;
+    }
+
+    private string? FindExistingFixturePath(string fixtureId)
+    {
+        foreach (var tier in new[] { FixtureTier.Gold, FixtureTier.Silver, FixtureTier.Discovery })
+        {
+            var path = FixtureIdHelper.GetFixturePath(_basePath, tier, fixtureId);
+            if (Directory.Exists(path)) return path;
+        }
+        return null;
+    }
+
+    private static void EnsureNotesTemplate(string fixturePath, FixtureMetadata meta)
+    {
+        var notesPath = Path.Combine(fixturePath, "notes.md");
+        if (File.Exists(notesPath)) return;
+
+        var template = $"""
+            # {meta.FixtureId}
+
+            **Repo:** {meta.Repo}  
+            **PR:** #{meta.PullRequestNumber}  
+            **Tier:** {meta.Tier}  
+            **Size:** {meta.PrSizeBucket} ({meta.FilesChanged} files)  
+
+            ## Reviewer Notes
+
+            <!-- Add notes here -->
+
+            ## Label Justification
+
+            <!-- Explain why expected.json was labeled the way it was -->
+            """;
+
+        File.WriteAllText(notesPath, template);
+    }
+
+    private async Task UpsertFixtureSqliteAsync(FixtureMetadata meta, string fixturePath, CancellationToken ct)
+    {
+        using var cmd = _db.Connection.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO fixtures (id, fixture_id, tier, repo, pr_number, language, path,
+                rule_ids_json, tags_json, pr_size_bucket, has_tests_changed,
+                has_review_comments, source, created_at_utc)
+            VALUES ($id, $fixture_id, $tier, $repo, $pr_number, $language, $path,
+                $rule_ids_json, $tags_json, $pr_size_bucket, $has_tests_changed,
+                $has_review_comments, $source, $created_at_utc)
+            ON CONFLICT(fixture_id) DO UPDATE SET
+                tier = excluded.tier,
+                path = excluded.path,
+                rule_ids_json = excluded.rule_ids_json,
+                tags_json = excluded.tags_json,
+                pr_size_bucket = excluded.pr_size_bucket,
+                has_tests_changed = excluded.has_tests_changed,
+                has_review_comments = excluded.has_review_comments;
+            """;
+
+        cmd.Parameters.AddWithValue("$id", Guid.NewGuid().ToString());
+        cmd.Parameters.AddWithValue("$fixture_id", meta.FixtureId);
+        cmd.Parameters.AddWithValue("$tier", meta.Tier.ToString());
+        cmd.Parameters.AddWithValue("$repo", meta.Repo);
+        cmd.Parameters.AddWithValue("$pr_number", meta.PullRequestNumber);
+        cmd.Parameters.AddWithValue("$language", meta.Language);
+        cmd.Parameters.AddWithValue("$path", fixturePath);
+        cmd.Parameters.AddWithValue("$rule_ids_json", JsonSerializer.Serialize(meta.RuleIds));
+        cmd.Parameters.AddWithValue("$tags_json", JsonSerializer.Serialize(meta.Tags));
+        cmd.Parameters.AddWithValue("$pr_size_bucket", meta.PrSizeBucket.ToString());
+        cmd.Parameters.AddWithValue("$has_tests_changed", meta.HasTestsChanged ? 1 : 0);
+        cmd.Parameters.AddWithValue("$has_review_comments", meta.HasReviewComments ? 1 : 0);
+        cmd.Parameters.AddWithValue("$source", meta.Source);
+        cmd.Parameters.AddWithValue("$created_at_utc", meta.CreatedAtUtc.ToString("o"));
+
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+}

--- a/src/GauntletCI.Corpus/Storage/FixtureIdHelper.cs
+++ b/src/GauntletCI.Corpus/Storage/FixtureIdHelper.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+
+namespace GauntletCI.Corpus.Storage;
+
+/// <summary>
+/// Builds deterministic fixture IDs and resolves fixture paths on disk.
+/// </summary>
+public static class FixtureIdHelper
+{
+    /// <summary>
+    /// Builds a fixture ID from repo owner, name, and PR number.
+    /// Example: "torvalds", "linux", 4321 → "torvalds_linux_pr4321"
+    /// </summary>
+    public static string Build(string repoOwner, string repoName, int prNumber)
+    {
+        var owner = Sanitize(repoOwner);
+        var repo  = Sanitize(repoName);
+        return $"{owner}_{repo}_pr{prNumber}";
+    }
+
+    /// <summary>Resolves the fixture folder path for the given tier and fixture ID.</summary>
+    public static string GetFixturePath(string basePath, FixtureTier tier, string fixtureId)
+        => Path.Combine(basePath, tier.ToString().ToLowerInvariant(), fixtureId);
+
+    /// <summary>Resolves the raw snapshot sub-folder inside a fixture folder.</summary>
+    public static string GetRawPath(string fixturePath) => Path.Combine(fixturePath, "raw");
+
+    private static string Sanitize(string s)
+        => s.ToLowerInvariant()
+            .Replace('/', '_')
+            .Replace('\\', '_')
+            .Replace(' ', '-');
+}

--- a/src/GauntletCI.Corpus/Storage/RawSnapshotStore.cs
+++ b/src/GauntletCI.Corpus/Storage/RawSnapshotStore.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+
+namespace GauntletCI.Corpus.Storage;
+
+/// <summary>
+/// Persists raw API response snapshots into a fixture's raw/ subfolder.
+/// This ensures original payloads are never lost, even if normalization changes.
+/// </summary>
+public sealed class RawSnapshotStore
+{
+    private readonly string _basePath;
+
+    public RawSnapshotStore(string basePath = "./data/fixtures")
+    {
+        _basePath = basePath;
+    }
+
+    public async Task SaveAsync(
+        FixtureTier tier,
+        string fixtureId,
+        string fileName,
+        string content,
+        CancellationToken ct = default)
+    {
+        var rawDir = FixtureIdHelper.GetRawPath(
+            FixtureIdHelper.GetFixturePath(_basePath, tier, fixtureId));
+
+        Directory.CreateDirectory(rawDir);
+        await File.WriteAllTextAsync(Path.Combine(rawDir, fileName), content, ct);
+    }
+
+    public async Task<string?> LoadAsync(
+        FixtureTier tier, string fixtureId, string fileName, CancellationToken ct = default)
+    {
+        var path = Path.Combine(
+            FixtureIdHelper.GetRawPath(
+                FixtureIdHelper.GetFixturePath(_basePath, tier, fixtureId)),
+            fileName);
+
+        return File.Exists(path) ? await File.ReadAllTextAsync(path, ct) : null;
+    }
+}


### PR DESCRIPTION
- FixtureIdHelper: deterministic fixture IDs (owner_repo_prNNN, slashes→underscores) and path resolution per tier (gold/silver/discovery)
- FixtureFolderStore: concrete IFixtureStore backed by file system + SQLite
  - SaveMetadataAsync: writes metadata.json, creates raw/ dir, creates notes.md template, upserts into SQLite fixtures table (ON CONFLICT DO UPDATE)
  - GetMetadataAsync: reads metadata.json from disk (gold > silver > discovery)
  - SaveExpectedFindingsAsync: writes expected.json
  - SaveActualFindingsAsync: writes actual.<runId>.json + latest actual.json
  - ListFixturesAsync: queries SQLite for paths, reads metadata.json from disk
- RawSnapshotStore: saves/loads raw API snapshots into fixture raw/ subfolder
- TestFileClassifier: heuristic test-file detection (path segments /test/ /tests/, filename suffixes Tests.cs / Test.cs, project-name segments)
- Normalization/ directory created for upcoming normalization pipeline