### PR TITLE
[CORPUS] Manual PR ingestion: hydrator, normalizer, CLI command

### DIFF
--- a/src/GauntletCI.Cli/Commands/CorpusCommand.cs
+++ b/src/GauntletCI.Cli/Commands/CorpusCommand.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.CommandLine;
+using GauntletCI.Corpus.Hydration;
+using GauntletCI.Corpus.Normalization;
+using GauntletCI.Corpus.Storage;
+
+namespace GauntletCI.Cli.Commands;
+
+public static class CorpusCommand
+{
+    public static Command Create()
+    {
+        var corpus = new Command("corpus", "Manage the GauntletCI fixture corpus");
+        corpus.AddCommand(CreateAddPr());
+        return corpus;
+    }
+
+    // gauntletci corpus add-pr --url <url> [--db <path>] [--fixtures <path>]
+    private static Command CreateAddPr()
+    {
+        var urlOpt      = new Option<string>("--url",      "GitHub PR URL (https://github.com/owner/repo/pull/NNN)") { IsRequired = true };
+        var dbOpt       = new Option<string>("--db",       () => "./data/gauntletci-corpus.db", "Path to corpus SQLite database");
+        var fixturesOpt = new Option<string>("--fixtures", () => "./data/fixtures",             "Path to fixtures root directory");
+
+        var cmd = new Command("add-pr", "Hydrate a pull request and add it to the corpus");
+        cmd.AddOption(urlOpt);
+        cmd.AddOption(dbOpt);
+        cmd.AddOption(fixturesOpt);
+
+        cmd.SetHandler(async (ctx) =>
+        {
+            var url      = ctx.ParseResult.GetValueForOption(urlOpt)!;
+            var dbPath   = ctx.ParseResult.GetValueForOption(dbOpt)!;
+            var fixtures = ctx.ParseResult.GetValueForOption(fixturesOpt)!;
+            var ct       = ctx.GetCancellationToken();
+
+            Console.WriteLine($"[corpus] Hydrating {url}");
+
+            var db = new CorpusDb(dbPath);
+            await db.InitializeAsync(ct);
+
+            var hydrator   = GitHubRestHydrator.CreateDefault(fixtures);
+            var rawStore   = new RawSnapshotStore(fixtures);
+            var fixtureStore = new FixtureFolderStore(db, fixtures);
+
+            try
+            {
+                var hydrated = await hydrator.HydrateFromUrlAsync(url, ct);
+                var metadata = FixtureNormalizer.Normalize(hydrated, source: "manual");
+
+                await fixtureStore.SaveMetadataAsync(metadata, ct);
+
+                Console.WriteLine($"[corpus] Saved fixture: {metadata.FixtureId}");
+                Console.WriteLine($"[corpus] Tier: {metadata.Tier}  Size: {metadata.PrSizeBucket}  " +
+                                  $"Files: {metadata.FilesChanged}  Tags: {string.Join(", ", metadata.Tags)}");
+                Console.WriteLine($"[corpus] Run 'gauntletci corpus run --fixture {metadata.FixtureId}' next.");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[corpus] Error: {ex.Message}");
+                ctx.ExitCode = 1;
+            }
+        });
+
+        return cmd;
+    }
+}

--- a/src/GauntletCI.Cli/GauntletCI.Cli.csproj
+++ b/src/GauntletCI.Cli/GauntletCI.Cli.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GauntletCI.Core\GauntletCI.Core.csproj" />
+    <ProjectReference Include="..\GauntletCI.Corpus\GauntletCI.Corpus.csproj" />
     <ProjectReference Include="..\GauntletCI.Llm\GauntletCI.Llm.csproj" />
   </ItemGroup>
 

--- a/src/GauntletCI.Cli/Program.cs
+++ b/src/GauntletCI.Cli/Program.cs
@@ -21,6 +21,7 @@ if (!isInitCommand && !isTelemetryCommand)
 var rootCommand = new RootCommand("GauntletCI — deterministic pre-commit risk detection engine");
 
 rootCommand.AddCommand(AnalyzeCommand.Create());
+rootCommand.AddCommand(CorpusCommand.Create());
 rootCommand.AddCommand(InitCommand.Create());
 rootCommand.AddCommand(IgnoreCommand.Create());
 rootCommand.AddCommand(ModelCommand.Create());

--- a/src/GauntletCI.Corpus/Discovery/ManualSeedProvider.cs
+++ b/src/GauntletCI.Corpus/Discovery/ManualSeedProvider.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Interfaces;
+using GauntletCI.Corpus.Models;
+using GauntletCI.Corpus.Storage;
+
+namespace GauntletCI.Corpus.Discovery;
+
+/// <summary>
+/// Trivial discovery provider that converts a static list of PR URLs into candidates.
+/// This is the first provider — no network calls beyond what the caller already has.
+/// </summary>
+public sealed class ManualSeedProvider : IDiscoveryProvider
+{
+    private readonly IReadOnlyList<string> _urls;
+
+    public ManualSeedProvider(IReadOnlyList<string> prUrls) => _urls = prUrls;
+
+    public string GetProviderName() => "manual";
+    public bool SupportsIncrementalSync => false;
+
+    public Task<IReadOnlyList<PullRequestCandidate>> SearchCandidatesAsync(
+        DiscoveryQuery query, CancellationToken ct = default)
+    {
+        var candidates = _urls
+            .Select(url =>
+            {
+                var (owner, repo, prNumber) = Hydration.GitHubRestHydrator.ParsePrUrl(url);
+                return new PullRequestCandidate
+                {
+                    Source            = GetProviderName(),
+                    RepoOwner         = owner,
+                    RepoName          = repo,
+                    PullRequestNumber = prNumber,
+                    Url               = url,
+                    CandidateReason   = "manual-seed",
+                };
+            })
+            .Take(query.MaxCandidates)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<PullRequestCandidate>>(candidates);
+    }
+}

--- a/src/GauntletCI.Corpus/Hydration/GitHubApiModels.cs
+++ b/src/GauntletCI.Corpus/Hydration/GitHubApiModels.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.Json.Serialization;
+
+namespace GauntletCI.Corpus.Hydration;
+
+// Lightweight internal DTOs for deserializing GitHub REST API responses.
+// Only fields used by the hydrator are mapped; extras are silently ignored.
+
+internal sealed class GhPullRequest
+{
+    [JsonPropertyName("number")]    public int Number { get; init; }
+    [JsonPropertyName("title")]     public string Title { get; init; } = "";
+    [JsonPropertyName("body")]      public string? Body { get; init; }
+    [JsonPropertyName("state")]     public string State { get; init; } = "";
+    [JsonPropertyName("draft")]     public bool Draft { get; init; }
+    [JsonPropertyName("additions")] public int Additions { get; init; }
+    [JsonPropertyName("deletions")] public int Deletions { get; init; }
+    [JsonPropertyName("changed_files")] public int ChangedFiles { get; init; }
+    [JsonPropertyName("merge_commit_sha")] public string? MergeCommitSha { get; init; }
+    [JsonPropertyName("base")]      public GhRef Base { get; init; } = new();
+    [JsonPropertyName("head")]      public GhRef Head { get; init; } = new();
+    [JsonPropertyName("created_at")] public DateTime CreatedAt { get; init; }
+    [JsonPropertyName("updated_at")] public DateTime UpdatedAt { get; init; }
+}
+
+internal sealed class GhRef
+{
+    [JsonPropertyName("sha")] public string Sha { get; init; } = "";
+}
+
+internal sealed class GhFile
+{
+    [JsonPropertyName("filename")]  public string Filename { get; init; } = "";
+    [JsonPropertyName("status")]    public string Status { get; init; } = "";
+    [JsonPropertyName("additions")] public int Additions { get; init; }
+    [JsonPropertyName("deletions")] public int Deletions { get; init; }
+    [JsonPropertyName("patch")]     public string? Patch { get; init; }
+}
+
+internal sealed class GhReviewComment
+{
+    [JsonPropertyName("user")]       public GhUser User { get; init; } = new();
+    [JsonPropertyName("body")]       public string Body { get; init; } = "";
+    [JsonPropertyName("path")]       public string Path { get; init; } = "";
+    [JsonPropertyName("diff_hunk")]  public string DiffHunk { get; init; } = "";
+    [JsonPropertyName("position")]   public int? Position { get; init; }
+    [JsonPropertyName("created_at")] public DateTime CreatedAt { get; init; }
+    [JsonPropertyName("html_url")]   public string HtmlUrl { get; init; } = "";
+}
+
+internal sealed class GhUser
+{
+    [JsonPropertyName("login")] public string Login { get; init; } = "";
+}
+
+internal sealed class GhCommit
+{
+    [JsonPropertyName("sha")] public string Sha { get; init; } = "";
+}

--- a/src/GauntletCI.Corpus/Hydration/GitHubRestHydrator.cs
+++ b/src/GauntletCI.Corpus/Hydration/GitHubRestHydrator.cs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.Json;
+using GauntletCI.Corpus.Interfaces;
+using GauntletCI.Corpus.Models;
+using GauntletCI.Corpus.Normalization;
+using GauntletCI.Corpus.Storage;
+
+namespace GauntletCI.Corpus.Hydration;
+
+/// <summary>
+/// Hydrates pull requests via the GitHub REST API.
+/// Set GITHUB_TOKEN env var for authenticated requests (higher rate limits).
+/// </summary>
+public sealed class GitHubRestHydrator : IPullRequestHydrator
+{
+    private readonly HttpClient _http;
+    private readonly RawSnapshotStore _rawStore;
+
+    private static readonly JsonSerializerOptions JsonOpts =
+        new() { PropertyNameCaseInsensitive = true };
+
+    public GitHubRestHydrator(HttpClient http, RawSnapshotStore rawStore)
+    {
+        _http = http;
+        _rawStore = rawStore;
+    }
+
+    public static GitHubRestHydrator CreateDefault(string fixturesBasePath = "./data/fixtures")
+    {
+        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        var http = new HttpClient();
+        http.DefaultRequestHeaders.Add("User-Agent", "GauntletCI/2.0");
+        http.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+        if (!string.IsNullOrEmpty(token))
+            http.DefaultRequestHeaders.Add("Authorization", $"token {token}");
+
+        return new GitHubRestHydrator(http, new RawSnapshotStore(fixturesBasePath));
+    }
+
+    public async Task<HydratedPullRequest> HydrateFromUrlAsync(string url, CancellationToken ct = default)
+    {
+        var (owner, repo, prNumber) = ParsePrUrl(url);
+        var candidate = new PullRequestCandidate
+        {
+            Source = "manual",
+            RepoOwner = owner,
+            RepoName = repo,
+            PullRequestNumber = prNumber,
+            Url = url,
+        };
+        return await HydrateAsync(candidate, ct);
+    }
+
+    public async Task<HydratedPullRequest> HydrateAsync(
+        PullRequestCandidate candidate, CancellationToken ct = default)
+    {
+        var owner    = candidate.RepoOwner;
+        var repo     = candidate.RepoName;
+        var prNumber = candidate.PullRequestNumber;
+        var fixtureId = FixtureIdHelper.Build(owner, repo, prNumber);
+        var base_    = $"https://api.github.com/repos/{owner}/{repo}/pulls/{prNumber}";
+
+        // Fetch all parts concurrently where safe
+        var prTask       = GetJsonAsync<GhPullRequest>(base_, ct);
+        var filesTask    = GetJsonListAsync<GhFile>($"{base_}/files", ct);
+        var commentsTask = GetJsonListAsync<GhReviewComment>($"{base_}/comments", ct);
+        var commitsTask  = GetJsonListAsync<GhCommit>($"{base_}/commits", ct);
+
+        await Task.WhenAll(prTask, filesTask, commentsTask, commitsTask);
+
+        var pr       = prTask.Result;
+        var ghFiles  = filesTask.Result;
+        var ghComments = commentsTask.Result;
+        var ghCommits  = commitsTask.Result;
+
+        // Diff requires a separate Accept header — serial request
+        var diffText = await GetDiffAsync(base_, ct);
+
+        // Persist raw snapshots
+        var rawPrJson       = JsonSerializer.Serialize(pr, JsonOpts);
+        var rawFilesJson    = JsonSerializer.Serialize(ghFiles, JsonOpts);
+        var rawCommentsJson = JsonSerializer.Serialize(ghComments, JsonOpts);
+
+        await Task.WhenAll(
+            _rawStore.SaveAsync(FixtureTier.Discovery, fixtureId, "pr.json", rawPrJson, ct),
+            _rawStore.SaveAsync(FixtureTier.Discovery, fixtureId, "files.json", rawFilesJson, ct),
+            _rawStore.SaveAsync(FixtureTier.Discovery, fixtureId, "review-comments.json", rawCommentsJson, ct));
+
+        // Map to domain models
+        var changedFiles = ghFiles.Select(f => new ChangedFile
+        {
+            Path        = f.Filename,
+            Status      = f.Status,
+            Additions   = f.Additions,
+            Deletions   = f.Deletions,
+            Patch       = f.Patch ?? "",
+            IsTestFile  = TestFileClassifier.IsTestFile(f.Filename),
+            LanguageHint = GuessLanguage(f.Filename),
+        }).ToList();
+
+        var reviewComments = ghComments.Select(c => new ReviewComment
+        {
+            Author      = c.User.Login,
+            Body        = c.Body,
+            Path        = c.Path,
+            DiffHunk    = c.DiffHunk,
+            Position    = c.Position ?? 0,
+            CreatedAtUtc = c.CreatedAt,
+            Url         = c.HtmlUrl,
+        }).ToList();
+
+        return new HydratedPullRequest
+        {
+            RepoOwner          = owner,
+            RepoName           = repo,
+            PullRequestNumber  = prNumber,
+            Title              = pr.Title,
+            Body               = pr.Body ?? "",
+            BaseSha            = pr.Base.Sha,
+            HeadSha            = pr.Head.Sha,
+            MergeCommitSha     = pr.MergeCommitSha ?? "",
+            FilesChangedCount  = pr.ChangedFiles,
+            Additions          = pr.Additions,
+            Deletions          = pr.Deletions,
+            ChangedFiles       = changedFiles,
+            ReviewComments     = reviewComments,
+            Commits            = ghCommits.Select(c => c.Sha).ToList(),
+            DiffText           = diffText,
+            PatchText          = diffText,
+            RawApiPayloadJson  = rawPrJson,
+            HydratedAtUtc      = DateTime.UtcNow,
+        };
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<T> GetJsonAsync<T>(string url, CancellationToken ct)
+    {
+        var json = await _http.GetStringAsync(url, ct);
+        return JsonSerializer.Deserialize<T>(json, JsonOpts)
+            ?? throw new InvalidOperationException($"Null response from {url}");
+    }
+
+    private async Task<List<T>> GetJsonListAsync<T>(string url, CancellationToken ct)
+    {
+        var json = await _http.GetStringAsync(url, ct);
+        return JsonSerializer.Deserialize<List<T>>(json, JsonOpts) ?? [];
+    }
+
+    private async Task<string> GetDiffAsync(string prUrl, CancellationToken ct)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, prUrl);
+        req.Headers.Add("Accept", "application/vnd.github.v3.diff");
+        using var resp = await _http.SendAsync(req, ct);
+        return await resp.Content.ReadAsStringAsync(ct);
+    }
+
+    internal static (string Owner, string Repo, int PrNumber) ParsePrUrl(string url)
+    {
+        // Handles: https://github.com/owner/repo/pull/1234
+        var uri  = new Uri(url.Trim());
+        var segs = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segs.Length < 4 || !string.Equals(segs[2], "pull", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException($"Cannot parse PR URL: {url}");
+
+        return (segs[0], segs[1], int.Parse(segs[3]));
+    }
+
+    private static string GuessLanguage(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext switch
+        {
+            ".cs"   => "C#",
+            ".ts"   => "TypeScript",
+            ".js"   => "JavaScript",
+            ".py"   => "Python",
+            ".go"   => "Go",
+            ".java" => "Java",
+            ".rs"   => "Rust",
+            ".rb"   => "Ruby",
+            _       => "",
+        };
+    }
+}

--- a/src/GauntletCI.Corpus/Normalization/FixtureNormalizer.cs
+++ b/src/GauntletCI.Corpus/Normalization/FixtureNormalizer.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+using GauntletCI.Corpus.Storage;
+
+namespace GauntletCI.Corpus.Normalization;
+
+/// <summary>
+/// Converts a <see cref="HydratedPullRequest"/> into a <see cref="FixtureMetadata"/>
+/// ready for storage. Normalization is deterministic and idempotent.
+/// </summary>
+public static class FixtureNormalizer
+{
+    private static readonly string[] AsyncTags           = ["async", "await", ".Result", ".Wait("];
+    private static readonly string[] ContractChangeTags  = ["public ", "interface ", "abstract "];
+    private static readonly string[] EarlyReturnTags     = ["return ", "throw "];
+    private static readonly string[] NullSafetyTags      = ["null", "?.","??"];
+    private static readonly string[] StateMutationTags   = ["= new ", "List<", "Dictionary<", "HashSet<"];
+    private static readonly string[] LoggingTags         = ["_logger", "Log.", "ILogger"];
+    private static readonly string[] ExceptionFlowTags   = ["catch ", "throw ", "Exception"];
+
+    public static FixtureMetadata Normalize(HydratedPullRequest pr, string source = "manual")
+    {
+        var fixtureId = FixtureIdHelper.Build(pr.RepoOwner, pr.RepoName, pr.PullRequestNumber);
+        var tags      = InferTags(pr);
+        var language  = InferLanguage(pr.ChangedFiles);
+
+        return new FixtureMetadata
+        {
+            FixtureId         = fixtureId,
+            Tier              = FixtureTier.Discovery,
+            Repo              = $"{pr.RepoOwner}/{pr.RepoName}",
+            PullRequestNumber = pr.PullRequestNumber,
+            Language          = language,
+            RuleIds           = [],
+            Tags              = tags,
+            PrSizeBucket      = PrSizeBucketClassifier.Classify(pr.FilesChangedCount),
+            FilesChanged      = pr.FilesChangedCount,
+            HasTestsChanged   = pr.ChangedFiles.Any(f => f.IsTestFile),
+            HasReviewComments = pr.ReviewComments.Count > 0,
+            BaseSha           = pr.BaseSha,
+            HeadSha           = pr.HeadSha,
+            Source            = source,
+            CreatedAtUtc      = pr.HydratedAtUtc,
+        };
+    }
+
+    private static IReadOnlyList<string> InferTags(HydratedPullRequest pr)
+    {
+        var diff = pr.DiffText;
+        var tags = new HashSet<string>(StringComparer.Ordinal);
+
+        if (HasAny(diff, AsyncTags))          tags.Add("async");
+        if (HasAny(diff, ContractChangeTags)) tags.Add("contract-change");
+        if (HasAny(diff, EarlyReturnTags))    tags.Add("early-return");
+        if (HasAny(diff, NullSafetyTags))     tags.Add("null-safety");
+        if (HasAny(diff, StateMutationTags))  tags.Add("state-mutation");
+        if (HasAny(diff, LoggingTags))        tags.Add("logging");
+        if (HasAny(diff, ExceptionFlowTags))  tags.Add("exception-flow");
+
+        if (pr.ChangedFiles.Any(f =>
+            f.Patch.Contains("public ") && (f.Patch.Contains("(") || f.Patch.Contains("{"))))
+            tags.Add("api-change");
+
+        return [.. tags.Order()];
+    }
+
+    private static string InferLanguage(IReadOnlyList<ChangedFile> files)
+    {
+        var counts = files
+            .Where(f => !string.IsNullOrEmpty(f.LanguageHint))
+            .GroupBy(f => f.LanguageHint)
+            .OrderByDescending(g => g.Count());
+
+        return counts.FirstOrDefault()?.Key ?? "";
+    }
+
+    private static bool HasAny(string text, string[] tokens)
+        => tokens.Any(t => text.Contains(t, StringComparison.Ordinal));
+}


### PR DESCRIPTION
- GitHubRestHydrator (IPullRequestHydrator): fetches PR details, files, review comments, commits, and diff concurrently via GitHub REST API; saves raw snapshots (pr.json, files.json, review-comments.json) to fixture raw/ dir; maps responses to domain models; uses GITHUB_TOKEN env var for auth
- GitHubApiModels: internal DTOs for GitHub REST API response deserialization
- ManualSeedProvider (IDiscoveryProvider): converts static PR URL list to PullRequestCandidates; GetProviderName=manual, no incremental sync
- FixtureNormalizer: deterministic HydratedPullRequest -> FixtureMetadata; infers tags (async, contract-change, early-return, null-safety, state-mutation, logging, exception-flow, api-change) from diff content; detects dominant language from changed files; defaults tier to Discovery
- CorpusCommand + add-pr subcommand: 'gauntletci corpus add-pr --url <url>' hydrates a PR, normalizes it, saves metadata.json + SQLite index entry, and prints fixture ID and tags; --db and --fixtures flags for path overrides
- GauntletCI.Cli now references GauntletCI.Corpus
- corpus subcommand registered in Program.cs