### PR TITLE
feature(RULE): supersede GCI0030/GCI0033; absorb detection into GCI00…

### DIFF
--- a/src/GauntletCI.Core/Rules/Implementations/GCI0023_StructuredLogging.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0023_StructuredLogging.cs
@@ -9,6 +9,8 @@ namespace GauntletCI.Core.Rules.Implementations;
 /// GCI0023 – Structured Logging
 /// Detects log calls using string interpolation instead of structured key-value pairs,
 /// and catch blocks in critical sections without any log statement.
+/// See also: GCI0029 (PII Entity Logging Leak) — detects PII terms in log arguments.
+/// These rules are complementary: GCI0023 checks format, GCI0029 checks content.
 /// </summary>
 public class GCI0023_StructuredLogging : RuleBase
 {

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
+using System.Text.RegularExpressions;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.StaticAnalysis;
@@ -8,12 +9,16 @@ namespace GauntletCI.Core.Rules.Implementations;
 /// <summary>
 /// GCI0024 – Resource Lifecycle
 /// Detects disposable resources allocated without a using statement or try/finally disposal.
+/// Covers both explicit known types (FileStream, SqlConnection, …) and any type whose name
+/// ends with a disposable suffix (Stream, Reader, Writer, Connection, Client, etc.).
+/// Absorbs GCI0030 detection scope; GCI0030 is now superseded by this rule.
 /// </summary>
 public class GCI0024_ResourceLifecycle : RuleBase
 {
     public override string Id => "GCI0024";
     public override string Name => "Resource Lifecycle";
 
+    // Explicit known-type prefixes (fast path)
     private static readonly string[] DisposableTypes =
     [
         "new FileStream(", "new StreamWriter(", "new StreamReader(", "new MemoryStream(",
@@ -25,6 +30,17 @@ public class GCI0024_ResourceLifecycle : RuleBase
         "new GZipStream(", "new DeflateStream(", "new CryptoStream(",
         "new X509Certificate(", "new RSACryptoServiceProvider("
     ];
+
+    // Suffix-based heuristic (from GCI0030) — catches any type whose name ends in these
+    private static readonly string[] DisposableSuffixes =
+    [
+        "Stream", "Reader", "Writer", "Connection", "Command", "Client",
+        "Listener", "Channel", "Context", "Provider", "Session", "Transaction",
+        "Certificate", "Scope", "Timer", "Enumerator"
+    ];
+
+    private static readonly Regex NewTypeRegex =
+        new(@"new ([A-Z][A-Za-z0-9]+)\(", RegexOptions.Compiled);
 
     public override Task<List<Finding>> EvaluateAsync(
         DiffContext diff, AnalyzerResult? staticAnalysis, CancellationToken ct = default)
@@ -51,18 +67,11 @@ public class GCI0024_ResourceLifecycle : RuleBase
             if (line.Kind != DiffLineKind.Added) continue;
             var content = line.Content;
 
-            string? matched = null;
-            foreach (var type in DisposableTypes)
-            {
-                if (content.Contains(type, StringComparison.OrdinalIgnoreCase))
-                { matched = type; break; }
-            }
-            if (matched is null) continue;
+            string? typeName = MatchDisposableType(content);
+            if (typeName is null) continue;
 
-            // Safe if: line itself contains "using " or "await using"
             if (content.Contains("using ", StringComparison.Ordinal)) continue;
 
-            // Safe if preceded by "using" on previous non-blank added/context line
             bool prevHasUsing = false;
             for (int j = i - 1; j >= Math.Max(0, i - 3); j--)
             {
@@ -74,7 +83,6 @@ public class GCI0024_ResourceLifecycle : RuleBase
             }
             if (prevHasUsing) continue;
 
-            // Safe if there's a .Dispose() or try/finally in the surrounding window
             int winStart = Math.Max(0, i - 2);
             int winEnd = Math.Min(allLines.Count, i + 20);
             bool hasDispose = allLines[winStart..winEnd].Any(l =>
@@ -82,14 +90,34 @@ public class GCI0024_ResourceLifecycle : RuleBase
                 l.Content.Contains("finally", StringComparison.Ordinal));
             if (hasDispose) continue;
 
-            var typeName = matched.Replace("new ", "").TrimEnd('(');
             findings.Add(CreateFinding(
                 summary: $"{typeName} allocated without using statement in {file.NewPath}.",
                 evidence: $"Line {line.LineNumber}: {content.Trim()}",
-                whyItMatters: $"{typeName} implements IDisposable. If not disposed, it leaks OS handles, file locks, or connection pool slots — especially under exceptions.",
-                suggestedAction: "Wrap in a using statement: using var resource = new " + typeName + "(...); — this guarantees disposal even when exceptions occur.",
+                whyItMatters: $"{typeName} implements IDisposable. Without using, it leaks OS handles or connection pool slots under exceptions.",
+                suggestedAction: $"Wrap in `using var resource = new {typeName}(...);` to guarantee disposal.",
                 confidence: Confidence.High));
         }
+    }
+
+    private static string? MatchDisposableType(string content)
+    {
+        // Fast path: explicit known types
+        foreach (var knownType in DisposableTypes)
+        {
+            if (content.Contains(knownType, StringComparison.OrdinalIgnoreCase))
+                return knownType.Replace("new ", "").TrimEnd('(');
+        }
+
+        // Suffix heuristic: any new XxxYyy( where the type name ends with a disposable suffix
+        var match = NewTypeRegex.Match(content);
+        if (match.Success)
+        {
+            var name = match.Groups[1].Value;
+            if (DisposableSuffixes.Any(suffix => name.EndsWith(suffix, StringComparison.Ordinal)))
+                return name;
+        }
+
+        return null;
     }
 
     private static void AddRoslynFindings(AnalyzerResult? staticAnalysis, List<Finding> findings)

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0029_PiiLoggingLeak.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0029_PiiLoggingLeak.cs
@@ -8,6 +8,8 @@ namespace GauntletCI.Core.Rules.Implementations;
 /// <summary>
 /// GCI0029 – PII Entity Logging Leak
 /// Detects PII terms in log calls in added lines of .cs files.
+/// See also: GCI0023 (Structured Logging) — detects format issues in log calls.
+/// These rules are complementary: GCI0029 checks content (PII), GCI0023 checks format.
 /// </summary>
 public class GCI0029_PiiLoggingLeak : RuleBase
 {

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0030_DisposableResourceSafety.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0030_DisposableResourceSafety.cs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Elastic-2.0
-using System.Text.RegularExpressions;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.StaticAnalysis;
@@ -7,80 +6,18 @@ using GauntletCI.Core.StaticAnalysis;
 namespace GauntletCI.Core.Rules.Implementations;
 
 /// <summary>
-/// GCI0030 – IDisposable Resource Safety
-/// Detects disposable resources allocated without a using statement, using suffix-based type detection.
+/// GCI0030 – IDisposable Resource Safety (superseded)
+/// This rule's detection scope has been fully absorbed into GCI0024 (Resource Lifecycle),
+/// which now covers both explicit known types and suffix-based heuristic detection.
+/// GCI0030 returns no findings to prevent duplicate alerts. It is retained as a reserved
+/// ID to avoid breaking configurations that reference it.
 /// </summary>
 public class GCI0030_DisposableResourceSafety : RuleBase
 {
     public override string Id => "GCI0030";
     public override string Name => "IDisposable Resource Safety";
 
-    private static readonly Regex TypeRegex =
-        new(@"new ([A-Z][A-Za-z0-9]+)\(", RegexOptions.Compiled);
-
-    private static readonly string[] DisposableSuffixes =
-    [
-        "Stream", "Reader", "Writer", "Connection", "Command", "Client",
-        "Listener", "Channel", "Context", "Provider", "Session", "Transaction",
-        "Certificate", "Scope", "Timer", "Enumerator"
-    ];
-
     public override Task<List<Finding>> EvaluateAsync(
         DiffContext diff, AnalyzerResult? staticAnalysis, CancellationToken ct = default)
-    {
-        var findings = new List<Finding>();
-
-        foreach (var file in diff.Files.Where(f => f.NewPath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)))
-        {
-            CheckUnguardedDisposables(file, findings);
-        }
-
-        return Task.FromResult(findings);
-    }
-
-    private void CheckUnguardedDisposables(DiffFile file, List<Finding> findings)
-    {
-        var allLines = file.Hunks.SelectMany(h => h.Lines).ToList();
-
-        for (int i = 0; i < allLines.Count; i++)
-        {
-            var line = allLines[i];
-            if (line.Kind != DiffLineKind.Added) continue;
-            var content = line.Content;
-
-            var match = TypeRegex.Match(content);
-            if (!match.Success) continue;
-
-            var typeName = match.Groups[1].Value;
-            if (!DisposableSuffixes.Any(suffix => typeName.EndsWith(suffix, StringComparison.Ordinal)))
-                continue;
-
-            if (content.Contains("using ", StringComparison.Ordinal)) continue;
-
-            bool prevHasUsing = false;
-            for (int j = i - 1; j >= Math.Max(0, i - 3); j--)
-            {
-                var prev = allLines[j].Content.Trim();
-                if (string.IsNullOrWhiteSpace(prev)) continue;
-                if (prev.StartsWith("using ") || prev.StartsWith("await using "))
-                { prevHasUsing = true; break; }
-                break;
-            }
-            if (prevHasUsing) continue;
-
-            int winStart = Math.Max(0, i - 2);
-            int winEnd = Math.Min(allLines.Count, i + 20);
-            bool hasDispose = allLines[winStart..winEnd].Any(l =>
-                l.Content.Contains(".Dispose()", StringComparison.Ordinal) ||
-                l.Content.Contains("finally", StringComparison.Ordinal));
-            if (hasDispose) continue;
-
-            findings.Add(CreateFinding(
-                summary: $"{typeName} allocated without using statement in {file.NewPath}.",
-                evidence: $"Line {line.LineNumber}: {content.Trim()}",
-                whyItMatters: $"{typeName} likely implements IDisposable. Without using, it leaks OS handles or connection pool slots under exceptions.",
-                suggestedAction: $"Wrap in `using var resource = new {typeName}(...);` to guarantee disposal.",
-                confidence: Confidence.High));
-        }
-    }
+        => Task.FromResult(new List<Finding>());
 }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0033_AsyncSinkhole.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0033_AsyncSinkhole.cs
@@ -6,8 +6,11 @@ using GauntletCI.Core.StaticAnalysis;
 namespace GauntletCI.Core.Rules.Implementations;
 
 /// <summary>
-/// GCI0033 – Async Sinkhole
-/// Detects .Result property access or .Wait() calls that block threads and cause deadlocks.
+/// GCI0033 – Async Sinkhole (superseded)
+/// This rule's detection of .Result and .Wait() blocking calls has been absorbed into
+/// GCI0016 (Concurrency and State Risk), which already fires on the same patterns
+/// with equivalent confidence and guidance. GCI0033 returns no findings to prevent
+/// duplicate alerts. It is retained as a reserved ID to avoid breaking configurations.
 /// </summary>
 public class GCI0033_AsyncSinkhole : RuleBase
 {
@@ -16,44 +19,5 @@ public class GCI0033_AsyncSinkhole : RuleBase
 
     public override Task<List<Finding>> EvaluateAsync(
         DiffContext diff, AnalyzerResult? staticAnalysis, CancellationToken ct = default)
-    {
-        var findings = new List<Finding>();
-
-        foreach (var file in diff.Files.Where(f => f.NewPath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)))
-        {
-            foreach (var line in file.AddedLines)
-            {
-                var content = line.Content;
-                var trimmed = content.TrimStart();
-
-                // Skip comments
-                if (trimmed.StartsWith("//") || trimmed.StartsWith("*")) continue;
-
-                if (content.Contains(".Result", StringComparison.Ordinal))
-                {
-                    findings.Add(CreateFinding(
-                        summary: $"Blocking .Result access on a Task in {file.NewPath} — risk of deadlock.",
-                        evidence: $"Line {line.LineNumber}: {trimmed}",
-                        whyItMatters: "Calling .Result or .Wait() on a Task blocks the calling thread and can cause deadlocks in ASP.NET, WPF, or any context with a synchronization context.",
-                        suggestedAction: "Use `await` instead of `.Result` or `.Wait()`. If calling from a sync context, use `Task.Run(() => ...).GetAwaiter().GetResult()` as a last resort.",
-                        confidence: Confidence.High));
-                    continue;
-                }
-
-                if ((content.Contains(".Wait()", StringComparison.Ordinal) ||
-                     content.Contains(".Wait(", StringComparison.Ordinal)) &&
-                    !content.Contains(".WaitOne(", StringComparison.Ordinal))
-                {
-                    findings.Add(CreateFinding(
-                        summary: $"Blocking .Wait() call on a Task in {file.NewPath} — risk of deadlock.",
-                        evidence: $"Line {line.LineNumber}: {trimmed}",
-                        whyItMatters: "Calling .Result or .Wait() on a Task blocks the calling thread and can cause deadlocks in ASP.NET, WPF, or any context with a synchronization context.",
-                        suggestedAction: "Use `await` instead of `.Result` or `.Wait()`. If calling from a sync context, use `Task.Run(() => ...).GetAwaiter().GetResult()` as a last resort.",
-                        confidence: Confidence.High));
-                }
-            }
-        }
-
-        return Task.FromResult(findings);
-    }
+        => Task.FromResult(new List<Finding>());
 }

--- a/src/GauntletCI.Tests/Rules/GCI0030Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0030Tests.cs
@@ -4,9 +4,33 @@ using GauntletCI.Core.Rules.Implementations;
 
 namespace GauntletCI.Tests.Rules;
 
+/// <summary>
+/// GCI0030 is now superseded by GCI0024 (Resource Lifecycle), which absorbs all
+/// suffix-based disposable detection. These tests validate the absorbed behavior via
+/// GCI0024, and verify GCI0030 itself no longer produces findings.
+/// </summary>
 public class GCI0030Tests
 {
-    private static readonly GCI0030_DisposableResourceSafety Rule = new();
+    private static readonly GCI0024_ResourceLifecycle Rule = new();
+    private static readonly GCI0030_DisposableResourceSafety SupersededRule = new();
+
+    [Fact]
+    public async Task GCI0030_IsSuperseded_ShouldReturnNoFindings()
+    {
+        var raw = """
+            diff --git a/src/Parser.cs b/src/Parser.cs
+            index abc..def 100644
+            --- a/src/Parser.cs
+            +++ b/src/Parser.cs
+            @@ -1,3 +1,4 @@
+             public class Parser {
+            +    var reader = new StreamReader("file.txt");
+             }
+            """;
+        var diff = DiffParser.Parse(raw);
+        var findings = await SupersededRule.EvaluateAsync(diff, null);
+        Assert.Empty(findings);
+    }
 
     [Fact]
     public async Task StreamReaderWithoutUsing_ShouldFlag()

--- a/src/GauntletCI.Tests/Rules/GCI0033Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0033Tests.cs
@@ -4,9 +4,33 @@ using GauntletCI.Core.Rules.Implementations;
 
 namespace GauntletCI.Tests.Rules;
 
+/// <summary>
+/// GCI0033 is now superseded by GCI0016 (Concurrency and State Risk), which already
+/// detects .Result/.Wait() blocking calls with equivalent guidance. These tests validate
+/// the absorbed behavior via GCI0016, and verify GCI0033 itself no longer produces findings.
+/// </summary>
 public class GCI0033Tests
 {
-    private static readonly GCI0033_AsyncSinkhole Rule = new();
+    private static readonly GCI0016_ConcurrencyAndStateRisk Rule = new();
+    private static readonly GCI0033_AsyncSinkhole SupersededRule = new();
+
+    [Fact]
+    public async Task GCI0033_IsSuperseded_ShouldReturnNoFindings()
+    {
+        var raw = """
+            diff --git a/src/Service.cs b/src/Service.cs
+            index abc..def 100644
+            --- a/src/Service.cs
+            +++ b/src/Service.cs
+            @@ -1,3 +1,4 @@
+             public class Service {
+            +    var data = GetDataAsync().Result;
+             }
+            """;
+        var diff = DiffParser.Parse(raw);
+        var findings = await SupersededRule.EvaluateAsync(diff, null);
+        Assert.Empty(findings);
+    }
 
     [Fact]
     public async Task DotResultAccess_ShouldFlag()
@@ -65,7 +89,7 @@ public class GCI0033Tests
         var diff = DiffParser.Parse(raw);
         var findings = await Rule.EvaluateAsync(diff, null);
 
-        Assert.Empty(findings);
+        Assert.DoesNotContain(findings, f => f.Summary.Contains(".Result") || f.Summary.Contains(".Wait()"));
     }
 
     [Fact]
@@ -85,7 +109,7 @@ public class GCI0033Tests
         var diff = DiffParser.Parse(raw);
         var findings = await Rule.EvaluateAsync(diff, null);
 
-        Assert.Empty(findings);
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("deadlock"));
     }
 
     [Fact]
@@ -105,6 +129,6 @@ public class GCI0033Tests
         var diff = DiffParser.Parse(raw);
         var findings = await Rule.EvaluateAsync(diff, null);
 
-        Assert.Empty(findings);
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("deadlock"));
     }
 }

--- a/tests/GauntletCI.Benchmarks/Models/FixtureManifest.cs
+++ b/tests/GauntletCI.Benchmarks/Models/FixtureManifest.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.Json.Serialization;
+
+namespace GauntletCI.Benchmarks.Models;
+
+public class FixtureManifest
+{
+    [JsonPropertyName("mapped_gci_rules")]
+    public List<string> MappedGciRules { get; set; } = [];
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("fixtures")]
+    public List<FixtureEntry> Fixtures { get; set; } = [];
+}
+
+public class FixtureEntry
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("diff_file")]
+    public string DiffFile { get; set; } = string.Empty;
+
+    [JsonPropertyName("category")]
+    public string Category { get; set; } = string.Empty;
+
+    [JsonPropertyName("expected_outcome")]
+    public string ExpectedOutcome { get; set; } = string.Empty;
+
+    [JsonPropertyName("expected_gci_rules")]
+    public List<string> ExpectedGciRules { get; set; } = [];
+
+    [JsonPropertyName("notes")]
+    public string Notes { get; set; } = string.Empty;
+
+    [JsonPropertyName("origin")]
+    public string Origin { get; set; } = string.Empty;
+
+    [JsonPropertyName("source_url")]
+    public string SourceUrl { get; set; } = string.Empty;
+}


### PR DESCRIPTION
GCI0030 (DisposableResourceSafety) is now a hollow-shell rule - its suffix-based disposable heuristic has been absorbed into GCI0024 (Resource Lifecycle), which now handles both explicit type matching and suffix-based detection (e.g. *Reader, *Connection, *Stream) via MatchDisposableType().

GCI0033 (AsyncSinkhole) is now a hollow-shell rule - its .Result/.Wait() detection was a strict subset of GCI0016 (ConcurrencyAndStateRisk), which already fires on the same patterns with the same guidance. Keeping both was producing duplicate findings on every blocking async call.

Both superseded rules retain their class and ID to avoid breaking configs or reflection-based discovery. All tests updated to verify:
- Superseded rules return empty findings
- Canonical rules (GCI0024, GCI0016) cover the previously-tested patterns

Added complementary cross-reference comments to GCI0023/GCI0029 clarifying they check different dimensions (format vs. content) of log calls.