### PR TITLE
fix(diff): throw GitProcessException on non-zero git exit code

### DIFF
--- a/src/GauntletCI.Core/Diff/DiffParser.cs
+++ b/src/GauntletCI.Core/Diff/DiffParser.cs
@@ -228,8 +228,17 @@ public static class DiffParser
         };
 
         process.Start();
-        var output = await process.StandardOutput.ReadToEndAsync(ct);
+
+        // Read stdout and stderr concurrently to prevent deadlocks on large output.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(ct);
+        var stderrTask = process.StandardError.ReadToEndAsync(ct);
         await process.WaitForExitAsync(ct);
+        var output = await stdoutTask;
+        var stderr = await stderrTask;
+
+        if (process.ExitCode != 0)
+            throw new GitProcessException($"{executable} {arguments}", process.ExitCode, stderr);
+
         return output;
     }
 }

--- a/src/GauntletCI.Core/Diff/DiffParser.cs
+++ b/src/GauntletCI.Core/Diff/DiffParser.cs
@@ -229,12 +229,42 @@ public static class DiffParser
 
         process.Start();
 
+        // Kill the process (and its tree) if the token is canceled.
+        using var cancellationRegistration = ct.Register(() =>
+        {
+            try
+            {
+                if (!process.HasExited)
+                    process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException) { /* already exited */ }
+            catch (NotSupportedException)
+            {
+                // entireProcessTree not supported on all platforms — fall back to single-process kill.
+                try { if (!process.HasExited) process.Kill(); }
+                catch (InvalidOperationException) { /* already exited */ }
+            }
+        });
+
         // Read stdout and stderr concurrently to prevent deadlocks on large output.
         var stdoutTask = process.StandardOutput.ReadToEndAsync(ct);
         var stderrTask = process.StandardError.ReadToEndAsync(ct);
-        await process.WaitForExitAsync(ct);
-        var output = await stdoutTask;
-        var stderr = await stderrTask;
+        string output = string.Empty;
+        string stderr = string.Empty;
+
+        try
+        {
+            await process.WaitForExitAsync(ct);
+        }
+        finally
+        {
+            // Drain streams even on cancellation to release handles.
+            try { output = await stdoutTask; }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+
+            try { stderr = await stderrTask; }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        }
 
         if (process.ExitCode != 0)
             throw new GitProcessException($"{executable} {arguments}", process.ExitCode, stderr);

--- a/src/GauntletCI.Core/Diff/GitProcessException.cs
+++ b/src/GauntletCI.Core/Diff/GitProcessException.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Core.Diff;
+
+/// <summary>
+/// Thrown when a git process exits with a non-zero exit code.
+/// Carries the exit code and stderr output for diagnostics.
+/// </summary>
+public sealed class GitProcessException : Exception
+{
+    public int ExitCode { get; }
+    public string StdErr { get; }
+
+    public GitProcessException(string command, int exitCode, string stderr)
+        : base($"git process failed (exit {exitCode}): {stderr.Trim()}")
+    {
+        ExitCode = exitCode;
+        StdErr = stderr;
+        Data["Command"] = command;
+    }
+}

--- a/src/GauntletCI.Core/Diff/GitProcessException.cs
+++ b/src/GauntletCI.Core/Diff/GitProcessException.cs
@@ -3,16 +3,18 @@ namespace GauntletCI.Core.Diff;
 
 /// <summary>
 /// Thrown when a git process exits with a non-zero exit code.
-/// Carries the exit code and stderr output for diagnostics.
+/// Carries the command, exit code, and stderr output for diagnostics.
 /// </summary>
 public sealed class GitProcessException : Exception
 {
     public int ExitCode { get; }
     public string StdErr { get; }
+    public string Command { get; }
 
     public GitProcessException(string command, int exitCode, string stderr)
-        : base($"git process failed (exit {exitCode}): {stderr.Trim()}")
+        : base($"git process failed for '{command}' (exit {exitCode}): {stderr.Trim()}")
     {
+        Command = command;
         ExitCode = exitCode;
         StdErr = stderr;
         Data["Command"] = command;

--- a/src/GauntletCI.Tests/DiffParserTests.cs
+++ b/src/GauntletCI.Tests/DiffParserTests.cs
@@ -86,4 +86,49 @@ public class DiffParserTests
         Assert.True(ctx.Files[0].IsAdded);
         Assert.Equal(3, ctx.Files[0].AddedLines.Count());
     }
+
+    [Fact]
+    public async Task FromGitAsync_InvalidRepo_ShouldThrowGitProcessException()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"gci_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var ex = await Assert.ThrowsAsync<GitProcessException>(
+                () => DiffParser.FromGitAsync(tempDir, "HEAD"));
+            Assert.True(ex.ExitCode != 0);
+            Assert.False(string.IsNullOrEmpty(ex.StdErr));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task FromStagedAsync_InvalidRepo_ShouldThrowGitProcessException()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"gci_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            await Assert.ThrowsAsync<GitProcessException>(
+                () => DiffParser.FromStagedAsync(tempDir));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GitProcessException_Properties_ShouldBePreserved()
+    {
+        var ex = new GitProcessException("git diff HEAD", exitCode: 128, stderr: "not a git repository");
+        Assert.Equal(128, ex.ExitCode);
+        Assert.Equal("not a git repository", ex.StdErr);
+        Assert.Contains("128", ex.Message);
+        Assert.Contains("not a git repository", ex.Message);
+        Assert.Equal("git diff HEAD", ex.Data["Command"]);
+    }
 }

--- a/src/GauntletCI.Tests/DiffParserTests.cs
+++ b/src/GauntletCI.Tests/DiffParserTests.cs
@@ -90,35 +90,28 @@ public class DiffParserTests
     [Fact]
     public async Task FromGitAsync_InvalidRepo_ShouldThrowGitProcessException()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"gci_test_{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var ex = await Assert.ThrowsAsync<GitProcessException>(
-                () => DiffParser.FromGitAsync(tempDir, "HEAD"));
-            Assert.True(ex.ExitCode != 0);
-            Assert.False(string.IsNullOrEmpty(ex.StdErr));
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        if (!await GitAvailableAsync()) return;
+
+        // Use a guaranteed non-existent path so git fails deterministically
+        // without risking parent-repo discovery when TMP is inside a worktree.
+        var nonExistentDir = Path.Combine(Path.GetTempPath(), $"gci_test_{Guid.NewGuid():N}");
+
+        var ex = await Assert.ThrowsAsync<GitProcessException>(
+            () => DiffParser.FromGitAsync(nonExistentDir, "HEAD"));
+        Assert.True(ex.ExitCode != 0);
+        Assert.False(string.IsNullOrEmpty(ex.StdErr));
+        Assert.Contains(nonExistentDir, ex.Command);
     }
 
     [Fact]
     public async Task FromStagedAsync_InvalidRepo_ShouldThrowGitProcessException()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"gci_test_{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            await Assert.ThrowsAsync<GitProcessException>(
-                () => DiffParser.FromStagedAsync(tempDir));
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        if (!await GitAvailableAsync()) return;
+
+        var nonExistentDir = Path.Combine(Path.GetTempPath(), $"gci_test_{Guid.NewGuid():N}");
+
+        await Assert.ThrowsAsync<GitProcessException>(
+            () => DiffParser.FromStagedAsync(nonExistentDir));
     }
 
     [Fact]
@@ -127,8 +120,30 @@ public class DiffParserTests
         var ex = new GitProcessException("git diff HEAD", exitCode: 128, stderr: "not a git repository");
         Assert.Equal(128, ex.ExitCode);
         Assert.Equal("not a git repository", ex.StdErr);
+        Assert.Equal("git diff HEAD", ex.Command);
+        Assert.Contains("git diff HEAD", ex.Message);
         Assert.Contains("128", ex.Message);
         Assert.Contains("not a git repository", ex.Message);
-        Assert.Equal("git diff HEAD", ex.Data["Command"]);
+    }
+
+    private static async Task<bool> GitAvailableAsync()
+    {
+        try
+        {
+            using var process = new System.Diagnostics.Process();
+            process.StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = "--version",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            process.Start();
+            await process.WaitForExitAsync();
+            return process.ExitCode == 0;
+        }
+        catch { return false; }
     }
 }

--- a/tests/GauntletCI.Benchmarks/Models/FixtureManifest.cs
+++ b/tests/GauntletCI.Benchmarks/Models/FixtureManifest.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.Json.Serialization;
+
+namespace GauntletCI.Benchmarks.Models;
+
+public class FixtureManifest
+{
+    [JsonPropertyName("mapped_gci_rules")]
+    public List<string> MappedGciRules { get; set; } = [];
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("fixtures")]
+    public List<FixtureEntry> Fixtures { get; set; } = [];
+}
+
+public class FixtureEntry
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("diff_file")]
+    public string DiffFile { get; set; } = string.Empty;
+
+    [JsonPropertyName("category")]
+    public string Category { get; set; } = string.Empty;
+
+    [JsonPropertyName("expected_outcome")]
+    public string ExpectedOutcome { get; set; } = string.Empty;
+
+    [JsonPropertyName("expected_gci_rules")]
+    public List<string> ExpectedGciRules { get; set; } = [];
+
+    [JsonPropertyName("notes")]
+    public string Notes { get; set; } = string.Empty;
+
+    [JsonPropertyName("origin")]
+    public string Origin { get; set; } = string.Empty;
+
+    [JsonPropertyName("source_url")]
+    public string SourceUrl { get; set; } = string.Empty;
+}


### PR DESCRIPTION
DiffParser.RunProcessAsync previously ignored process exit codes, silently returning empty output when git failed (bad ref, not a repo, permission error, etc.). This caused the evaluation engine to receive an empty diff and silently pass the gate instead of surfacing the error.