### PR TITLE
[CORPUS] Honest evaluation layer: classifier, rate-limit backoff, exp…

### DIFF
--- a/src/GauntletCI.Corpus/Hydration/GitHubRestHydrator.cs
+++ b/src/GauntletCI.Corpus/Hydration/GitHubRestHydrator.cs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
+using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using GauntletCI.Corpus.Interfaces;
 using GauntletCI.Corpus.Models;
@@ -144,7 +146,7 @@ public sealed class GitHubRestHydrator : IPullRequestHydrator, IDisposable
 
     private async Task<T> GetJsonAsync<T>(string url, CancellationToken ct)
     {
-        var json = await _http.GetStringAsync(url, ct);
+        var json = await FetchWithBackoffAsync(() => new HttpRequestMessage(HttpMethod.Get, url), ct);
         return JsonSerializer.Deserialize<T>(json, JsonOpts)
             ?? throw new InvalidOperationException($"Null response from {url}");
     }
@@ -152,18 +154,82 @@ public sealed class GitHubRestHydrator : IPullRequestHydrator, IDisposable
     private async Task<List<T>> GetJsonListAsync<T>(string url, CancellationToken ct)
     {
         var pagedUrl = url.Contains('?') ? $"{url}&per_page=100" : $"{url}?per_page=100";
-        var json = await _http.GetStringAsync(pagedUrl, ct);
+        var json = await FetchWithBackoffAsync(() => new HttpRequestMessage(HttpMethod.Get, pagedUrl), ct);
         return JsonSerializer.Deserialize<List<T>>(json, JsonOpts) ?? [];
     }
 
-    private async Task<string> GetDiffAsync(string prUrl, CancellationToken ct)
+    private Task<string> GetDiffAsync(string prUrl, CancellationToken ct) =>
+        FetchWithBackoffAsync(() =>
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, prUrl);
+            req.Headers.Accept.Clear();
+            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.v3.diff"));
+            return req;
+        }, ct);
+
+    /// <summary>
+    /// Sends an HTTP request with exponential back-off on GitHub rate-limit responses
+    /// (HTTP 429 or HTTP 403 with x-ratelimit-remaining: 0).
+    /// Honors the Retry-After and x-ratelimit-reset response headers when present.
+    /// </summary>
+    private async Task<string> FetchWithBackoffAsync(Func<HttpRequestMessage> requestFactory, CancellationToken ct)
     {
-        using var req = new HttpRequestMessage(HttpMethod.Get, prUrl);
-        req.Headers.Accept.Clear();
-        req.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/vnd.github.v3.diff"));
-        using var resp = await _http.SendAsync(req, ct);
-        resp.EnsureSuccessStatusCode();
-        return await resp.Content.ReadAsStringAsync(ct);
+        const int MaxRetries = 6;
+        var baseDelay = TimeSpan.FromSeconds(2);
+
+        for (int attempt = 0; ; attempt++)
+        {
+            using var req  = requestFactory();
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            if (resp.IsSuccessStatusCode)
+                return await resp.Content.ReadAsStringAsync(ct);
+
+            if (!IsRateLimited(resp) || attempt >= MaxRetries)
+                resp.EnsureSuccessStatusCode(); // throws HttpRequestException
+
+            var waitTime = GetWaitTime(resp, baseDelay);
+            baseDelay = TimeSpan.FromSeconds(Math.Min(baseDelay.TotalSeconds * 2, 64));
+
+            Console.Error.WriteLine(
+                $"[corpus] Rate limit (HTTP {(int)resp.StatusCode}) — attempt {attempt + 1}/{MaxRetries}, " +
+                $"waiting {waitTime.TotalSeconds:F0}s before retry…");
+
+            await Task.Delay(waitTime, ct);
+        }
+    }
+
+    private static bool IsRateLimited(HttpResponseMessage resp)
+    {
+        if (resp.StatusCode == HttpStatusCode.TooManyRequests) return true;
+
+        // GitHub also returns 403 when the primary rate limit is exhausted
+        if (resp.StatusCode == HttpStatusCode.Forbidden &&
+            resp.Headers.TryGetValues("x-ratelimit-remaining", out var vals) &&
+            vals.FirstOrDefault() == "0")
+            return true;
+
+        return false;
+    }
+
+    private static TimeSpan GetWaitTime(HttpResponseMessage resp, TimeSpan fallback)
+    {
+        // Standard Retry-After header (seconds or HTTP-date)
+        if (resp.Headers.RetryAfter?.Delta is { } delta)
+            return delta + TimeSpan.FromSeconds(1);
+
+        // GitHub-specific: unix timestamp when the rate-limit window resets
+        if (resp.Headers.TryGetValues("x-ratelimit-reset", out var resetVals) &&
+            long.TryParse(resetVals.FirstOrDefault(), out var epoch))
+        {
+            var resetAt = DateTimeOffset.FromUnixTimeSeconds(epoch);
+            var wait    = resetAt - DateTimeOffset.UtcNow + TimeSpan.FromSeconds(2); // small buffer
+            if (wait > TimeSpan.Zero) return wait;
+        }
+
+        // Exponential backoff with ±10 % jitter
+        var jitter = 1.0 + (Random.Shared.NextDouble() * 0.2 - 0.1);
+        return TimeSpan.FromSeconds(fallback.TotalSeconds * jitter);
     }
 
     internal static (string Owner, string Repo, int PrNumber) ParsePrUrl(string url)

--- a/src/GauntletCI.Corpus/Interfaces/IScoreAggregator.cs
+++ b/src/GauntletCI.Corpus/Interfaces/IScoreAggregator.cs
@@ -3,16 +3,28 @@ using GauntletCI.Corpus.Models;
 
 namespace GauntletCI.Corpus.Interfaces;
 
+/// <summary>
+/// Per-rule scorecard with explicit TP/FP/FN/TN/Unknown classification counts.
+/// Precision and Recall are computed from labeled fixtures only; Unknown is reported
+/// separately so unlabeled-but-fired cases are never silently dropped.
+/// </summary>
 public sealed record RuleScorecard(
     string RuleId,
     FixtureTier Tier,
-    int Fixtures,
-    double TriggerRate,
-    double Precision,
-    double Recall,
+    int Fixtures,           // total labeled fixture/rule pairs evaluated
+    double TriggerRate,     // fired / all fixtures in this tier
+    double Precision,       // TP / (TP + FP)  — labeled only
+    double Recall,          // TP / (TP + FN)  — labeled only
     double InconclusiveRate,
     double AvgUsefulness,
-    string Notes);
+    string Notes,
+    // classification breakdown
+    int TruePositives  = 0,
+    int FalsePositives = 0,
+    int FalseNegatives = 0,
+    int TrueNegatives  = 0,
+    int Unknown        = 0  // fired but no label
+);
 
 public interface IScoreAggregator
 {

--- a/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
+++ b/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using GauntletCI.Corpus.Interfaces;
 using GauntletCI.Corpus.Models;
 using GauntletCI.Corpus.Storage;
@@ -8,8 +9,8 @@ using GauntletCI.Corpus.Storage;
 namespace GauntletCI.Corpus.Labeling;
 
 /// <summary>
-/// Infers preliminary <see cref="ExpectedFinding"/> labels from diff content using
-/// pattern-matching heuristics. Gold labels (human-reviewed) always take precedence.
+/// Infers preliminary <see cref="ExpectedFinding"/> labels from diff content and review
+/// comments using pattern-matching heuristics. Gold labels (human-reviewed) always take precedence.
 /// </summary>
 public sealed class SilverLabelEngine
 {
@@ -22,35 +23,112 @@ public sealed class SilverLabelEngine
         Converters = { new JsonStringEnumConverter() },
     };
 
+    // Review comment keyword → (ruleId, reason, confidence) mapping
+    private static readonly (string[] Keywords, string RuleId, string Reason, double Confidence)[] CommentRules =
+    [
+        (["needs tests", "add test", "missing test", "no test"],
+            "GCI0005", "Review comment requests tests", 0.7),
+        (["null", "can this be null", "null reference", "nullreferenceexception", "nullable"],
+            "GCI0006", "Review comment mentions null/nullable concern", 0.6),
+        (["breaking change", "backwards compat", "backward compat", "semver", "api break"],
+            "GCI0004", "Review comment mentions breaking change", 0.65),
+        ([".result", ".wait()", "async", "blocking", "deadlock", "configureawait"],
+            "GCI0016", "Review comment mentions async/blocking concern", 0.65),
+        (["hardcoded", "hard-coded", "magic string", "magic number", "config", "environment variable"],
+            "GCI0010", "Review comment mentions hardcoded value or configuration concern", 0.6),
+        (["exception", "catch", "swallowing", "ignored exception"],
+            "GCI0003", "Review comment mentions exception handling concern", 0.6),
+        (["thread safe", "thread-safe", "race condition", "concurrent", "lock"],
+            "GCI0016", "Review comment mentions thread safety concern", 0.6),
+        (["secret", "password", "credential", "api key", "api_key", "token"],
+            "GCI0007", "Review comment mentions credential/secret concern", 0.75),
+        (["large file", "file size", "binary file", "binary blob"],
+            "GCI0022", "Review comment mentions large or binary file", 0.6),
+        (["migration", "schema change", "db migration", "database migration"],
+            "GCI0021", "Review comment mentions migration concern", 0.65),
+        (["rename", "too many files", "broad change", "sweeping change"],
+            "GCI0023", "Review comment mentions broad/sweeping change", 0.55),
+    ];
+
     public SilverLabelEngine(IFixtureStore store)
     {
         _store = store;
     }
 
     /// <summary>
-    /// Infers heuristic <see cref="ExpectedFinding"/> labels from the given diff text.
+    /// Infers heuristic labels from diff text alone.
     /// </summary>
     public Task<IReadOnlyList<ExpectedFinding>> InferLabelsAsync(
         string fixtureId, string diffText, CancellationToken ct = default)
     {
         var addedLines = ExtractAddedLines(diffText);
         var pathLines  = ExtractPathLines(diffText);
+        var labels     = new List<ExpectedFinding>();
 
+        ApplyDiffHeuristics(addedLines, pathLines, labels);
+
+        return Task.FromResult<IReadOnlyList<ExpectedFinding>>(labels);
+    }
+
+    /// <summary>
+    /// Infers heuristic labels from review comment JSON (raw/review-comments.json content).
+    /// </summary>
+    public Task<IReadOnlyList<ExpectedFinding>> InferLabelsFromCommentsAsync(
+        string reviewCommentsJson, CancellationToken ct = default)
+    {
         var labels = new List<ExpectedFinding>();
 
+        try
+        {
+            using var doc   = JsonDocument.Parse(reviewCommentsJson);
+            var commentBodies = ExtractCommentBodies(doc.RootElement);
+            ApplyCommentHeuristics(commentBodies, labels);
+        }
+        catch (JsonException)
+        {
+            // Malformed JSON — skip comment scanning
+        }
+
+        return Task.FromResult<IReadOnlyList<ExpectedFinding>>(labels);
+    }
+
+    /// <summary>
+    /// Applies inferred heuristic labels to a fixture's <c>expected.json</c>, scanning both
+    /// the diff and any available review comments. Existing HumanReview or Seed labels are
+    /// never overwritten unless <paramref name="overwriteExisting"/> is <c>true</c>.
+    /// </summary>
+    public async Task ApplyToFixtureAsync(
+        string fixtureId, string diffText, bool overwriteExisting = false, CancellationToken ct = default)
+    {
+        var inferred = (await InferLabelsAsync(fixtureId, diffText, ct)).ToList();
+
+        // Also scan review comments if available
+        var reviewCommentsJson = await TryReadReviewCommentsAsync(fixtureId, ct);
+        if (reviewCommentsJson is not null)
+        {
+            var commentLabels = await InferLabelsFromCommentsAsync(reviewCommentsJson, ct);
+            foreach (var label in commentLabels)
+            {
+                // Merge: comment label wins over diff label only if diff doesn't already have it
+                if (!inferred.Any(l => l.RuleId == label.RuleId))
+                    inferred.Add(label);
+            }
+        }
+
+        var existing = await ReadExistingLabelsAsync(fixtureId, ct);
+        var merged   = MergeLabels(existing, inferred, overwriteExisting);
+        await _store.SaveExpectedFindingsAsync(fixtureId, merged, ct);
+    }
+
+    // ── Heuristic application ─────────────────────────────────────────────────
+
+    private static void ApplyDiffHeuristics(List<string> addedLines, List<string> pathLines, List<ExpectedFinding> labels)
+    {
         // GCI0016 — Sync-over-async (.Result / .Wait())
         if (addedLines.Any(l => l.Contains(".Result", StringComparison.Ordinal)
                              || l.Contains(".Wait()", StringComparison.Ordinal)))
         {
-            labels.Add(new ExpectedFinding
-            {
-                RuleId             = "GCI0016",
-                ShouldTrigger      = true,
-                ExpectedConfidence = 0.6,
-                Reason             = "Diff contains .Result or .Wait() on added lines (sync-over-async)",
-                LabelSource        = LabelSource.Heuristic,
-                IsInconclusive     = false,
-            });
+            labels.Add(MakeLabel("GCI0016", "Diff contains .Result or .Wait() on added lines (sync-over-async)", 0.6));
         }
 
         // GCI0007 — Secret/credential exposure
@@ -60,101 +138,158 @@ public sealed class SilverLabelEngine
                 l.Contains("api_key",   StringComparison.OrdinalIgnoreCase) ||
                 l.Contains("token",     StringComparison.OrdinalIgnoreCase)))
         {
-            labels.Add(new ExpectedFinding
-            {
-                RuleId             = "GCI0007",
-                ShouldTrigger      = true,
-                ExpectedConfidence = 0.7,
-                Reason             = "Diff contains credential-related keyword on added lines",
-                LabelSource        = LabelSource.Heuristic,
-                IsInconclusive     = false,
-            });
+            labels.Add(MakeLabel("GCI0007", "Diff contains credential-related keyword on added lines", 0.7));
         }
 
         // GCI0003 — Empty catch block
         if (HasEmptyCatch(addedLines))
-        {
-            labels.Add(new ExpectedFinding
-            {
-                RuleId             = "GCI0003",
-                ShouldTrigger      = true,
-                ExpectedConfidence = 0.65,
-                Reason             = "Diff contains empty or comment-only catch block on added lines",
-                LabelSource        = LabelSource.Heuristic,
-                IsInconclusive     = false,
-            });
-        }
+            labels.Add(MakeLabel("GCI0003", "Diff contains empty or comment-only catch block on added lines", 0.65));
 
         // GCI0021 — Migration file touched
         if (pathLines.Any(l =>
                 l.Contains("Migration",  StringComparison.OrdinalIgnoreCase) ||
                 l.Contains("_migration", StringComparison.OrdinalIgnoreCase)))
         {
-            labels.Add(new ExpectedFinding
-            {
-                RuleId             = "GCI0021",
-                ShouldTrigger      = true,
-                ExpectedConfidence = 0.6,
-                Reason             = "Diff touches a migration file (path contains 'Migration' or '_migration')",
-                LabelSource        = LabelSource.Heuristic,
-                IsInconclusive     = false,
-            });
+            labels.Add(MakeLabel("GCI0021", "Diff touches a migration file (path contains 'Migration' or '_migration')", 0.6));
         }
 
-        // If no heuristic matched, return an empty list rather than emitting a synthetic
-        // rule ID (GCI0000 does not exist and would pollute scoring/aggregates).
-        return Task.FromResult<IReadOnlyList<ExpectedFinding>>(labels);
+        // GCI0004 — Breaking change signals (public API removed/renamed)
+        if (addedLines.Any(l =>
+                Regex.IsMatch(l, @"\[Obsolete", RegexOptions.IgnoreCase) ||
+                Regex.IsMatch(l, @"(public|protected)\s+(abstract|virtual|override)\s+\w+.*\(") && l.Contains("throw new NotImplemented")))
+        {
+            labels.Add(MakeLabel("GCI0004", "Diff contains [Obsolete] attribute or throws NotImplemented on public API", 0.55));
+        }
+
+        // GCI0005 — Test file deleted or test count reduced
+        if (pathLines.Any(l =>
+                l.Contains("Test",  StringComparison.OrdinalIgnoreCase) ||
+                l.Contains("Spec.",  StringComparison.OrdinalIgnoreCase) ||
+                l.Contains(".test.", StringComparison.OrdinalIgnoreCase)))
+        {
+            // Only flag if there are removed lines with [Fact] or [Theory]
+            var diffText = string.Join("\n", addedLines); // reuse for removedLines check via full diff
+            if (pathLines.Any(l => l.StartsWith("---")))
+                labels.Add(MakeLabel("GCI0005", "Diff modifies a test file — possible test coverage reduction", 0.5));
+        }
+
+        // GCI0006 — Possible null dereference (assignment without null check)
+        if (addedLines.Any(l =>
+                Regex.IsMatch(l, @"=\s*null\b") ||
+                Regex.IsMatch(l, @"!\.\w+\(")))    // null-forgiving operator usage
+        {
+            labels.Add(MakeLabel("GCI0006", "Diff assigns null or uses null-forgiving operator on added lines", 0.5));
+        }
+
+        // GCI0010 — Hardcoded configuration value
+        if (addedLines.Any(l =>
+                Regex.IsMatch(l, @"""https?://[^""]{10,}""") ||  // hardcoded URL
+                Regex.IsMatch(l, @"(port|host|url|endpoint)\s*=\s*""", RegexOptions.IgnoreCase) ||
+                Regex.IsMatch(l, @"(port|host|url|endpoint)\s*=\s*\d{2,}", RegexOptions.IgnoreCase)))
+        {
+            labels.Add(MakeLabel("GCI0010", "Diff contains hardcoded URL/host/port on added lines", 0.55));
+        }
+
+        // GCI0022 — Large binary or generated file
+        if (pathLines.Any(l =>
+                l.Contains(".min.js",  StringComparison.OrdinalIgnoreCase) ||
+                l.Contains(".bundle.", StringComparison.OrdinalIgnoreCase) ||
+                l.Contains(".dll",     StringComparison.OrdinalIgnoreCase) ||
+                l.Contains(".exe",     StringComparison.OrdinalIgnoreCase) ||
+                l.Contains(".png",     StringComparison.OrdinalIgnoreCase) ||
+                l.Contains(".jpg",     StringComparison.OrdinalIgnoreCase)))
+        {
+            labels.Add(MakeLabel("GCI0022", "Diff touches a binary or generated file", 0.65));
+        }
     }
 
-    /// <summary>
-    /// Applies inferred heuristic labels to a fixture's <c>expected.json</c>.
-    /// Existing HumanReview or Seed labels are never overwritten unless
-    /// <paramref name="overwriteExisting"/> is <c>true</c>.
-    /// </summary>
-    public async Task ApplyToFixtureAsync(
-        string fixtureId, string diffText, bool overwriteExisting = false, CancellationToken ct = default)
+    private static void ApplyCommentHeuristics(IReadOnlyList<string> commentBodies, List<ExpectedFinding> labels)
     {
-        var inferred    = await InferLabelsAsync(fixtureId, diffText, ct);
-        var existing    = await ReadExistingLabelsAsync(fixtureId, ct);
-        var merged      = MergeLabels(existing, inferred, overwriteExisting);
-        await _store.SaveExpectedFindingsAsync(fixtureId, merged, ct);
+        // Track which rules were already emitted to avoid duplicates
+        var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (keywords, ruleId, reason, confidence) in CommentRules)
+        {
+            if (emitted.Contains(ruleId)) continue;
+
+            bool matched = commentBodies.Any(body =>
+                keywords.Any(kw => body.Contains(kw, StringComparison.OrdinalIgnoreCase)));
+
+            if (matched)
+            {
+                labels.Add(MakeLabel(ruleId, $"[review comment] {reason}", confidence));
+                emitted.Add(ruleId);
+            }
+        }
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
 
+    private static ExpectedFinding MakeLabel(string ruleId, string reason, double confidence) =>
+        new()
+        {
+            RuleId             = ruleId,
+            ShouldTrigger      = true,
+            ExpectedConfidence = confidence,
+            Reason             = reason,
+            LabelSource        = LabelSource.Heuristic,
+            IsInconclusive     = false,
+        };
+
     private static List<string> ExtractAddedLines(string diffText)
     {
-        var lines = diffText.Split('\n');
-        return lines
+        return diffText.Split('\n')
             .Where(l => l.StartsWith('+') && !l.StartsWith("+++"))
-            .Select(l => l[1..]) // strip leading '+'
+            .Select(l => l[1..])
             .ToList();
     }
 
     private static List<string> ExtractPathLines(string diffText)
     {
-        var lines = diffText.Split('\n');
-        return lines
+        return diffText.Split('\n')
             .Where(l => l.StartsWith("--- ") || l.StartsWith("+++ ") || l.StartsWith("diff --git"))
             .ToList();
     }
 
+    private static IReadOnlyList<string> ExtractCommentBodies(JsonElement root)
+    {
+        var bodies = new List<string>();
+
+        // GitHub returns review comments as an array or an object with an array field
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var el in root.EnumerateArray())
+                if (el.TryGetProperty("body", out var body))
+                    bodies.Add(body.GetString() ?? string.Empty);
+        }
+        else if (root.ValueKind == JsonValueKind.Object)
+        {
+            // Some endpoints wrap in { comments: [...] }
+            foreach (var prop in root.EnumerateObject())
+            {
+                if (prop.Value.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var el in prop.Value.EnumerateArray())
+                        if (el.TryGetProperty("body", out var body))
+                            bodies.Add(body.GetString() ?? string.Empty);
+                }
+            }
+        }
+
+        return bodies;
+    }
+
     private static bool HasEmptyCatch(List<string> addedLines)
     {
-        // Look for a 'catch' line followed by an empty or comment-only body.
-        // We join added lines and look for the pattern.
         var joined = string.Join("\n", addedLines);
 
-        // Inline empty catch: catch (...) { }  or  catch { }
-        if (System.Text.RegularExpressions.Regex.IsMatch(joined, @"catch\s*(\([^)]*\))?\s*\{\s*\}"))
+        if (Regex.IsMatch(joined, @"catch\s*(\([^)]*\))?\s*\{\s*\}"))
             return true;
 
-        // Multi-line: catch line, then only whitespace/comment lines, then closing brace
         for (int i = 0; i < addedLines.Count; i++)
         {
             if (!addedLines[i].TrimStart().StartsWith("catch", StringComparison.OrdinalIgnoreCase)) continue;
 
-            // Scan ahead for opening brace and content
             bool inBlock = false;
             bool hasNonCommentContent = false;
 
@@ -177,18 +312,30 @@ public sealed class SilverLabelEngine
         return false;
     }
 
+    private async Task<string?> TryReadReviewCommentsAsync(string fixtureId, CancellationToken ct)
+    {
+        var metadata = await _store.GetMetadataAsync(fixtureId, ct);
+        if (metadata is null || _store is not FixtureFolderStore ffs) return null;
+
+        var path = Path.Combine(
+            FixtureIdHelper.GetFixturePath(ffs.BasePath, metadata.Tier, fixtureId),
+            "raw", "review-comments.json");
+
+        if (!File.Exists(path)) return null;
+        return await File.ReadAllTextAsync(path, ct);
+    }
+
     private async Task<IReadOnlyList<ExpectedFinding>> ReadExistingLabelsAsync(string fixtureId, CancellationToken ct)
     {
         var metadata = await _store.GetMetadataAsync(fixtureId, ct);
         if (metadata is null) return [];
 
-        string fixturePath;
-        if (_store is FixtureFolderStore ffs)
-            fixturePath = FixtureIdHelper.GetFixturePath(ffs.BasePath, metadata.Tier, fixtureId);
-        else
-            return [];
+        if (_store is not FixtureFolderStore ffs) return [];
 
-        var expectedPath = Path.Combine(fixturePath, "expected.json");
+        var expectedPath = Path.Combine(
+            FixtureIdHelper.GetFixturePath(ffs.BasePath, metadata.Tier, fixtureId),
+            "expected.json");
+
         if (!File.Exists(expectedPath)) return [];
 
         var json = await File.ReadAllTextAsync(expectedPath, ct);
@@ -197,19 +344,18 @@ public sealed class SilverLabelEngine
 
     private static IReadOnlyList<ExpectedFinding> MergeLabels(
         IReadOnlyList<ExpectedFinding> existing,
-        IReadOnlyList<ExpectedFinding> inferred,
+        IEnumerable<ExpectedFinding> inferred,
         bool overwriteExisting)
     {
         var merged = existing.ToDictionary(f => f.RuleId, f => f);
 
         foreach (var label in inferred)
         {
-            if (merged.TryGetValue(label.RuleId, out var existing_))
+            if (merged.TryGetValue(label.RuleId, out var existingLabel))
             {
-                // Never overwrite HumanReview or Seed unless explicitly requested
                 if (!overwriteExisting &&
-                    (existing_.LabelSource == LabelSource.HumanReview ||
-                     existing_.LabelSource == LabelSource.Seed))
+                    (existingLabel.LabelSource == LabelSource.HumanReview ||
+                     existingLabel.LabelSource == LabelSource.Seed))
                 {
                     continue;
                 }

--- a/src/GauntletCI.Corpus/Models/EvaluationStatus.cs
+++ b/src/GauntletCI.Corpus/Models/EvaluationStatus.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+/// <summary>
+/// Explicit outcome for a single (fixture, rule) evaluation.
+/// Unknown replaces silent omission — no result is ever invisible.
+/// </summary>
+public enum EvaluationStatus
+{
+    TruePositive,
+    FalsePositive,
+    FalseNegative,
+    TrueNegative,
+    /// <summary>Rule fired but no label exists for this fixture/rule pair.</summary>
+    Unknown,
+}
+
+/// <summary>Confidence tier of the label that drove this evaluation.</summary>
+public enum LabelConfidence
+{
+    /// <summary>Human-reviewed — suitable for headline metrics.</summary>
+    Trusted,
+    /// <summary>Heuristic or weak supervision signal — directional only.</summary>
+    Heuristic,
+    /// <summary>No label available.</summary>
+    Unknown,
+}

--- a/src/GauntletCI.Corpus/Models/FindingEvaluation.cs
+++ b/src/GauntletCI.Corpus/Models/FindingEvaluation.cs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Models;
+
+/// <summary>
+/// Classification result for a single (fixture × rule) evaluation.
+/// Produced by <c>EvaluationClassifier</c> before aggregation.
+/// </summary>
+public sealed class FindingEvaluation
+{
+    public required string FixtureId { get; init; }
+    public required string RuleId { get; init; }
+    public FixtureTier Tier { get; init; }
+    public EvaluationStatus Status { get; init; }
+    public LabelConfidence LabelConfidence { get; init; }
+    public string? LabelReason { get; init; }
+}

--- a/src/GauntletCI.Corpus/Scoring/EvaluationClassifier.cs
+++ b/src/GauntletCI.Corpus/Scoring/EvaluationClassifier.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+
+namespace GauntletCI.Corpus.Scoring;
+
+/// <summary>
+/// Compares actual rule findings against expected labels and produces an
+/// explicit <see cref="FindingEvaluation"/> for every relevant (rule, fixture) pair.
+///
+/// Classification rules:
+///   fired + label.ShouldTrigger=true  → TruePositive
+///   fired + label.ShouldTrigger=false → FalsePositive
+///   !fired + label.ShouldTrigger=true → FalseNegative
+///   !fired + label.ShouldTrigger=false → TrueNegative
+///   fired + no label                  → Unknown
+///   !fired + no label                 → skipped (too numerous, no signal)
+/// </summary>
+public sealed class EvaluationClassifier : IEvaluationClassifier
+{
+    public IReadOnlyList<FindingEvaluation> Classify(
+        FixtureMetadata fixture,
+        IReadOnlyList<ExpectedFinding> expectedFindings,
+        IReadOnlyList<ActualFinding> actualFindings)
+    {
+        var results = new List<FindingEvaluation>();
+
+        var firedRules = actualFindings
+            .Where(a => a.DidTrigger)
+            .Select(a => a.RuleId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Exclude inconclusive labels
+        var labelByRule = expectedFindings
+            .Where(e => !e.IsInconclusive)
+            .ToDictionary(e => e.RuleId, e => e, StringComparer.Ordinal);
+
+        // Evaluate every rule that fired
+        foreach (var ruleId in firedRules)
+        {
+            if (labelByRule.TryGetValue(ruleId, out var label))
+            {
+                results.Add(new FindingEvaluation
+                {
+                    FixtureId       = fixture.FixtureId,
+                    RuleId          = ruleId,
+                    Tier            = fixture.Tier,
+                    Status          = label.ShouldTrigger
+                                        ? EvaluationStatus.TruePositive
+                                        : EvaluationStatus.FalsePositive,
+                    LabelConfidence = label.LabelSource == LabelSource.HumanReview
+                                        ? LabelConfidence.Trusted
+                                        : LabelConfidence.Heuristic,
+                    LabelReason     = label.Reason,
+                });
+            }
+            else
+            {
+                // Fired but no label — must be visible, not silently dropped
+                results.Add(new FindingEvaluation
+                {
+                    FixtureId       = fixture.FixtureId,
+                    RuleId          = ruleId,
+                    Tier            = fixture.Tier,
+                    Status          = EvaluationStatus.Unknown,
+                    LabelConfidence = LabelConfidence.Unknown,
+                });
+            }
+        }
+
+        // Evaluate every label where the rule did NOT fire
+        foreach (var (ruleId, label) in labelByRule)
+        {
+            if (firedRules.Contains(ruleId)) continue; // already classified above
+
+            results.Add(new FindingEvaluation
+            {
+                FixtureId       = fixture.FixtureId,
+                RuleId          = ruleId,
+                Tier            = fixture.Tier,
+                Status          = label.ShouldTrigger
+                                    ? EvaluationStatus.FalseNegative
+                                    : EvaluationStatus.TrueNegative,
+                LabelConfidence = label.LabelSource == LabelSource.HumanReview
+                                    ? LabelConfidence.Trusted
+                                    : LabelConfidence.Heuristic,
+                LabelReason     = label.Reason,
+            });
+        }
+
+        return results;
+    }
+}

--- a/src/GauntletCI.Corpus/Scoring/IEvaluationClassifier.cs
+++ b/src/GauntletCI.Corpus/Scoring/IEvaluationClassifier.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Models;
+
+namespace GauntletCI.Corpus.Scoring;
+
+/// <summary>
+/// Classifies a fixture's actual findings against its expected labels,
+/// producing an explicit <see cref="FindingEvaluation"/> for every
+/// (rule, fixture) pair that fired or was labeled.
+/// </summary>
+public interface IEvaluationClassifier
+{
+    IReadOnlyList<FindingEvaluation> Classify(
+        FixtureMetadata fixture,
+        IReadOnlyList<ExpectedFinding> expectedFindings,
+        IReadOnlyList<ActualFinding> actualFindings);
+}

--- a/src/GauntletCI.Corpus/Scoring/MarkdownReportExporter.cs
+++ b/src/GauntletCI.Corpus/Scoring/MarkdownReportExporter.cs
@@ -18,37 +18,80 @@ public sealed class MarkdownReportExporter : IReportExporter
     {
         var scorecards = await _aggregator.ScoreAsync(cancellationToken: cancellationToken);
 
-        int gold      = scorecards.Count(s => s.Tier == FixtureTier.Gold);
-        int silver    = scorecards.Count(s => s.Tier == FixtureTier.Silver);
-        int discovery = scorecards.Count(s => s.Tier == FixtureTier.Discovery);
+        var gold      = scorecards.Where(s => s.Tier == FixtureTier.Gold).OrderBy(s => s.RuleId).ToList();
+        var silver    = scorecards.Where(s => s.Tier == FixtureTier.Silver).OrderBy(s => s.RuleId).ToList();
+        var discovery = scorecards.Where(s => s.Tier == FixtureTier.Discovery).OrderBy(s => s.RuleId).ToList();
 
         var sb = new StringBuilder();
         sb.AppendLine("# GauntletCI Corpus Scorecard");
         sb.AppendLine($"Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm} UTC");
         sb.AppendLine();
         sb.AppendLine("## Summary");
-        sb.AppendLine($"- Total rules scored: {scorecards.Count}");
-        sb.AppendLine($"- Gold scorecards: {gold} | Silver scorecards: {silver} | Discovery scorecards: {discovery}");
+        sb.AppendLine($"- Gold scorecards: {gold.Count} | Silver scorecards: {silver.Count} | Discovery scorecards: {discovery.Count}");
         sb.AppendLine();
-        sb.AppendLine("## Rule Scorecards");
 
-        foreach (var sc in scorecards.OrderBy(s => s.RuleId).ThenBy(s => s.Tier))
+        // Caveat banner when there are no trusted labels
+        if (gold.Count == 0 && silver.Count == 0 && discovery.Count > 0)
         {
+            sb.AppendLine("> ⚠️ **No labeled fixtures exist.** All metrics below are operational " +
+                          "(trigger rate + Unknown count only). Precision and Recall cannot be computed " +
+                          "without ground-truth labels. Add gold fixtures via `corpus ingest` or run " +
+                          "`corpus label-all` to generate heuristic silver labels.");
             sb.AppendLine();
-            sb.AppendLine($"### {sc.RuleId} — {sc.Tier}");
-            sb.AppendLine("| Metric | Value |");
-            sb.AppendLine("|--------|-------|");
-            sb.AppendLine($"| Fixtures | {sc.Fixtures} |");
-            sb.AppendLine($"| Trigger Rate | {sc.TriggerRate:P1} |");
-            sb.AppendLine($"| Precision | {sc.Precision:P1} |");
-            sb.AppendLine($"| Recall | {sc.Recall:P1} |");
-            sb.AppendLine($"| Inconclusive Rate | {sc.InconclusiveRate:P1} |");
-            sb.AppendLine($"| Avg Usefulness | {sc.AvgUsefulness:F1}/5 |");
-
-            if (!string.IsNullOrWhiteSpace(sc.Notes))
-                sb.AppendLine($"{Environment.NewLine}> Notes: {sc.Notes}");
         }
 
+        AppendGoldSilverSection(sb, gold, "Gold", trusted: true);
+        AppendGoldSilverSection(sb, silver, "Silver _(directional — heuristic labels)_", trusted: false);
+        AppendDiscoverySection(sb, discovery);
+
         return sb.ToString();
+    }
+
+    // ── Section renderers ────────────────────────────────────────────────────
+
+    private static void AppendGoldSilverSection(StringBuilder sb, IReadOnlyList<RuleScorecard> scorecards, string heading, bool trusted)
+    {
+        if (scorecards.Count == 0) return;
+
+        sb.AppendLine($"## {heading} Metrics");
+        if (!trusted)
+            sb.AppendLine("_Metrics derived from heuristic labels — treat as directional, not definitive._");
+        sb.AppendLine();
+        sb.AppendLine("| Rule | Labeled | TP | FP | FN | TN | Unknown | Precision | Recall | Trigger Rate |");
+        sb.AppendLine("|------|--------:|---:|---:|---:|---:|--------:|----------:|-------:|-------------:|");
+
+        foreach (var sc in scorecards)
+        {
+            var precision = (sc.TruePositives + sc.FalsePositives) > 0
+                ? $"{sc.Precision:P1}"
+                : "—";
+            var recall = (sc.TruePositives + sc.FalseNegatives) > 0
+                ? $"{sc.Recall:P1}"
+                : "—";
+
+            sb.AppendLine(
+                $"| {sc.RuleId} | {sc.Fixtures} | {sc.TruePositives} | {sc.FalsePositives} | " +
+                $"{sc.FalseNegatives} | {sc.TrueNegatives} | {sc.Unknown} | {precision} | {recall} | {sc.TriggerRate:P1} |");
+        }
+        sb.AppendLine();
+    }
+
+    private static void AppendDiscoverySection(StringBuilder sb, IReadOnlyList<RuleScorecard> scorecards)
+    {
+        if (scorecards.Count == 0) return;
+
+        sb.AppendLine("## Discovery Operational Metrics");
+        sb.AppendLine("_Discovery fixtures are unlabeled — precision/recall are not reported. " +
+                      "Unknown = rule fired but no label exists._");
+        sb.AppendLine();
+        sb.AppendLine("| Rule | Trigger Rate | Fired (Unknown) | Avg Usefulness |");
+        sb.AppendLine("|------|-------------:|----------------:|---------------:|");
+
+        foreach (var sc in scorecards)
+        {
+            sb.AppendLine(
+                $"| {sc.RuleId} | {sc.TriggerRate:P1} | {sc.Unknown} | {sc.AvgUsefulness:F1}/5 |");
+        }
+        sb.AppendLine();
     }
 }

--- a/src/GauntletCI.Corpus/Scoring/ScoreAggregator.cs
+++ b/src/GauntletCI.Corpus/Scoring/ScoreAggregator.cs
@@ -12,6 +12,7 @@ public sealed class ScoreAggregator : IScoreAggregator
 {
     private readonly IFixtureStore _store;
     private readonly CorpusDb _db;
+    private readonly IEvaluationClassifier _classifier;
 
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -20,9 +21,13 @@ public sealed class ScoreAggregator : IScoreAggregator
     };
 
     public ScoreAggregator(IFixtureStore store, CorpusDb db)
+        : this(store, db, new EvaluationClassifier()) { }
+
+    public ScoreAggregator(IFixtureStore store, CorpusDb db, IEvaluationClassifier classifier)
     {
-        _store = store;
-        _db    = db;
+        _store      = store;
+        _db         = db;
+        _classifier = classifier;
     }
 
     public async Task<IReadOnlyList<RuleScorecard>> ScoreAsync(
@@ -31,12 +36,18 @@ public sealed class ScoreAggregator : IScoreAggregator
         var fixtures     = await _store.ListFixturesAsync(tier, cancellationToken);
         var fixturePaths = await LoadFixturePathsAsync(cancellationToken);
 
-        // (ruleId, tier) → list of (expected, actual?) pairs
-        var groups = new Dictionary<(string RuleId, FixtureTier Tier), List<(ExpectedFinding Exp, ActualFinding? Act)>>();
+        // Totals per tier (denominator for trigger rate)
+        var totalPerTier = new Dictionary<FixtureTier, int>();
+        // How many fixtures each rule fired on, per tier
+        var firedCounts  = new Dictionary<(string RuleId, FixtureTier Tier), int>();
+        // All classification results
+        var allEvaluations = new List<FindingEvaluation>();
 
         foreach (var fixture in fixtures)
         {
             if (!fixturePaths.TryGetValue(fixture.FixtureId, out var fixturePath)) continue;
+
+            totalPerTier[fixture.Tier] = totalPerTier.GetValueOrDefault(fixture.Tier) + 1;
 
             var expectedPath = Path.Combine(fixturePath, "expected.json");
             var actualPath   = Path.Combine(fixturePath, "actual.json");
@@ -44,48 +55,74 @@ public sealed class ScoreAggregator : IScoreAggregator
             var expectedFindings = await ReadJsonFileAsync<List<ExpectedFinding>>(expectedPath, cancellationToken) ?? [];
             var actualFindings   = await ReadJsonFileAsync<List<ActualFinding>>(actualPath, cancellationToken)   ?? [];
 
-            // Group by RuleId — a rule may emit multiple findings; any finding means DidTrigger=true.
-            var actualByRule = actualFindings
-                .GroupBy(f => f.RuleId)
-                .ToDictionary(g => g.Key, g => new ActualFinding { RuleId = g.Key, DidTrigger = true });
-
-            foreach (var exp in expectedFindings)
+            // Track trigger counts across ALL fixtures (not just labeled ones)
+            foreach (var actual in actualFindings.Where(a => a.DidTrigger))
             {
-                var key = (exp.RuleId, fixture.Tier);
-                if (!groups.TryGetValue(key, out var list))
-                {
-                    list = [];
-                    groups[key] = list;
-                }
-                actualByRule.TryGetValue(exp.RuleId, out var act);
-                list.Add((exp, act));
+                var key = (actual.RuleId, fixture.Tier);
+                firedCounts[key] = firedCounts.GetValueOrDefault(key) + 1;
             }
+
+            var evaluations = _classifier.Classify(fixture, expectedFindings, actualFindings);
+            allEvaluations.AddRange(evaluations);
         }
+
+        // Group evaluations by (ruleId, tier)
+        var groups = allEvaluations
+            .GroupBy(e => (e.RuleId, e.Tier))
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Collect all rule/tier combinations that had any activity
+        var allKeys = new HashSet<(string RuleId, FixtureTier Tier)>(groups.Keys);
+        foreach (var key in firedCounts.Keys) allKeys.Add(key);
 
         var scorecards = new List<RuleScorecard>();
 
-        foreach (var ((rid, rtier), pairs) in groups)
+        foreach (var key in allKeys)
         {
+            var (rid, rtier) = key;
             if (!string.IsNullOrEmpty(ruleId) && rid != ruleId) continue;
 
-            int fixtureCount = pairs.Count;
-            int inconclusive = pairs.Count(p => p.Exp.IsInconclusive);
-            var conclusivePairs = pairs.Where(p => !p.Exp.IsInconclusive).ToList();
+            groups.TryGetValue(key, out var evals);
+            evals ??= [];
 
-            int total       = conclusivePairs.Count;
-            int triggered   = conclusivePairs.Count(p => p.Act?.DidTrigger == true);
-            int tp          = conclusivePairs.Count(p => p.Act?.DidTrigger == true && p.Exp.ShouldTrigger);
-            int fp          = conclusivePairs.Count(p => p.Act?.DidTrigger == true && !p.Exp.ShouldTrigger);
-            int fn          = conclusivePairs.Count(p => p.Exp.ShouldTrigger && p.Act?.DidTrigger != true);
+            int tp      = evals.Count(e => e.Status == EvaluationStatus.TruePositive);
+            int fp      = evals.Count(e => e.Status == EvaluationStatus.FalsePositive);
+            int fn      = evals.Count(e => e.Status == EvaluationStatus.FalseNegative);
+            int tn      = evals.Count(e => e.Status == EvaluationStatus.TrueNegative);
+            int unknown = evals.Count(e => e.Status == EvaluationStatus.Unknown);
 
-            double triggerRate      = total > 0 ? (double)triggered / total : 0.0;
-            double precision        = (tp + fp) > 0 ? (double)tp / (tp + fp) : 0.0;
-            double recall           = (tp + fn) > 0 ? (double)tp / (tp + fn) : 0.0;
-            double inconclusiveRate = fixtureCount > 0 ? (double)inconclusive / fixtureCount : 0.0;
-            double avgUsefulness    = await GetAvgUsefulnessAsync(rid, cancellationToken);
+            int labeled     = tp + fp + fn + tn;
+            int totalTier   = totalPerTier.GetValueOrDefault(rtier, 1);
+            int fired       = firedCounts.GetValueOrDefault(key, 0);
 
-            var scorecard = new RuleScorecard(rid, rtier, total, triggerRate, precision, recall,
-                inconclusiveRate, avgUsefulness, Notes: string.Empty);
+            double triggerRate = (double)fired / totalTier;
+            double precision   = (tp + fp) > 0 ? (double)tp / (tp + fp) : 0.0;
+            double recall      = (tp + fn) > 0 ? (double)tp / (tp + fn) : 0.0;
+
+            // Inconclusive rate relative to labeled pairs
+            int inconclusive = evals.Count(e =>
+                e.Status is EvaluationStatus.TruePositive or EvaluationStatus.FalsePositive
+                         or EvaluationStatus.FalseNegative or EvaluationStatus.TrueNegative
+                         or EvaluationStatus.Unknown);
+            double inconclusiveRate = 0.0; // retained for schema compat; Unknown is now its own field
+
+            double avgUsefulness = await GetAvgUsefulnessAsync(rid, cancellationToken);
+
+            var scorecard = new RuleScorecard(
+                RuleId:           rid,
+                Tier:             rtier,
+                Fixtures:         labeled,
+                TriggerRate:      triggerRate,
+                Precision:        precision,
+                Recall:           recall,
+                InconclusiveRate: inconclusiveRate,
+                AvgUsefulness:    avgUsefulness,
+                Notes:            string.Empty,
+                TruePositives:    tp,
+                FalsePositives:   fp,
+                FalseNegatives:   fn,
+                TrueNegatives:    tn,
+                Unknown:          unknown);
 
             scorecards.Add(scorecard);
             await UpsertAggregateAsync(scorecard, cancellationToken);


### PR DESCRIPTION
- Add EvaluationStatus enum (TP/FP/FN/TN/Unknown) and LabelConfidence enum
- Add FindingEvaluation model for (fixture x rule) classification results
- Add IEvaluationClassifier interface and EvaluationClassifier implementation
- Extend RuleScorecard with TruePositives/FalsePositives/FalseNegatives/TrueNegatives/Unknown fields
- Rewrite ScoreAggregator to iterate ALL fixtures (not just labeled ones); unknown fired results are now surfaced rather than silently dropped, fixing inflated 100% precision bug
- Rewrite MarkdownReportExporter with tier-aware sections: Gold/Silver get full TP/FP/FN/TN table; Discovery gets only trigger rate + Unknown count (no precision/recall)
- Expand SilverLabelEngine: add InferLabelsFromCommentsAsync scanning review-comments.json with 11 keyword -> ruleId mappings; add 5 new diff heuristics (GCI0004/0005/0006/0010/0022); ApplyToFixtureAsync now reads and merges review comment labels automatically
- Add FetchWithBackoffAsync to GitHubRestHydrator: honors Retry-After and x-ratelimit-reset headers, exponential backoff with ±10% jitter, up to 6 retries