### PR TITLE
docs: add complete rule catalog table to README (36 rules)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,51 @@ GauntletCI complements your existing tools — it does not replace them.
 
 ---
 
+## Rule catalog (36 rules, GCI0001–GCI0037)
+
+| ID | Name | What it detects |
+|----|------|-----------------|
+| GCI0001 | Diff Integrity | Unrelated changes, formatting churn, mixed scope in a single diff |
+| GCI0002 | Goal Alignment | Diffs unrelated to the commit message or spanning too many areas |
+| GCI0003 | Behavioral Change Detection | Removed logic lines, changed method signatures without tests |
+| GCI0004 | Breaking Change Risk | Removed public APIs, changed public method signatures |
+| GCI0005 | Test Coverage Relevance | Code changes with no test changes; orphaned test-only changes |
+| GCI0006 | Edge Case Handling | Potential null dereferences, missing parameter validation |
+| GCI0007 | Error Handling Integrity | Swallowed exceptions, empty catch blocks |
+| GCI0008 | Complexity Control | Excessive nesting, long methods, duplicate logic |
+| GCI0009 | Consistency with Patterns | Async/await deviations from the project's established patterns |
+| GCI0010 | Hardcoding and Configuration | Hardcoded IPs, URLs, connection strings, secrets, env names |
+| GCI0011 | Performance Risk | Blocking async calls, N+1 patterns, inefficient allocations |
+| GCI0012 | Security Risk | General security anti-patterns (injection, auth bypass signals) |
+| GCI0013 | Observability/Debuggability | Removed error context logging, reduced trace coverage |
+| GCI0014 | Rollback Safety | Missing rollback scripts alongside migration additions |
+| GCI0015 | Data Integrity Risk | Data loss paths, unsafe null propagation in data operations |
+| GCI0016 | Concurrency and State Risk | `async void`, `.Result`/`.Wait()`, `lock(this)`, static mutable state |
+| GCI0017 | Scope Discipline | Scope creep, unrelated file changes bundled into one diff |
+| GCI0018 | Production Readiness | Aggregate risk signal when multiple rules fire on the same diff |
+| GCI0019 | Confidence and Evidence | High-risk changes without sufficient supporting evidence in diff |
+| GCI0020 | Accountability Standard | Missing audit trail and accountability logging |
+| GCI0021 | Data & Schema Compatibility | Non-backward-compatible schema changes without migration guards |
+| GCI0022 | Idempotency & Retry Safety | Non-idempotent operations, missing retry/duplicate guards |
+| GCI0023 | Structured Logging | Unstructured log calls, PII in log message templates |
+| GCI0024 | Resource Lifecycle | IDisposable lifecycle violations, resource leaks |
+| GCI0025 | Feature Flag Readiness | Missing feature flag guards for high-risk or staged rollout changes |
+| GCI0026 | Documentation Adequacy | Missing or insufficient docs for public APIs and exported types |
+| GCI0027 | Test Quality | Test hygiene: no assertions, `Assert.True(false)`, magic literals |
+| GCI0029 | PII Entity Logging Leak | PII data (email, SSN, card) detected in log call arguments |
+| GCI0030 | IDisposable Resource Safety | Missing `using` / `Dispose()` on IDisposable instances |
+| GCI0031 | Boundary Drift | Off-by-one boundary values added without matching test evidence |
+| GCI0032 | Uncaught Exception Path | New `throw` statements without `Assert.Throws` test evidence |
+| GCI0033 | Async Sinkhole | `.Result` or `.Wait()` blocking calls that risk thread deadlocks |
+| GCI0034 | Null-Coalescing Expansion | Null-coalescing patterns that mask deeper null propagation bugs |
+| GCI0035 | Architecture Layer Guard | Wrong-direction layer dependencies (e.g. Core → Infrastructure) |
+| GCI0036 | Pure Context Mutation | Side-effect mutations in property getters or `[Pure]`-annotated methods |
+| GCI0037 | AutoMapper Integrity | AutoMapper misuse: missing profiles, flattened nullable chains |
+
+> **Note:** GCI0028 is reserved and intentionally unassigned.
+
+---
+
 ## Example
 
 ```bash


### PR DESCRIPTION
README previously had no enumeration of the rules GauntletCI runs, making it impossible for users to discover what analysis they are getting. The example output referenced specific GCI IDs with no reference for what they mean.