### PR TITLE
[CLI] Integrate Spectre.Console for professional CLI output

### DIFF
--- a/src/GauntletCI.Cli/Commands/CorpusCommand.cs
+++ b/src/GauntletCI.Cli/Commands/CorpusCommand.cs
@@ -12,6 +12,7 @@ using GauntletCI.Corpus.Runners;
 using GauntletCI.Corpus.Scoring;
 using GauntletCI.Corpus.Storage;
 using Microsoft.Data.Sqlite;
+using Spectre.Console;
 
 namespace GauntletCI.Cli.Commands;
 
@@ -54,7 +55,7 @@ public static class CorpusCommand
             var fixtures = ctx.ParseResult.GetValueForOption(fixturesOpt)!;
             var ct       = ctx.GetCancellationToken();
 
-            Console.WriteLine($"[corpus] Hydrating {url}");
+            AnsiConsole.MarkupLine($"[blue][[corpus]][/] Hydrating {Markup.Escape(url)}");
 
             var (db, _, pipeline) = await BuildPipeline(dbPath, fixtures, ct);
             using (db)
@@ -141,7 +142,7 @@ public static class CorpusCommand
                     return;
                 }
 
-                Console.WriteLine($"[corpus] Re-normalizing {fixtureId} ({tier})");
+                AnsiConsole.MarkupLine($"[blue][[corpus]][/] Re-normalizing {Markup.Escape(fixtureId)} ({tier})");
 
                 try
                 {
@@ -244,29 +245,34 @@ public static class CorpusCommand
 
     private static void PrintFixtureTable(IReadOnlyList<FixtureMetadata> fixtures)
     {
-        const int colFixtureId = 36;
-        const int colTier      = 10;
-        const int colSize      = 8;
-        const int colLanguage  = 12;
-        const int colRules     = 30;
-
-        var header = $"{"FixtureId",-colFixtureId}  {"Tier",-colTier}  {"Size",-colSize}  {"Language",-colLanguage}  {"Rules",-colRules}  Tags";
-        var sep    = new string('-', header.Length + 4);
-
-        Console.WriteLine(sep);
-        Console.WriteLine(header);
-        Console.WriteLine(sep);
+        var table = new Table()
+            .BorderColor(Color.Grey)
+            .AddColumn("[bold]FixtureId[/]")
+            .AddColumn("[bold]Tier[/]")
+            .AddColumn("[bold]Size[/]")
+            .AddColumn("[bold]Language[/]")
+            .AddColumn("[bold]Rules[/]")
+            .AddColumn("[bold]Tags[/]");
 
         foreach (var m in fixtures)
         {
-            var rules = string.Join(",", m.RuleIds);
-            var tagsStr = string.Join(",", m.Tags);
-            Console.WriteLine(
-                $"{m.FixtureId,-colFixtureId}  {m.Tier,-colTier}  {m.PrSizeBucket,-colSize}  {m.Language,-colLanguage}  {rules,-colRules}  {tagsStr}");
+            var tierColor = m.Tier switch
+            {
+                FixtureTier.Gold      => "gold1",
+                FixtureTier.Silver    => "silver",
+                _                     => "blue",
+            };
+            table.AddRow(
+                Markup.Escape(m.FixtureId),
+                $"[{tierColor}]{m.Tier}[/]",
+                Markup.Escape(m.PrSizeBucket.ToString()),
+                Markup.Escape(m.Language),
+                Markup.Escape(string.Join(",", m.RuleIds)),
+                Markup.Escape(string.Join(",", m.Tags)));
         }
 
-        Console.WriteLine(sep);
-        Console.WriteLine($"[corpus] {fixtures.Count} fixture(s)");
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine($"[dim][[corpus]] {fixtures.Count} fixture(s)[/]");
     }
 
     // ── gauntletci corpus discover --provider gh-search|gh-archive ───────────
@@ -344,11 +350,11 @@ public static class CorpusCommand
                 MaxCandidates      = limit,
             };
 
-            Console.WriteLine($"[corpus] Discovering candidates via {provider.GetProviderName()} (limit={limit}) …");
+            AnsiConsole.MarkupLine($"[blue][[corpus]][/] Discovering candidates via {provider.GetProviderName()} (limit={limit}) …");
             if (startDate.HasValue)
             {
                 var endLabel = endDate.HasValue ? endDate.Value.ToString("yyyy-MM-dd") : startDate.Value.ToString("yyyy-MM-dd");
-                Console.WriteLine($"[corpus] Date range: {startDate.Value:yyyy-MM-dd} → {endLabel}");
+                AnsiConsole.MarkupLine($"[blue][[corpus]][/] Date range: {startDate.Value:yyyy-MM-dd} → {endLabel}");
             }
 
             var candidates = await provider.SearchCandidatesAsync(query, ct);
@@ -388,7 +394,7 @@ public static class CorpusCommand
                 }
 
                 var skipped = candidates.Count - inserted;
-                Console.WriteLine($"[corpus] Discovered {candidates.Count} candidates ({inserted} new, {skipped} already known)");
+                AnsiConsole.MarkupLine($"[blue][[corpus]][/] Discovered {candidates.Count} candidates ({inserted} new, {skipped} already known)");
             }
         });
 
@@ -436,7 +442,7 @@ public static class CorpusCommand
 
                 if (candidates.Count == 0)
                 {
-                    Console.WriteLine("[corpus] No pending candidates found.");
+                    AnsiConsole.MarkupLine("[dim][[corpus]] No pending candidates found.[/]");
                     return;
                 }
 
@@ -449,13 +455,13 @@ public static class CorpusCommand
 
                     if (dryRun)
                     {
-                        Console.WriteLine($"[corpus] [dry-run] Would hydrate {owner}/{repo}#{prNumber}");
+                        AnsiConsole.MarkupLine($"[dim][[corpus]] [[dry-run]][/] Would hydrate {owner}/{repo}#{prNumber}");
                         success++;
                         continue;
                     }
 
                     var fixtureId = GauntletCI.Corpus.Storage.FixtureIdHelper.Build(owner, repo, prNumber);
-                    Console.WriteLine($"[corpus] Hydrating {owner}/{repo}#{prNumber} → {fixtureId}");
+                    AnsiConsole.MarkupLine($"[blue][[corpus]][/] Hydrating {owner}/{repo}#{prNumber} → {Markup.Escape(fixtureId)}");
 
                     var tier = tierStr.ToLowerInvariant() switch
                     {
@@ -477,7 +483,7 @@ public static class CorpusCommand
                     }
                 }
 
-                Console.WriteLine($"[corpus] Batch complete: {success}/{total} fixtures hydrated");
+                AnsiConsole.MarkupLine($"[blue][[corpus]][/] Batch complete: [green]{success}[/]/{total} fixtures hydrated");
             }
         });
 
@@ -549,7 +555,7 @@ public static class CorpusCommand
                         return;
                     }
 
-                    Console.WriteLine($"[corpus] Running GCI rules against {fixtureId}");
+                    AnsiConsole.MarkupLine($"[blue][[corpus]][/] Running GCI rules against {Markup.Escape(fixtureId)}");
 
                     var diffText = await File.ReadAllTextAsync(diffPath, ct);
                     var runner   = new RuleCorpusRunner(store, db);
@@ -559,9 +565,9 @@ public static class CorpusCommand
                     int medium = findings.Count(f => f.ActualConfidence is >= 0.5 and < 1.0);
                     int low    = findings.Count(f => f.ActualConfidence < 0.5);
 
-                    Console.WriteLine($"[corpus] Run ID  : {runner.LastRunId}");
-                    Console.WriteLine($"[corpus] Findings: {findings.Count} ({high} High, {medium} Medium, {low} Low)");
-                    Console.WriteLine($"[corpus] Saved to: {fixturePath}");
+                    AnsiConsole.MarkupLine($"[dim][[corpus]][/] Run ID  : {runner.LastRunId}");
+                    AnsiConsole.MarkupLine($"[dim][[corpus]][/] Findings: {findings.Count} ({high} High, {medium} Medium, {low} Low)");
+                    AnsiConsole.MarkupLine($"[dim][[corpus]][/] Saved to: {Markup.Escape(fixturePath)}");
                 }
                 catch (Exception ex)
                 {
@@ -613,7 +619,7 @@ public static class CorpusCommand
 
                 if (allFixtures.Count == 0)
                 {
-                    Console.WriteLine("[corpus] No fixtures found.");
+                    AnsiConsole.MarkupLine("[dim][[corpus]] No fixtures found.[/]");
                     return;
                 }
 
@@ -628,7 +634,7 @@ public static class CorpusCommand
 
                     if (!File.Exists(diffPath))
                     {
-                        Console.WriteLine($"[corpus] SKIP {metadata.FixtureId} — diff.patch not found");
+                        AnsiConsole.MarkupLine($"[yellow][[corpus]] SKIP {Markup.Escape(metadata.FixtureId)}[/] — diff.patch not found");
                         failed++;
                         continue;
                     }
@@ -642,7 +648,7 @@ public static class CorpusCommand
                         totalFindings += findings.Count;
                         completed++;
 
-                        Console.WriteLine($"[corpus] OK  {metadata.FixtureId,-40} {findings.Count,3} finding(s)");
+                        AnsiConsole.MarkupLine($"[green][[corpus]] OK [/] {Markup.Escape(metadata.FixtureId),-40} {findings.Count,3} finding(s)");
                     }
                     catch (Exception ex)
                     {
@@ -651,8 +657,8 @@ public static class CorpusCommand
                     }
                 }
 
-                Console.WriteLine();
-                Console.WriteLine($"[corpus] Run-all complete: {completed} OK, {failed} skipped/failed, {totalFindings} total findings");
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"[blue][[corpus]][/] Run-all complete: [green]{completed} OK[/], {failed} skipped/failed, {totalFindings} total findings");
             }
         });
 
@@ -702,35 +708,34 @@ public static class CorpusCommand
 
                 if (scorecards.Count == 0)
                 {
-                    Console.WriteLine("[corpus] No scorecards — run 'corpus run-all' first to generate actual.json files.");
+                    AnsiConsole.MarkupLine("[yellow][[corpus]] No scorecards — run 'corpus run-all' first to generate actual.json files.[/]");
                     return;
                 }
 
-                const int colRule      = 10;
-                const int colTier      = 10;
-                const int colFixtures  = 9;
-                const int colTrigger   = 12;
-                const int colPrecision = 10;
-                const int colRecall    = 8;
-                const int colUseful    = 11;
-
-                var header = $"{"RuleId",-colRule}  {"Tier",-colTier}  {"Fixtures",-colFixtures}  {"TriggerRate",-colTrigger}  {"Precision",-colPrecision}  {"Recall",-colRecall}  {"Usefulness"}";
-                var sep    = new string('-', header.Length + 4);
-
-                Console.WriteLine(sep);
-                Console.WriteLine(header);
-                Console.WriteLine(sep);
+                var table = new Table()
+                    .BorderColor(Color.Grey)
+                    .AddColumn("[bold]RuleId[/]")
+                    .AddColumn("[bold]Tier[/]")
+                    .AddColumn(new TableColumn("[bold]Fixtures[/]").RightAligned())
+                    .AddColumn(new TableColumn("[bold]TriggerRate[/]").RightAligned())
+                    .AddColumn(new TableColumn("[bold]Precision[/]").RightAligned())
+                    .AddColumn(new TableColumn("[bold]Recall[/]").RightAligned())
+                    .AddColumn(new TableColumn("[bold]Usefulness[/]").RightAligned());
 
                 foreach (var sc in scorecards.OrderBy(s => s.RuleId).ThenBy(s => s.Tier))
                 {
-                    Console.WriteLine(
-                        $"{sc.RuleId,-colRule}  {sc.Tier,-colTier}  {sc.Fixtures,-colFixtures}  " +
-                        $"{sc.TriggerRate,colTrigger:P1}  {sc.Precision,colPrecision:P1}  " +
-                        $"{sc.Recall,colRecall:P1}  {sc.AvgUsefulness:F1}/5");
+                    table.AddRow(
+                        sc.RuleId,
+                        sc.Tier.ToString(),
+                        sc.Fixtures.ToString(),
+                        sc.TriggerRate.ToString("P1"),
+                        sc.Precision.ToString("P1"),
+                        sc.Recall.ToString("P1"),
+                        $"{sc.AvgUsefulness:F1}/5");
                 }
 
-                Console.WriteLine(sep);
-                Console.WriteLine($"[corpus] {scorecards.Count} scorecard(s)");
+                AnsiConsole.Write(table);
+                AnsiConsole.MarkupLine($"[dim][[corpus]] {scorecards.Count} scorecard(s)[/]");
             }
         });
 
@@ -768,7 +773,7 @@ public static class CorpusCommand
                 if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
 
                 await File.WriteAllTextAsync(outputPath, markdown, ct);
-                Console.WriteLine($"[corpus] Report written to {outputPath}");
+                AnsiConsole.MarkupLine($"[green][[corpus]][/] Report written to {Markup.Escape(outputPath)}");
             }
         });
 
@@ -826,7 +831,7 @@ public static class CorpusCommand
                     var inferred = await engine.InferLabelsAsync(fixtureId, diffText, ct);
                     await engine.ApplyToFixtureAsync(fixtureId, diffText, overwrite, ct);
 
-                    Console.WriteLine($"[corpus] Labeled {fixtureId}: {inferred.Count} heuristic label(s) applied");
+                    AnsiConsole.MarkupLine($"[green][[corpus]][/] Labeled {Markup.Escape(fixtureId)}: {inferred.Count} heuristic label(s) applied");
                 }
                 catch (Exception ex)
                 {
@@ -876,7 +881,7 @@ public static class CorpusCommand
 
                 if (allFixtures.Count == 0)
                 {
-                    Console.WriteLine("[corpus] No fixtures found.");
+                    AnsiConsole.MarkupLine("[dim][[corpus]] No fixtures found.[/]");
                     return;
                 }
 
@@ -892,7 +897,7 @@ public static class CorpusCommand
 
                     if (!File.Exists(diffPath))
                     {
-                        Console.WriteLine($"[corpus] SKIP {metadata.FixtureId,-40} — diff.patch not found");
+                        AnsiConsole.MarkupLine($"[yellow][[corpus]] SKIP {Markup.Escape(metadata.FixtureId)}[/] — diff.patch not found");
                         skipped++;
                         continue;
                     }
@@ -906,7 +911,7 @@ public static class CorpusCommand
                         totalLabels += inferred.Count;
                         labeled++;
 
-                        Console.WriteLine($"[corpus] OK   {metadata.FixtureId,-40} {inferred.Count,3} label(s)");
+                        AnsiConsole.MarkupLine($"[green][[corpus]] OK [/] {Markup.Escape(metadata.FixtureId),-40} {inferred.Count,3} label(s)");
                     }
                     catch (Exception ex)
                     {
@@ -915,8 +920,8 @@ public static class CorpusCommand
                     }
                 }
 
-                Console.WriteLine();
-                Console.WriteLine($"[corpus] label-all complete: {labeled} labeled, {skipped} skipped, {totalLabels} total labels applied");
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"[blue][[corpus]][/] label-all complete: [green]{labeled} labeled[/], {skipped} skipped, {totalLabels} total labels applied");
             }
         });
 
@@ -937,11 +942,11 @@ public static class CorpusCommand
 
     private static void PrintMetadata(GauntletCI.Corpus.Models.FixtureMetadata m)
     {
-        Console.WriteLine($"[corpus] Fixture : {m.FixtureId}");
-        Console.WriteLine($"[corpus] Tier    : {m.Tier}");
-        Console.WriteLine($"[corpus] Size    : {m.PrSizeBucket} ({m.FilesChanged} files)");
-        Console.WriteLine($"[corpus] Language: {m.Language}");
-        Console.WriteLine($"[corpus] Tags    : {string.Join(", ", m.Tags)}");
-        Console.WriteLine($"[corpus] Next    : gauntletci corpus normalize --fixture {m.FixtureId}");
+        AnsiConsole.MarkupLine($"[dim][[corpus]][/] Fixture : {Markup.Escape(m.FixtureId)}");
+        AnsiConsole.MarkupLine($"[dim][[corpus]][/] Tier    : {m.Tier}");
+        AnsiConsole.MarkupLine($"[dim][[corpus]][/] Size    : {m.PrSizeBucket} ({m.FilesChanged} files)");
+        AnsiConsole.MarkupLine($"[dim][[corpus]][/] Language: {Markup.Escape(m.Language)}");
+        AnsiConsole.MarkupLine($"[dim][[corpus]][/] Tags    : {Markup.Escape(string.Join(", ", m.Tags))}");
+        AnsiConsole.MarkupLine($"[dim][[corpus]][/] Next    : gauntletci corpus normalize --fixture {Markup.Escape(m.FixtureId)}");
     }
 }

--- a/src/GauntletCI.Cli/Commands/FeedbackCommand.cs
+++ b/src/GauntletCI.Cli/Commands/FeedbackCommand.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.CommandLine;
 using GauntletCI.Cli.Telemetry;
+using Spectre.Console;
 
 namespace GauntletCI.Cli.Commands;
 
@@ -33,15 +34,15 @@ public static class FeedbackCommand
 
             if (!TelemetryConsent.HasDecided)
             {
-                Console.WriteLine("  Telemetry is not enabled. Run 'gauntletci telemetry --enable' to opt in.");
+                AnsiConsole.MarkupLine("[yellow]  Telemetry is not enabled. Run 'gauntletci telemetry --enable' to opt in.[/]");
                 ctx.ExitCode = 0;
                 return;
             }
 
             if (!TelemetryConsent.IsOptedIn)
             {
-                Console.WriteLine("  Feedback requires telemetry to be enabled.");
-                Console.WriteLine("  Run 'gauntletci telemetry --enable' to opt in.");
+                AnsiConsole.MarkupLine("[yellow]  Feedback requires telemetry to be enabled.[/]");
+                AnsiConsole.MarkupLine("[yellow]  Run 'gauntletci telemetry --enable' to opt in.[/]");
                 ctx.ExitCode = 0;
                 return;
             }
@@ -56,7 +57,7 @@ public static class FeedbackCommand
             TelemetryUploader.UploadInBackground();
 
             var emoji = vote == "up" ? "👍" : "👎";
-            Console.WriteLine($"  {emoji}  Feedback recorded — thank you!");
+            AnsiConsole.MarkupLine($"[green]  {emoji}  Feedback recorded — thank you![/]");
             ctx.ExitCode = 0;
         });
 

--- a/src/GauntletCI.Cli/Commands/IgnoreCommand.cs
+++ b/src/GauntletCI.Cli/Commands/IgnoreCommand.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.CommandLine;
 using GauntletCI.Core.Configuration;
+using Spectre.Console;
 
 namespace GauntletCI.Cli.Commands;
 
@@ -33,7 +34,7 @@ public static class IgnoreCommand
             IgnoreList.Append(repo.FullName, normalizedId, path);
 
             var entry = path is not null ? $"{normalizedId}:{path}" : normalizedId;
-            Console.WriteLine($"[GauntletCI] Added '{entry}' to .gauntletci-ignore");
+            AnsiConsole.MarkupLine($"[green][[GauntletCI]] Added '{Markup.Escape(entry)}' to .gauntletci-ignore[/]");
             return Task.CompletedTask;
         }, ruleIdArg, pathOption, repoOption);
 

--- a/src/GauntletCI.Cli/Commands/InitCommand.cs
+++ b/src/GauntletCI.Cli/Commands/InitCommand.cs
@@ -3,6 +3,7 @@ using System.CommandLine;
 using System.Text.Json;
 using GauntletCI.Cli.Resources;
 using GauntletCI.Cli.Telemetry;
+using Spectre.Console;
 
 namespace GauntletCI.Cli.Commands;
 
@@ -56,7 +57,7 @@ public static class InitCommand
         var configPath = Path.Combine(dir.FullName, ".gauntletci.json");
         if (File.Exists(configPath))
         {
-            Console.WriteLine($"Config already exists at {configPath}");
+            AnsiConsole.MarkupLine($"[yellow]Config already exists at {Markup.Escape(configPath)}[/]");
             return;
         }
 
@@ -68,7 +69,7 @@ public static class InitCommand
 
         var json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
         File.WriteAllText(configPath, json);
-        Console.WriteLine($"Created {configPath}");
+        AnsiConsole.MarkupLine($"[green]Created {Markup.Escape(configPath)}[/]");
     }
 
     private static void InstallHooks(string gitRoot, bool force)
@@ -84,7 +85,7 @@ public static class InitCommand
     {
         if (File.Exists(targetPath) && !force)
         {
-            Console.WriteLine($"Hook already exists at {targetPath}. Use --force to overwrite.");
+            AnsiConsole.MarkupLine($"[yellow]Hook already exists at {Markup.Escape(targetPath)}. Use --force to overwrite.[/]");
             return;
         }
 
@@ -100,7 +101,7 @@ public static class InitCommand
                 UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
         }
 
-        Console.WriteLine($"Installed hook: {targetPath}");
+        AnsiConsole.MarkupLine($"[green]Installed hook: {Markup.Escape(targetPath)}[/]");
     }
 
     private static string? FindGitRoot(string startDirectory)

--- a/src/GauntletCI.Cli/Commands/ModelCommand.cs
+++ b/src/GauntletCI.Cli/Commands/ModelCommand.cs
@@ -62,12 +62,12 @@ public static class ModelCommand
             var downloader = new ModelDownloader(DefaultModelDir);
             if (downloader.IsModelCached())
             {
-                AnsiConsole.MarkupLine($"[green]  ✓ Model cached at {DefaultModelDir}[/]");
+                AnsiConsole.MarkupLine($"[green]  ✓ Model cached at {Markup.Escape(DefaultModelDir)}[/]");
                 AnsiConsole.MarkupLine("[green]  Run 'gauntletci analyze --with-llm' to enable enrichment.[/]");
             }
             else
             {
-                AnsiConsole.MarkupLine($"[yellow]  ✗ Model not found at {DefaultModelDir}[/]");
+                AnsiConsole.MarkupLine($"[yellow]  ✗ Model not found at {Markup.Escape(DefaultModelDir)}[/]");
                 AnsiConsole.MarkupLine("[yellow]  Run 'gauntletci model download' to download it (~2 GB).[/]");
             }
         });

--- a/src/GauntletCI.Cli/Commands/ModelCommand.cs
+++ b/src/GauntletCI.Cli/Commands/ModelCommand.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.CommandLine;
 using GauntletCI.Llm;
+using Spectre.Console;
 
 namespace GauntletCI.Cli.Commands;
 
@@ -34,15 +35,13 @@ public static class ModelCommand
         {
             var dir = ctx.ParseResult.GetValueForOption(dirOption)!;
             var downloader = new ModelDownloader(dir);
-            var progress = new Progress<string>(msg => Console.WriteLine(msg));
+            var progress = new Progress<string>(msg => AnsiConsole.MarkupLine($"[dim]{Markup.Escape(msg)}[/]"));
 
             try
             {
                 await downloader.EnsureModelAsync(progress);
-                Console.WriteLine();
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine("  Model ready. Use 'gauntletci analyze --with-llm' to enable enrichment.");
-                Console.ResetColor();
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine("[green]  ✓ Model ready. Use 'gauntletci analyze --with-llm' to enable enrichment.[/]");
             }
             catch (Exception ex)
             {
@@ -63,17 +62,14 @@ public static class ModelCommand
             var downloader = new ModelDownloader(DefaultModelDir);
             if (downloader.IsModelCached())
             {
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine($"  ✓ Model cached at {DefaultModelDir}");
-                Console.WriteLine("  Run 'gauntletci analyze --with-llm' to enable enrichment.");
+                AnsiConsole.MarkupLine($"[green]  ✓ Model cached at {DefaultModelDir}[/]");
+                AnsiConsole.MarkupLine("[green]  Run 'gauntletci analyze --with-llm' to enable enrichment.[/]");
             }
             else
             {
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.WriteLine($"  ✗ Model not found at {DefaultModelDir}");
-                Console.WriteLine("  Run 'gauntletci model download' to download it (~2 GB).");
+                AnsiConsole.MarkupLine($"[yellow]  ✗ Model not found at {DefaultModelDir}[/]");
+                AnsiConsole.MarkupLine("[yellow]  Run 'gauntletci model download' to download it (~2 GB).[/]");
             }
-            Console.ResetColor();
         });
 
         return cmd;

--- a/src/GauntletCI.Cli/Commands/PostmortemCommand.cs
+++ b/src/GauntletCI.Cli/Commands/PostmortemCommand.cs
@@ -58,7 +58,7 @@ public static class PostmortemCommand
                 else
                 {
                     var shortSha = commit.Length >= 8 ? commit[..8] : commit;
-                    AnsiConsole.MarkupLine($"[dim]  ⏪  Postmortem — commit {shortSha}[/]");
+                    AnsiConsole.MarkupLine($"[dim]  ⏪  Postmortem — commit {Markup.Escape(shortSha)}[/]");
                     AnsiConsole.MarkupLine("[dim]     These findings would have been caught at pre-commit time.[/]");
                     AnsiConsole.WriteLine();
                     ConsoleReporter.Report(result, ascii);

--- a/src/GauntletCI.Cli/Commands/PostmortemCommand.cs
+++ b/src/GauntletCI.Cli/Commands/PostmortemCommand.cs
@@ -6,6 +6,7 @@ using GauntletCI.Cli.Presentation;
 using GauntletCI.Core.Configuration;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Rules;
+using Spectre.Console;
 
 namespace GauntletCI.Cli.Commands;
 
@@ -57,11 +58,9 @@ public static class PostmortemCommand
                 else
                 {
                     var shortSha = commit.Length >= 8 ? commit[..8] : commit;
-                    Console.ForegroundColor = ConsoleColor.DarkGray;
-                    Console.WriteLine($"  ⏪  Postmortem — commit {shortSha}");
-                    Console.WriteLine("     These findings would have been caught at pre-commit time.");
-                    Console.WriteLine();
-                    Console.ResetColor();
+                    AnsiConsole.MarkupLine($"[dim]  ⏪  Postmortem — commit {shortSha}[/]");
+                    AnsiConsole.MarkupLine("[dim]     These findings would have been caught at pre-commit time.[/]");
+                    AnsiConsole.WriteLine();
                     ConsoleReporter.Report(result, ascii);
                 }
 

--- a/src/GauntletCI.Cli/Commands/TelemetryCommand.cs
+++ b/src/GauntletCI.Cli/Commands/TelemetryCommand.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.CommandLine;
 using GauntletCI.Cli.Telemetry;
+using Spectre.Console;
 
 namespace GauntletCI.Cli.Commands;
 
@@ -34,14 +35,14 @@ public static class TelemetryCommand
             if (enable)
             {
                 TelemetryConsent.SetMode(TelemetryMode.Shared);
-                Console.WriteLine("  ✓ Telemetry mode set to shared.");
+                AnsiConsole.MarkupLine("[green]  ✓ Telemetry mode set to shared.[/]");
                 return;
             }
 
             if (disable)
             {
                 TelemetryConsent.SetMode(TelemetryMode.Off);
-                Console.WriteLine("  ✓ Telemetry mode set to off.");
+                AnsiConsole.MarkupLine("[green]  ✓ Telemetry mode set to off.[/]");
                 return;
             }
 
@@ -63,23 +64,23 @@ public static class TelemetryCommand
                 }
 
                 TelemetryConsent.SetMode(parsed.Value);
-                Console.WriteLine($"  ✓ Telemetry mode set to {mode.Trim().ToLowerInvariant()}.");
+                AnsiConsole.MarkupLine($"[green]  ✓ Telemetry mode set to {Markup.Escape(mode.Trim().ToLowerInvariant())}.[/]");
                 return;
             }
 
             var currentMode = TelemetryConsent.GetMode();
             var installId = TelemetryConsent.InstallId;
 
-            Console.WriteLine();
-            Console.WriteLine($"  Install ID : {installId}");
-            Console.WriteLine($"  Mode       : {currentMode.ToString().ToLowerInvariant()}");
-            Console.WriteLine();
-            Console.WriteLine("  shared = local store + anonymous aggregate upload");
-            Console.WriteLine("  local  = local store only, no network calls");
-            Console.WriteLine("  off    = telemetry disabled");
-            Console.WriteLine();
-            Console.WriteLine("  To change: gauntletci telemetry --mode shared|local|off");
-            Console.WriteLine();
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine($"[dim]  Install ID :[/] {Markup.Escape(installId)}");
+            AnsiConsole.MarkupLine($"[dim]  Mode       :[/] {currentMode.ToString().ToLowerInvariant()}");
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("  shared = local store + anonymous aggregate upload");
+            AnsiConsole.MarkupLine("  local  = local store only, no network calls");
+            AnsiConsole.MarkupLine("  off    = telemetry disabled");
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("  To change: gauntletci telemetry --mode shared|local|off");
+            AnsiConsole.WriteLine();
             ctx.ExitCode = 0;
         });
 

--- a/src/GauntletCI.Cli/GauntletCI.Cli.csproj
+++ b/src/GauntletCI.Cli/GauntletCI.Cli.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/src/GauntletCI.Cli/Output/ConsoleReporter.cs
+++ b/src/GauntletCI.Cli/Output/ConsoleReporter.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 using GauntletCI.Core.Model;
 using GauntletCI.Core.Rules;
+using Spectre.Console;
 
 namespace GauntletCI.Cli.Output;
 
@@ -28,38 +29,32 @@ public static class ConsoleReporter
 
     public static void Report(EvaluationResult result, bool ascii = false)
     {
-        var originalColor = Console.ForegroundColor;
-
         string hr  = ascii ? "=======================================================" : "═══════════════════════════════════════════════════════";
         string sep = ascii ? "-- {0} CONFIDENCE ({1}) --------------------------" : "── {0} CONFIDENCE ({1}) ──────────────────────────";
         string ok  = ascii ? "  OK No findings -- diff looks clean!" : "  ✓ No findings — diff looks clean!";
 
-        Console.ForegroundColor = ConsoleColor.Cyan;
-        Console.WriteLine(hr);
-        Console.WriteLine("  GauntletCI Risk Analysis Report");
-        Console.WriteLine(hr);
-        Console.ResetColor();
+        AnsiConsole.MarkupLine($"[cyan]{hr}[/]");
+        AnsiConsole.MarkupLine("[cyan]  GauntletCI Risk Analysis Report[/]");
+        AnsiConsole.MarkupLine($"[cyan]{hr}[/]");
 
         if (!string.IsNullOrEmpty(result.CommitSha))
-            Console.WriteLine($"  Commit : {result.CommitSha}");
+            AnsiConsole.MarkupLine($"  Commit : {result.CommitSha}");
 
-        Console.WriteLine($"  Rules  : {result.RulesEvaluated} evaluated");
-        Console.WriteLine($"  Findings: {result.Findings.Count}");
-        Console.WriteLine();
+        AnsiConsole.MarkupLine($"  Rules  : {result.RulesEvaluated} evaluated");
+        AnsiConsole.MarkupLine($"  Findings: {result.Findings.Count}");
+        AnsiConsole.WriteLine();
 
         if (!result.HasFindings)
         {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine(ok);
-            Console.ResetColor();
+            AnsiConsole.MarkupLine($"[green]{ok}[/]");
             return;
         }
 
         var groups = new[]
         {
-            (Confidence.High,   "HIGH",   ConsoleColor.Red),
-            (Confidence.Medium, "MEDIUM", ConsoleColor.Yellow),
-            (Confidence.Low,    "LOW",    ConsoleColor.DarkYellow),
+            (Confidence.High,   "HIGH",   "red"),
+            (Confidence.Medium, "MEDIUM", "yellow"),
+            (Confidence.Low,    "LOW",    "darkorange"),
         };
 
         foreach (var (confidence, label, color) in groups)
@@ -67,44 +62,29 @@ public static class ConsoleReporter
             var findings = result.Findings.Where(f => f.Confidence == confidence).ToList();
             if (findings.Count == 0) continue;
 
-            Console.ForegroundColor = color;
-            Console.WriteLine(string.Format(sep, label, findings.Count));
-            Console.ResetColor();
+            AnsiConsole.MarkupLine($"[{color}]{string.Format(sep, label, findings.Count)}[/]");
 
             foreach (var finding in findings)
                 PrintFinding(finding, color);
         }
-
-        Console.ForegroundColor = originalColor;
     }
 
-    private static void PrintFinding(Finding finding, ConsoleColor accentColor)
+    private static void PrintFinding(Finding finding, string accentColor)
     {
-        Console.ForegroundColor = accentColor;
-        Console.Write($"  [{finding.RuleId}] ");
-        Console.ForegroundColor = ConsoleColor.White;
-        Console.WriteLine(finding.RuleName);
-        Console.ResetColor();
+        AnsiConsole.MarkupLine($"[{accentColor}]  [[{finding.RuleId}]][/] [white]{finding.RuleName}[/]");
+        AnsiConsole.MarkupLine($"  Summary  : {finding.Summary}");
 
-        Console.WriteLine($"  Summary  : {finding.Summary}");
-        Console.ForegroundColor = ConsoleColor.DarkGray;
         var evidenceDisplay = SensitiveRuleIds.Contains(finding.RuleId)
             ? MaskEvidenceSnippet(finding.Evidence)
             : finding.Evidence;
-        Console.WriteLine($"  Evidence : {evidenceDisplay}");
-        Console.ResetColor();
-        Console.WriteLine($"  Why      : {finding.WhyItMatters}");
-        Console.ForegroundColor = ConsoleColor.Cyan;
-        Console.WriteLine($"  Action   : {finding.SuggestedAction}");
-        Console.ResetColor();
+        AnsiConsole.MarkupLine($"[grey]  Evidence : {Markup.Escape(evidenceDisplay)}[/]");
+
+        AnsiConsole.MarkupLine($"  Why      : {Markup.Escape(finding.WhyItMatters)}");
+        AnsiConsole.MarkupLine($"[cyan]  Action   : {Markup.Escape(finding.SuggestedAction)}[/]");
 
         if (!string.IsNullOrEmpty(finding.LlmExplanation))
-        {
-            Console.ForegroundColor = ConsoleColor.Magenta;
-            Console.WriteLine($"  LLM      : {finding.LlmExplanation}");
-            Console.ResetColor();
-        }
+            AnsiConsole.MarkupLine($"[magenta]  LLM      : {Markup.Escape(finding.LlmExplanation)}[/]");
 
-        Console.WriteLine();
+        AnsiConsole.WriteLine();
     }
 }

--- a/src/GauntletCI.Cli/Output/ConsoleReporter.cs
+++ b/src/GauntletCI.Cli/Output/ConsoleReporter.cs
@@ -71,8 +71,8 @@ public static class ConsoleReporter
 
     private static void PrintFinding(Finding finding, string accentColor)
     {
-        AnsiConsole.MarkupLine($"[{accentColor}]  [[{finding.RuleId}]][/] [white]{finding.RuleName}[/]");
-        AnsiConsole.MarkupLine($"  Summary  : {finding.Summary}");
+        AnsiConsole.MarkupLine($"[{accentColor}]  [[{finding.RuleId}]][/] [white]{Markup.Escape(finding.RuleName)}[/]");
+        AnsiConsole.MarkupLine($"  Summary  : {Markup.Escape(finding.Summary)}");
 
         var evidenceDisplay = SensitiveRuleIds.Contains(finding.RuleId)
             ? MaskEvidenceSnippet(finding.Evidence)

--- a/src/GauntletCI.Cli/Presentation/CliBanner.cs
+++ b/src/GauntletCI.Cli/Presentation/CliBanner.cs
@@ -20,7 +20,7 @@ public static class CliBanner
             ?.InformationalVersion?.Split('+')[0] ?? "0.0.0";
 
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine($"  [bold gold1]GauntletCI[/]  [dim]v{version}[/]");
+        AnsiConsole.MarkupLine($"  [bold gold1]GauntletCI[/]  [dim]v{Markup.Escape(version)}[/]");
         AnsiConsole.MarkupLine("  [dim]pre-commit change-risk detection[/]");
         AnsiConsole.WriteLine();
     }

--- a/src/GauntletCI.Cli/Presentation/CliBanner.cs
+++ b/src/GauntletCI.Cli/Presentation/CliBanner.cs
@@ -1,15 +1,11 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.Reflection;
+using Spectre.Console;
 
 namespace GauntletCI.Cli.Presentation;
 
 public static class CliBanner
 {
-    private const string Bold       = "\u001b[1m";
-    private const string Amber      = "\u001b[38;5;214m";
-    private const string Dim        = "\u001b[2m";
-    private const string Reset      = "\u001b[0m";
-
     public static void PrintIfEnabled(BannerContext context)
     {
         if (context is null) throw new ArgumentNullException(nameof(context));
@@ -23,10 +19,10 @@ public static class CliBanner
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion?.Split('+')[0] ?? "0.0.0";
 
-        Console.WriteLine();
-        Console.WriteLine($"  {Bold}{Amber}GauntletCI{Reset}  {Dim}v{version}{Reset}");
-        Console.WriteLine($"  {Dim}pre-commit change-risk detection{Reset}");
-        Console.WriteLine();
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"  [bold gold1]GauntletCI[/]  [dim]v{version}[/]");
+        AnsiConsole.MarkupLine("  [dim]pre-commit change-risk detection[/]");
+        AnsiConsole.WriteLine();
     }
 
     private static bool IsCiEnvironment()


### PR DESCRIPTION
## Summary
Replaces raw \Console.ForegroundColor\/\Console.Write\ calls with [Spectre.Console](https://spectreconsole.net/) across \GauntletCI.Cli\.

## Changes
- **Banner** — ANSI escape code constants removed; now uses \gold1\/\dim\ markup via \AnsiConsole.MarkupLine\
- **ConsoleReporter** — findings report uses colored markup with \Markup.Escape\ on user data to prevent injection
- **CorpusCommand** — \corpus list\ and \corpus score\ output rendered as Spectre \Table\; all \[corpus]\ status messages use colored markup
- **ModelCommand** — download progress and model status use markup colors
- **TelemetryCommand, InitCommand, IgnoreCommand, FeedbackCommand, PostmortemCommand** — all status/confirmation messages use \AnsiConsole.MarkupLine\ with green/yellow/dim

## Preserved Behavior
- \Console.Error.WriteLine\ kept on all error paths (stderr compatibility for scripts)
- JSON output paths unchanged (pipe/redirect compatibility)
- Banner suppression logic (CI env vars, \--no-banner\, redirect detection) unchanged

## Tests
332/332 passing. Output format only — no logic changes.