### PR TITLE
[INFRA] Fix non-C# fixtures leaking into label queue

### DIFF
--- a/src/GauntletCI.Corpus/Discovery/GhArchiveDiscoveryProvider.cs
+++ b/src/GauntletCI.Corpus/Discovery/GhArchiveDiscoveryProvider.cs
@@ -148,7 +148,6 @@ public sealed class GhArchiveDiscoveryProvider : IDiscoveryProvider
         }
 
         if (query.Languages.Count > 0 &&
-            !string.IsNullOrEmpty(language) &&
             !query.Languages.Any(l => string.Equals(l, language, StringComparison.OrdinalIgnoreCase)))
             return null;
 

--- a/src/GauntletCI.Corpus/GauntletCI_Labeler_App/seed_queue.py
+++ b/src/GauntletCI.Corpus/GauntletCI_Labeler_App/seed_queue.py
@@ -15,6 +15,7 @@ def main() -> None:
     parser.add_argument("--limit", type=int, default=150, help="Total fired items to queue.")
     parser.add_argument("--include-nonfired", type=int, default=30, help="How many non-fired tasks to synthesize.")
     parser.add_argument("--rules", default="", help="Comma-separated rule ids to target.")
+    parser.add_argument("--language", default="C#", help="Only queue fixtures whose primary language matches (default: C#). Pass empty string to disable filter.")
     args = parser.parse_args()
 
     base_dir = Path(__file__).resolve().parent
@@ -23,11 +24,19 @@ def main() -> None:
     init_app_tables(conn)
 
     target_rules = [x.strip() for x in args.rules.split(",") if x.strip()]
-    where = ""
+    lang_filter = args.language.strip()
+
+    # Build WHERE clause for fired query
+    conditions: list[str] = []
     params: list[object] = []
     if target_rules:
-        where = f"WHERE af.rule_id IN ({','.join(['?'] * len(target_rules))})"
+        conditions.append(f"af.rule_id IN ({','.join(['?'] * len(target_rules))})")
         params.extend(target_rules)
+    if lang_filter:
+        conditions.append("f.language = ?")
+        params.append(lang_filter)
+    conditions.append("af.did_trigger = 1")
+    where = "WHERE " + " AND ".join(conditions)
 
     fired_sql = f"""
     WITH grouped AS (
@@ -41,7 +50,6 @@ def main() -> None:
         FROM actual_findings af
         JOIN fixtures f ON f.fixture_id = af.fixture_id
         {where}
-        AND af.did_trigger = 1
         GROUP BY af.fixture_id, af.rule_id
     )
     SELECT *
@@ -51,12 +59,8 @@ def main() -> None:
     """
 
     sql_params = params.copy()
-    if where:
-        sql = fired_sql
-    else:
-        sql = fired_sql.replace("\n        WHERE af.rule_id IN ()\n        AND af.did_trigger = 1", "\n        WHERE af.did_trigger = 1")
     sql_params.append(args.limit)
-    fired_rows = conn.execute(sql, tuple(sql_params)).fetchall()
+    fired_rows = conn.execute(fired_sql, tuple(sql_params)).fetchall()
 
     for row in fired_rows:
         bucket = "fired_high_signal" if row["finding_count"] >= 3 else "fired"
@@ -76,9 +80,14 @@ def main() -> None:
         else:
             rules = [r[0] for r in conn.execute("SELECT DISTINCT rule_id FROM actual_findings ORDER BY rule_id").fetchall()]
         per_rule = max(1, math.ceil(nonfired_limit / max(len(rules), 1)))
+
+        # Build language filter clause for nonfired probes
+        nonfired_lang_clause = "AND f.language = ?" if lang_filter else ""
+        nonfired_lang_params: list[object] = [lang_filter] if lang_filter else []
+
         for rule_id in rules:
             rows = conn.execute(
-                """
+                f"""
                 SELECT f.fixture_id
                 FROM fixtures f
                 WHERE NOT EXISTS (
@@ -86,10 +95,11 @@ def main() -> None:
                     FROM actual_findings af
                     WHERE af.fixture_id = f.fixture_id AND af.rule_id = ? AND af.did_trigger = 1
                 )
+                {nonfired_lang_clause}
                 ORDER BY f.has_review_comments DESC, f.has_tests_changed ASC, f.created_at_utc DESC
                 LIMIT ?
                 """,
-                (rule_id, per_rule),
+                (rule_id, *nonfired_lang_params, per_rule),
             ).fetchall()
             for row in rows:
                 conn.execute(


### PR DESCRIPTION
## Problem

After re-running the labeler script, non-C# files were appearing in the labeling UI. 142 of 360 queued fixtures were from non-C# repos (Python, Rust, Java, TypeScript, and unknown-language repos).

## Root Causes

**1. \seed_queue.py\ — no language filter (primary)**
The nonfired probe query selected from ALL fixtures regardless of language. Since GauntletCI only evaluates \.cs\ files, non-C# fixtures never produce findings — making them appear as perfect nonfired probes.

**2. \GhArchiveDiscoveryProvider\ — language filter bypass (secondary)**
The language filter had a guard \!string.IsNullOrEmpty(language)\ that allowed repos with unknown/empty language metadata to pass through even when \-Language C#\ was specified.

## Fixes

- \seed_queue.py\: Added \--language\ arg (default: \C#\) applied to both fired and nonfired probe queries
- \GhArchiveDiscoveryProvider\: Removed the empty-language bypass — unknown-language repos are now excluded when a filter is set

## Verification

Reset \label_queue\ and re-ran \seed_queue.py\:
- Before: 360 items (218 C# + 142 non-C#)
- After: 182 items (182 C# only, 0 non-C#)