### PR TITLE
[INFRA] Add winget and Homebrew packaging manifests for v2.0.0

### DIFF
--- a/packaging/homebrew/gauntletci.rb
+++ b/packaging/homebrew/gauntletci.rb
@@ -1,0 +1,36 @@
+class Gauntletci < Formula
+  desc "Deterministic pre-commit risk detection engine for git diffs"
+  homepage "https://github.com/EricCogen/GauntletCI"
+  version "2.0.0"
+  license "Elastic-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/EricCogen/GauntletCI/releases/download/v#{version}/gauntletci-osx-arm64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    on_intel do
+      url "https://github.com/EricCogen/GauntletCI/releases/download/v#{version}/gauntletci-osx-x64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/EricCogen/GauntletCI/releases/download/v#{version}/gauntletci-linux-arm64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    on_intel do
+      url "https://github.com/EricCogen/GauntletCI/releases/download/v#{version}/gauntletci-linux-x64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  def install
+    bin.install "gauntletci"
+  end
+
+  test do
+    assert_match "GauntletCI", shell_output("#{bin}/gauntletci --version")
+  end
+end

--- a/packaging/winget/EricCogen.GauntletCI.installer.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.installer.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: EricCogen.GauntletCI
+PackageVersion: 2.0.0
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Commands:
+  - gauntletci
+ReleaseDate: 2025-01-01
+Installers:
+  - Architecture: x64
+    Platform:
+      - Windows.Desktop
+    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.0.0/gauntletci-win-x64.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: gauntletci.exe
+        PortableCommandAlias: gauntletci
+  - Architecture: arm64
+    Platform:
+      - Windows.Desktop
+    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.0.0/gauntletci-win-arm64.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: gauntletci.exe
+        PortableCommandAlias: gauntletci
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/EricCogen.GauntletCI.locale.en-US.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: EricCogen.GauntletCI
+PackageVersion: 2.0.0
+PackageLocale: en-US
+Publisher: Eric Cogen
+PublisherUrl: https://github.com/EricCogen
+PublisherSupportUrl: https://github.com/EricCogen/GauntletCI/issues
+PackageName: GauntletCI
+PackageUrl: https://github.com/EricCogen/GauntletCI
+License: Elastic-2.0
+LicenseUrl: https://github.com/EricCogen/GauntletCI/blob/main/LICENSE
+ShortDescription: Deterministic pre-commit risk detection engine for git diffs.
+Description: |-
+  GauntletCI analyzes git diffs for behavioral changes that may not be properly validated.
+  It runs a suite of deterministic rules over pull request or pre-commit diffs and flags
+  risks such as concurrency issues, missing error handling, schema changes, secrets exposure,
+  and more — all without sending code to an external service.
+Moniker: gauntletci
+Tags:
+  - git
+  - diff
+  - code-review
+  - static-analysis
+  - pre-commit
+  - risk-detection
+  - ci
+ReleaseNotesUrl: https://github.com/EricCogen/GauntletCI/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/EricCogen.GauntletCI.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: EricCogen.GauntletCI
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
- packaging/winget/: three-file winget manifest (version, locale, installer) covering x64 and arm64 Windows portable installs
- packaging/homebrew/gauntletci.rb: Homebrew formula for macOS (arm64/x64) and Linux (arm64/x64)
- SHA256 hashes are placeholder zeros; update when release artifacts are published