### PR TITLE
feat(static-analysis): wire RoslynAnalyzer into the CLI analyze pipeline

### DIFF
--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -9,6 +9,7 @@ using GauntletCI.Core.Configuration;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.Rules;
+using GauntletCI.Core.StaticAnalysis;
 using GauntletCI.Llm;
 
 namespace GauntletCI.Cli.Commands;
@@ -90,7 +91,12 @@ public static class AnalyzeCommand
                 var config = ConfigLoader.Load(repo.FullName);
                 var ignoreList = IgnoreList.Load(repo.FullName);
                 var orchestrator = RuleOrchestrator.CreateDefault(config);
-                var result = await orchestrator.RunAsync(diff, ignoreList: ignoreList);
+
+                // Run static analysis on changed C# files (null when no repo path or no .cs changes)
+                var repoPath = diffFile is null ? repo.FullName : null;
+                var staticAnalysis = await StaticAnalysisRunner.RunAsync(diff, repoPath);
+
+                var result = await orchestrator.RunAsync(diff, staticAnalysis, ignoreList: ignoreList);
 
                 using ILlmEngine llm = await LlmEngineSelector.ResolveAsync(config, withLlm && !noLlm);
                 if (llm.IsAvailable)

--- a/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Diff;
+
+namespace GauntletCI.Core.StaticAnalysis;
+
+/// <summary>
+/// Runs Roslyn static analysis over the C# files changed in a diff.
+/// Reads changed files from disk using the repo path as root.
+/// Returns an aggregated <see cref="AnalyzerResult"/> with diagnostics from all analyzed files.
+/// If no repo path is provided or no C# files are changed, returns a null result.
+/// </summary>
+public static class StaticAnalysisRunner
+{
+    private static readonly RoslynAnalyzer Analyzer = new();
+
+    /// <summary>
+    /// Analyzes all changed C# source files in the diff. Returns null when analysis
+    /// cannot be performed (no repo path, no C# files, or diff-file-only mode).
+    /// </summary>
+    public static async Task<AnalyzerResult?> RunAsync(
+        DiffContext diff,
+        string? repoPath,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(repoPath))
+            return null;
+
+        var csFiles = diff.Files
+            .Where(f => !f.IsDeleted &&
+                        f.NewPath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (csFiles.Count == 0)
+            return null;
+
+        var allDiagnostics = new List<AnalyzerDiagnostic>();
+        var anySuccess = false;
+
+        foreach (var file in csFiles)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // Normalize to OS path separator
+            var relativePath = file.NewPath.Replace('/', Path.DirectorySeparatorChar);
+            var absolutePath = Path.Combine(repoPath, relativePath);
+
+            if (!File.Exists(absolutePath))
+                continue;
+
+            string sourceCode;
+            try
+            {
+                sourceCode = await File.ReadAllTextAsync(absolutePath, ct);
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+
+            var changedLines = file.AddedLines.Select(l => l.LineNumber).ToList();
+            var result = await Analyzer.AnalyzeFileAsync(
+                absolutePath, sourceCode, changedLines.Count > 0 ? changedLines : null, ct);
+
+            if (result.Success)
+            {
+                anySuccess = true;
+                allDiagnostics.AddRange(result.Diagnostics);
+            }
+        }
+
+        if (!anySuccess && allDiagnostics.Count == 0)
+            return null;
+
+        return new AnalyzerResult
+        {
+            AnalyzedFile = $"[{csFiles.Count} file(s)]",
+            Success = anySuccess,
+            Diagnostics = allDiagnostics
+        };
+    }
+}

--- a/src/GauntletCI.Tests/StaticAnalysisTests.cs
+++ b/src/GauntletCI.Tests/StaticAnalysisTests.cs
@@ -266,4 +266,83 @@ public class StaticAnalysisTests
 
         Assert.Single(ctx.Files);
     }
+
+    // ── StaticAnalysisRunner ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StaticAnalysisRunner_NullRepoPath_ShouldReturnNull()
+    {
+        var diff = DiffParser.Parse("diff --git a/src/Foo.cs b/src/Foo.cs\nindex abc..def 100644\n--- a/src/Foo.cs\n+++ b/src/Foo.cs\n@@ -1,1 +1,2 @@\n int x;\n+int y;\n");
+        var result = await StaticAnalysisRunner.RunAsync(diff, repoPath: null);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task StaticAnalysisRunner_NoCsFiles_ShouldReturnNull()
+    {
+        var raw = """
+            diff --git a/README.md b/README.md
+            index abc..def 100644
+            --- a/README.md
+            +++ b/README.md
+            @@ -1,1 +1,2 @@
+             # Hello
+            +World
+            """;
+        var diff = DiffParser.Parse(raw);
+        var result = await StaticAnalysisRunner.RunAsync(diff, repoPath: Path.GetTempPath());
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task StaticAnalysisRunner_CsFileMissingFromDisk_ShouldReturnNull()
+    {
+        var raw = """
+            diff --git a/src/Ghost.cs b/src/Ghost.cs
+            index abc..def 100644
+            --- a/src/Ghost.cs
+            +++ b/src/Ghost.cs
+            @@ -1,1 +1,2 @@
+             // nothing
+            +int x = 1;
+            """;
+        var diff = DiffParser.Parse(raw);
+        // Repo path exists but the file doesn't
+        var result = await StaticAnalysisRunner.RunAsync(diff, repoPath: Path.GetTempPath());
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task StaticAnalysisRunner_ValidCsFile_ShouldReturnResult()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"gci_sas_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        var filePath = Path.Combine(srcDir, "Foo.cs");
+        await File.WriteAllTextAsync(filePath, "public class Foo { public void Bar() { } }");
+
+        try
+        {
+            var raw = """
+                diff --git a/src/Foo.cs b/src/Foo.cs
+                index abc..def 100644
+                --- a/src/Foo.cs
+                +++ b/src/Foo.cs
+                @@ -1,1 +1,1 @@
+                -public class Foo { }
+                +public class Foo { public void Bar() { } }
+                """;
+            var diff = DiffParser.Parse(raw);
+            var result = await StaticAnalysisRunner.RunAsync(diff, repoPath: tempDir);
+
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.NotNull(result.Diagnostics);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
 }


### PR DESCRIPTION
Static analysis was integrated in tests but the CLI always passed null for the staticAnalysis argument, meaning 6 rules (GCI0006, GCI0007, GCI0009, GCI0012, GCI0015, GCI0024) never surfaced their Roslyn-backed findings in real runs.

Changes:
- Add StaticAnalysisRunner: runs RoslynAnalyzer over changed .cs files found on disk, aggregates diagnostics across all files in the diff
- AnalyzeCommand: call StaticAnalysisRunner.RunAsync after parsing diff; pass result to orchestrator.RunAsync (null for --diff file mode)
- Static analysis is automatically skipped when: no repo path available, no .cs files changed, or changed files not present on disk
- Add 4 tests: null repo path, no .cs files, missing file, valid file

Fixes: audit finding 'static analysis pipeline half-integrated'