### PR TITLE
[DOCS] Architecture overview, CLI reference, README overhaul, corpus pipeline guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ artifacts/
 !docs/change-risk-thesis.md
 !docs/change-risk-research.md
 !docs/rules.md
+!docs/architecture.md
 !.github/CONTRIBUTING.md
 !.github/CODE_OF_CONDUCT.md
 !.github/SECURITY.md

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ artifacts/
 !docs/rules.md
 !docs/architecture.md
 !docs/cli-reference.md
+!docs/corpus-pipeline.md
 !.github/CONTRIBUTING.md
 !.github/CODE_OF_CONDUCT.md
 !.github/SECURITY.md

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ artifacts/
 !docs/change-risk-thesis.md
 !docs/change-risk-research.md
 !docs/rules.md
+!docs/cli-reference.md
 !.github/CONTRIBUTING.md
 !.github/CODE_OF_CONDUCT.md
 !.github/SECURITY.md

--- a/README.md
+++ b/README.md
@@ -63,6 +63,45 @@ GauntletCI complements your existing tools — it does not replace them.
 
 ---
 
+## Installation
+
+```bash
+dotnet tool install -g GauntletCI
+```
+
+> **Coming soon:**
+> - `winget install EricCogen.GauntletCI`
+> - `brew install gauntletci`
+
+---
+
+## Quick start
+
+```bash
+# Analyze staged changes before committing
+gauntletci analyze --staged
+
+# Analyze a specific commit
+gauntletci analyze --commit <sha>
+
+# Analyze a saved diff file
+gauntletci analyze --diff changes.diff
+
+# Output JSON (for tooling/automation)
+gauntletci analyze --staged --output json
+
+# Emit GitHub Actions inline PR annotations
+gauntletci analyze --staged --github-annotations
+
+# Enable LLM enrichment of High-confidence findings
+gauntletci analyze --staged --with-llm
+
+# ASCII-only output (for terminals without Unicode support)
+gauntletci analyze --staged --ascii
+```
+
+---
+
 ## Rule catalog (36 rules, GCI0001–GCI0037)
 
 | ID | Name | What it detects |
@@ -190,3 +229,58 @@ GauntletCI complements your existing tools — it does not replace them.
    Summary  : Critical-path file src/Payments/PaymentProcessor.cs has logging but no correlation/request ID.
    Action   : Include CorrelationId or TraceId in log statements for end-to-end traceability.
 ```
+
+---
+
+## Optional: LLM enrichment
+
+GauntletCI can enrich High-confidence findings with natural-language explanations using a local Phi-3 Mini ONNX model — no API key, no data sent externally.
+
+```bash
+# Download the model (~2GB)
+gauntletci model download
+
+# Run with LLM enrichment
+gauntletci analyze --staged --with-llm
+```
+
+---
+
+## CI/CD integration
+
+### GitHub Actions
+
+```yaml
+- name: GauntletCI risk analysis
+  run: gauntletci analyze --staged --github-annotations
+```
+
+Findings appear as inline annotations on the pull request diff.
+
+### Pre-commit hook
+
+```bash
+gauntletci init
+```
+
+Installs a pre-commit hook that runs `gauntletci analyze --staged` before every commit.
+
+---
+
+## Telemetry
+
+GauntletCI collects anonymous usage data to improve rule quality. No code, no file paths, no PII is ever collected.
+
+```bash
+gauntletci telemetry status    # view current mode
+gauntletci telemetry opt-in    # enable shared telemetry
+gauntletci telemetry opt-out   # disable all telemetry
+```
+
+---
+
+## Documentation
+
+- [CLI Reference](docs/cli-reference.md)
+- [Architecture](docs/architecture.md)
+- [Corpus Pipeline](docs/corpus-pipeline.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,244 @@
+# GauntletCI Architecture
+
+## Project layout
+
+| Project | Role |
+|---|---|
+| `GauntletCI.Core` | Rule engine, diff parser, static analysis runner, configuration models, domain types |
+| `GauntletCI.Cli` | System.CommandLine entry point, output formatters, telemetry pipeline, all CLI commands |
+| `GauntletCI.Llm` | ONNX runtime integration (Phi-3 Mini); `NullLlmEngine` is the default no-op |
+| `GauntletCI.Corpus` | Corpus ingestion pipeline — pull request hydration, normalization, scoring |
+| `GauntletCI.Tests` | xUnit test suite for Core and Cli |
+| `GauntletCI.BenchmarkReporter` | Benchmark report generation |
+| `GauntletCI.Benchmarks` | BenchmarkDotNet harness (in `/tests/`) |
+
+---
+
+## Analysis pipeline (per-run flow)
+
+```
+gauntletci analyze [options]
+        │
+        ▼
+1. Diff ingestion          DiffParser
+        │                  ├── --diff <file>       → FromFile()
+        │                  ├── --commit <sha>      → FromGitAsync()   (git diff <sha>^..<sha>)
+        │                  ├── --staged            → FromStagedAsync() (git diff --cached)
+        │                  ├── --unstaged          → FromUnstagedAsync() (git diff)
+        │                  ├── --all-changes       → FromAllChangesAsync() (git diff HEAD)
+        │                  └── (none)              → Parse(stdin)
+        │
+        ▼
+2. Config loading           ConfigLoader.Load(repoRoot)
+        │                  Reads .gauntletci.json → GauntletConfig
+        │                  Also loads .gauntletci-ignore → IgnoreList
+        │
+        ▼
+3. Static analysis          StaticAnalysisRunner.RunAsync()
+        │                  Roslyn-based; runs only on changed .cs files present on disk.
+        │                  Returns null when no repo path is available (--diff mode)
+        │                  or when no C# files changed.
+        │
+        ▼
+4. Rule evaluation          RuleOrchestrator.RunAsync()
+        │                  Rules are auto-discovered via reflection — all non-abstract
+        │                  IRule implementations in the Core assembly are loaded and
+        │                  sorted by ID. IConfigurableRule instances receive the config.
+        │                  Each rule runs with a 30-second per-rule timeout.
+        │
+        ▼
+5. Post-processing          RuleOrchestrator.PostProcess()
+        │                  GCI0018: aggregate finding when >3 distinct rules fire.
+        │                  GCI0019: large-diff warning based on total line count.
+        │                  Severity overrides from config applied to all findings.
+        │                  IgnoreList suppressions applied.
+        │
+        ▼
+6. LLM enrichment           LlmEngineSelector.ResolveAsync()  [opt-in: --with-llm]
+        │                  Enriches High-confidence findings with a natural-language
+        │                  explanation via Phi-3 Mini ONNX or a CI endpoint (see below).
+        │
+        ▼
+7. Output                   ConsoleReporter (text) | JsonSerializer (--output json)
+        │                  GitHubAnnotationWriter (--github-annotations)
+        │
+        ▼
+8. Telemetry                TelemetryCollector.CollectAsync()
+                           Anonymous events written to ~/.gauntletci/telemetry.ndjson.
+                           Background HTTP upload in Shared mode only.
+```
+
+---
+
+## Rule system
+
+### Interfaces
+
+```csharp
+public interface IRule
+{
+    string Id   { get; }
+    string Name { get; }
+    Task<List<Finding>> EvaluateAsync(DiffContext diff, AnalyzerResult? staticAnalysis, CancellationToken ct);
+}
+```
+
+`RuleBase` is the abstract base class that all built-in rules extend. It provides:
+
+- `CreateFinding(summary, evidence, whyItMatters, suggestedAction, confidence)` — constructs a `Finding` with the rule's `Id` and `Name` pre-filled.
+
+`IConfigurableRule` is an optional secondary interface for rules that need access to `GauntletConfig` (e.g., GCI0035 Architecture Layer Guard reads `ForbiddenImports`).
+
+### Auto-discovery
+
+`RuleOrchestrator.CreateDefault()` reflects over the `GauntletCI.Core` assembly at startup:
+
+```csharp
+typeof(RuleOrchestrator).Assembly.GetTypes()
+    .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(IRule).IsAssignableFrom(t))
+    .Select(t => (IRule)Activator.CreateInstance(t)!)
+    .Where(r => IsRuleEnabled(r.Id, config))
+```
+
+Adding a new rule requires only dropping a new `IRule` class into the assembly — no registration step.
+
+### Rule IDs
+
+Rules are named `GCI0001` through `GCI0037`. `GCI0028` is reserved.
+
+### Per-rule timeout
+
+Each rule runs under a linked `CancellationTokenSource` with a 30-second deadline (`_ruleTimeout`). A timeout produces a synthetic `Medium`-confidence finding reporting the timeout, so the run still completes.
+
+### Configuration
+
+Rules are configured via `.gauntletci.json`:
+
+```json
+{
+  "rules": {
+    "GCI0002": { "enabled": false },
+    "GCI0005": { "severity": "High" }
+  }
+}
+```
+
+`severity` overrides the rule's default `Confidence` level. Valid values: `"High"`, `"Medium"`, `"Low"`.
+
+---
+
+## Diff model
+
+```
+DiffContext
+ ├── CommitSha        : string
+ ├── CommitMessage    : string?
+ ├── RawDiff          : string
+ └── Files            : List<DiffFile>
+       ├── OldPath / NewPath : string
+       ├── IsAdded / IsDeleted / IsRenamed : bool
+       └── Hunks       : List<DiffHunk>
+             ├── OldStartLine / NewStartLine : int
+             └── Lines : List<DiffLine>
+                   ├── Kind        : DiffLineKind  (Added | Removed | Context)
+                   ├── LineNumber  : int  (new-file line; 0 for Removed)
+                   ├── OldLineNumber: int (old-file line; 0 for Added)
+                   └── Content     : string
+```
+
+Cross-file helpers on `DiffContext`:
+- `AllAddedLines` — flattens added lines across all files and hunks.
+- `AllRemovedLines` — flattens removed lines across all files and hunks.
+
+Per-file helpers on `DiffFile`:
+- `AddedLines`, `RemovedLines` — lines within that file only.
+
+`DiffParser` handles both the standard `diff --git` header format and bare unified diff format (e.g., from `git diff` piped through stdin).
+
+---
+
+## Configuration
+
+| File | Purpose |
+|---|---|
+| `.gauntletci.json` | Per-rule `enabled`/`severity` overrides; `policy_refs`; `llm` block; `forbidden_imports` for GCI0035 |
+| `.gauntletci-ignore` | One rule ID per line — suppresses that rule's findings for the entire repo |
+
+`ConfigLoader.Load(repoPath)` returns a default `GauntletConfig` (all rules enabled, no overrides) when the file is absent or unparseable, so no config file is required to run.
+
+---
+
+## Telemetry pipeline
+
+Telemetry is **opt-in** and collected anonymously. No code, no file paths, no PII.
+
+### Consent modes
+
+| Mode | Behavior |
+|---|---|
+| `Off` | No events written or uploaded |
+| `Local` | Events written to `~/.gauntletci/telemetry.ndjson` only |
+| `Shared` | Local write + background HTTP upload to the GauntletCI endpoint |
+
+Consent is prompted on first non-`init` run and stored in a local preference file.
+
+### Event types
+
+| Event | When emitted | Key fields |
+|---|---|---|
+| `analysis` | Once per run | `findingCount`, `filesChanged`, `rulesEvaluated`, `linesAdded`, `linesRemoved` |
+| `finding` | Once per finding | `ruleId`, `confidence`, `fileExt` (extension only, never full path) |
+| `feedback` | On `gauntletci feedback` | `vote` (`"up"` or `"down"`) |
+
+### Anonymization
+
+- **Install ID**: stable random UUID stored locally; identifies an installation, not a person.
+- **Repo hash**: 8-character SHA-256 prefix of the git remote URL — identifies a repo without revealing its path or name.
+
+### Storage and upload
+
+- `TelemetryStore`: appends NDJSON records to `~/.gauntletci/telemetry.ndjson`.
+- `TelemetryUploader`: fires a background HTTP upload (`Shared` mode only). Failures are silently swallowed — telemetry never crashes the tool.
+
+---
+
+## LLM integration
+
+GauntletCI supports two LLM enrichment paths:
+
+### Local ONNX (default opt-in path)
+
+- Requires `gauntletci model download` to fetch Phi-3 Mini weights.
+- Activated per-run with `--with-llm`.
+- Runs in a sidecar daemon process (`LlmDaemonServer`) to isolate ONNX memory from the main process.
+- `NullLlmEngine` is the no-op default when no model is present, adding zero dependencies to a standard run.
+
+### CI/CD premium endpoint
+
+- Configured via the `llm` block in `.gauntletci.json`.
+- Routes to any OpenAI-chat-completions-compatible endpoint (e.g., `api.openai.com`, Azure OpenAI).
+- API key read from the environment variable named by `ciApiKeyEnv` — never stored in config.
+- Requires a GauntletCI license key in the environment variable named by `licenseKeyEnv`.
+
+In both cases, enrichment applies only to `High`-confidence findings and appends a `LlmExplanation` string to each.
+
+---
+
+## Corpus pipeline
+
+The corpus pipeline ingests public pull request data for offline rule evaluation and dataset construction. See [`docs/corpus-pipeline.md`](corpus-pipeline.md) for details.
+
+---
+
+## CLI commands
+
+| Command | Description |
+|---|---|
+| `analyze` | Run rule evaluation against a diff (main entry point) |
+| `init` | Interactive first-run setup (telemetry consent, config scaffold) |
+| `ignore` | Add a rule ID to `.gauntletci-ignore` |
+| `model` | Download/manage the local ONNX model |
+| `postmortem` | Analyse a historical commit range |
+| `feedback` | Submit a thumbs-up/down vote on a finding |
+| `telemetry` | View or change telemetry consent |
+| `corpus` | Corpus ingestion and management |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,629 @@
+# GauntletCI CLI Reference
+
+**Version:** 2.0.0  
+**Tool command:** `gauntletci`
+
+GauntletCI is a deterministic pre-commit risk detection engine. It analyses git diffs for risky change patterns using a rule-based engine with optional local LLM enrichment.
+
+---
+
+## Global options
+
+These options are available on the root command:
+
+| Flag | Description |
+|------|-------------|
+| `--version` | Display the version number |
+| `--help`, `-h`, `-?` | Show help for the command or subcommand |
+
+---
+
+## Environment variables
+
+| Variable | Affects | Description |
+|----------|---------|-------------|
+| `GITHUB_TOKEN` | `corpus add-pr`, `corpus batch-hydrate`, `corpus discover` | Personal access token for GitHub REST API calls. Required for hydrating PRs from private repos; used for authenticated rate limits on public repos. |
+| `GAUNTLETCI_NO_BANNER` | All commands | Set to any non-empty value to suppress the ASCII banner without passing `--no-banner`. |
+| `CI` | Banner, telemetry | Suppresses the ASCII banner and telemetry consent prompt automatically. |
+| `GITHUB_ACTIONS` | Banner, telemetry | Suppresses banner and telemetry prompt (set automatically by GitHub Actions runners). |
+| `TF_BUILD` | Banner, telemetry | Suppresses banner and telemetry prompt (Azure Pipelines). |
+| `BUILD_BUILDID` | Banner | Suppresses banner (Azure Pipelines legacy). |
+| `JENKINS_URL` | Banner | Suppresses banner (Jenkins). |
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success — no findings detected (for `analyze` / `postmortem`) or command completed normally |
+| `1` | Findings detected (for `analyze` / `postmortem`), or invalid input for other commands |
+| `2` | Unhandled error / exception |
+
+---
+
+## analyze
+
+Analyse a git diff for pre-commit risks. Runs all enabled rules against the diff and reports findings.
+
+```
+gauntletci analyze [options]
+```
+
+Exactly one diff source should be specified. If none is provided, diff content is read from stdin.
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--diff <path>` | `file` | — | Path to a `.diff` file |
+| `--commit <sha>` | `string` | — | Commit SHA to analyse |
+| `--staged` | `bool` | `false` | Analyse staged changes (`git diff --cached`) |
+| `--unstaged` | `bool` | `false` | Analyse unstaged changes (`git diff`) |
+| `--all-changes` | `bool` | `false` | Analyse all local changes: staged + unstaged (`git diff HEAD`) |
+| `--repo <path>` | `directory` | CWD | Repository root (used for config loading and git operations) |
+| `--output <format>` | `string` | `text` | Output format: `text` or `json` |
+| `--with-llm` | `bool` | `false` | Enable LLM enrichment of High-confidence findings (requires `gauntletci model download`; adds latency) |
+| `--github-annotations` | `bool` | `false` | Emit GitHub Actions workflow commands for inline PR annotations |
+| `--ascii` | `bool` | `false` | Use ASCII-only output (for terminals without Unicode support) |
+| `--no-banner` | `bool` | `false` | Disable ASCII banner |
+
+> **Note:** `--no-llm` is a hidden deprecated flag. LLM is opt-in via `--with-llm`.
+
+### Examples
+
+```bash
+# Analyse staged changes before a commit
+gauntletci analyze --staged
+
+# Analyse all local changes (staged + unstaged)
+gauntletci analyze --all-changes
+
+# Analyse a specific commit
+gauntletci analyze --commit abc1234
+
+# Analyse from a saved diff file
+gauntletci analyze --diff changes.diff
+
+# Pipe a diff from stdin
+git diff HEAD | gauntletci analyze
+
+# Output JSON for downstream tooling
+gauntletci analyze --staged --output json
+
+# Enable LLM enrichment (requires model download first)
+gauntletci analyze --staged --with-llm
+
+# Emit GitHub Actions inline annotations
+gauntletci analyze --staged --github-annotations
+
+# Use in CI without banner
+gauntletci analyze --staged --no-banner --output json
+
+# Analyse a specific repo from a different working directory
+gauntletci analyze --staged --repo /path/to/my-repo
+```
+
+### Pre-commit hook
+
+After running `gauntletci init`, a git `pre-commit` hook is installed automatically. It runs `gauntletci analyze --staged` and blocks the commit if findings are detected (exit code 1).
+
+---
+
+## corpus
+
+Manage the GauntletCI fixture corpus — a local database of pull requests used to evaluate and score rule quality.
+
+```
+gauntletci corpus <subcommand> [options]
+```
+
+> **Note:** Most corpus subcommands require `GITHUB_TOKEN` for GitHub API access. The default corpus database path is `./data/gauntletci-corpus.db` and the default fixtures root is `./data/fixtures`.
+
+---
+
+### corpus add-pr
+
+Hydrate a single pull request and add it to the corpus.
+
+```
+gauntletci corpus add-pr --url <url> [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--url <url>` | `string` | **required** | GitHub PR URL (e.g. `https://github.com/owner/repo/pull/42`) |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+# Add a single PR to the corpus
+gauntletci corpus add-pr --url https://github.com/owner/repo/pull/42
+```
+
+---
+
+### corpus normalize
+
+Re-normalize a fixture from its existing raw snapshots (re-runs the normalization pipeline without re-fetching from GitHub).
+
+```
+gauntletci corpus normalize --fixture <id> [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--fixture <id>` | `string` | **required** | Fixture ID (e.g. `owner_repo_pr1234`) |
+| `--tier <tier>` | `string` | `discovery` | Fixture tier: `gold`, `silver`, or `discovery` |
+| `--owner <owner>` | `string` | — | Repo owner override |
+| `--repo <repo>` | `string` | — | Repo name override |
+| `--pr <number>` | `int` | — | PR number override |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+gauntletci corpus normalize --fixture owner_repo_pr42 --tier gold
+```
+
+---
+
+### corpus list
+
+Enumerate and filter corpus fixtures.
+
+```
+gauntletci corpus list [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--tier <tier>` | `string` | — | Filter by tier: `gold`, `silver`, or `discovery` |
+| `--language <lang>` | `string` | — | Filter by language (e.g. `cs`, `py`) |
+| `--tag <tag>` | `string[]` | — | Filter by tag (repeatable or comma-separated) |
+| `--output <format>` | `string` | `text` | Output format: `text` or `json` |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+# List all fixtures
+gauntletci corpus list
+
+# List only gold-tier C# fixtures
+gauntletci corpus list --tier gold --language cs
+
+# List as JSON
+gauntletci corpus list --output json
+
+# Filter by tag
+gauntletci corpus list --tag security --tag large-diff
+```
+
+---
+
+### corpus discover
+
+Discover pull request candidates from GitHub and persist them to the corpus database.
+
+```
+gauntletci corpus discover --provider <provider> [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--provider <provider>` | `string` | **required** | Discovery provider: `gh-search` or `gh-archive` |
+| `--limit <n>` | `int` | `100` | Maximum candidates to fetch |
+| `--language <lang>` | `string` | — | Filter by programming language (e.g. `cs`, `python`) |
+| `--min-stars <n>` | `int` | `0` | Minimum stars on the repository |
+| `--min-comments <n>` | `int` | `0` | Minimum review comment count |
+| `--start-date <date>` | `DateTime` | — | Filter by merge/event date (inclusive, UTC) |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+# Discover up to 50 C# PRs with at least 2 review comments
+gauntletci corpus discover --provider gh-search --limit 50 --language cs --min-comments 2
+
+# Discover from GH Archive since a specific date
+gauntletci corpus discover --provider gh-archive --start-date 2024-01-01 --limit 200
+```
+
+---
+
+### corpus batch-hydrate
+
+Bulk hydrate pending candidates from the corpus database.
+
+```
+gauntletci corpus batch-hydrate [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--limit <n>` | `int` | `10` | Maximum number of candidates to hydrate |
+| `--tier <tier>` | `string` | `discovery` | Target tier: `gold`, `silver`, or `discovery` |
+| `--dry-run` | `bool` | `false` | Print what would be processed without hydrating |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+# Hydrate up to 25 candidates into the discovery tier
+gauntletci corpus batch-hydrate --limit 25
+
+# Preview what would be hydrated
+gauntletci corpus batch-hydrate --limit 10 --dry-run
+
+# Hydrate into the silver tier
+gauntletci corpus batch-hydrate --limit 50 --tier silver
+```
+
+---
+
+### corpus run
+
+Run GCI rules against a single corpus fixture.
+
+```
+gauntletci corpus run --fixture <id> [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--fixture <id>` | `string` | **required** | Fixture ID to run rules against |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+gauntletci corpus run --fixture owner_repo_pr42
+```
+
+---
+
+### corpus run-all
+
+Run GCI rules against all (or filtered) corpus fixtures.
+
+```
+gauntletci corpus run-all [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--tier <tier>` | `string` | — | Filter by tier: `gold`, `silver`, or `discovery` |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+# Run all fixtures
+gauntletci corpus run-all
+
+# Run only gold-tier fixtures
+gauntletci corpus run-all --tier gold
+```
+
+---
+
+### corpus score
+
+Compute rule scorecards from corpus fixture results.
+
+```
+gauntletci corpus score [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--rule <id>` | `string` | — | Filter by rule ID (e.g. `GCI0001`) |
+| `--tier <tier>` | `string` | — | Filter by tier: `gold`, `silver`, or `discovery` |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+# Score all rules across all fixtures
+gauntletci corpus score
+
+# Score a specific rule on gold fixtures only
+gauntletci corpus score --rule GCI0003 --tier gold
+```
+
+---
+
+### corpus report
+
+Export a Markdown scorecard report for all rules.
+
+```
+gauntletci corpus report [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--output <path>` | `string` | `./corpus-report.md` | Output file path for the Markdown report |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+gauntletci corpus report
+
+gauntletci corpus report --output ./reports/2024-06-scorecard.md
+```
+
+---
+
+### corpus label
+
+Apply silver heuristic labels to a single corpus fixture.
+
+```
+gauntletci corpus label --fixture <id> [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--fixture <id>` | `string` | **required** | Fixture ID to label |
+| `--overwrite` | `bool` | `false` | Overwrite existing `HumanReview`/`Seed` labels with heuristic labels |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+gauntletci corpus label --fixture owner_repo_pr42
+
+# Force overwrite existing human-reviewed labels
+gauntletci corpus label --fixture owner_repo_pr42 --overwrite
+```
+
+---
+
+### corpus label-all
+
+Apply silver heuristic labels to all fixtures in a tier.
+
+```
+gauntletci corpus label-all [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--tier <tier>` | `string` | `discovery` | Fixture tier to process: `gold`, `silver`, or `discovery` |
+| `--overwrite` | `bool` | `false` | Overwrite existing `HumanReview`/`Seed` labels with heuristic labels |
+| `--db <path>` | `string` | `./data/gauntletci-corpus.db` | Path to corpus SQLite database |
+| `--fixtures <path>` | `string` | `./data/fixtures` | Path to fixtures root directory |
+
+```bash
+# Label all discovery fixtures
+gauntletci corpus label-all
+
+# Label all silver fixtures, overwriting previous labels
+gauntletci corpus label-all --tier silver --overwrite
+```
+
+---
+
+## model
+
+Manage the local LLM model used for finding enrichment. GauntletCI uses the **Phi-3 Mini INT4 ONNX** model (~2 GB) for offline enrichment of High-confidence findings.
+
+```
+gauntletci model <subcommand> [options]
+```
+
+---
+
+### model download
+
+Download the Phi-3 Mini INT4 ONNX model for offline enrichment.
+
+```
+gauntletci model download [options]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dir <path>` | `string` | `~/.gauntletci/models/phi3-mini` | Directory to download the model into |
+
+```bash
+# Download to default location
+gauntletci model download
+
+# Download to a custom directory
+gauntletci model download --dir /mnt/models/phi3-mini
+```
+
+After downloading, pass `--with-llm` to `analyze` to enable enrichment.
+
+---
+
+### model status
+
+Show whether the local LLM model is downloaded and ready.
+
+```
+gauntletci model status
+```
+
+No options. Prints the cached model path and whether enrichment is available.
+
+```bash
+gauntletci model status
+```
+
+---
+
+## feedback
+
+Rate the quality of the last analysis. Feedback is stored as an anonymous telemetry event and uploaded with the next batch. Requires telemetry to be enabled (`gauntletci telemetry --enable`).
+
+```
+gauntletci feedback <vote>
+```
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `vote` | `string` | **required** — `up` (useful) or `down` (too noisy) |
+
+```bash
+# Mark the last analysis as useful
+gauntletci feedback up
+
+# Mark it as too noisy
+gauntletci feedback down
+```
+
+> Feedback is silently accepted without error if telemetry is not enabled, but is not stored.
+
+---
+
+## telemetry
+
+Manage telemetry preferences. Telemetry collects anonymous usage data to improve rule quality.
+
+```
+gauntletci telemetry [options]
+```
+
+With no options, prints the current telemetry status and install ID.
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--status` | `bool` | `false` | Show current telemetry status and install ID |
+| `--mode <mode>` | `string` | — | Set telemetry mode: `shared`, `local`, or `off` |
+| `--enable` | `bool` | `false` | Opt in to shared telemetry (alias for `--mode shared`) |
+| `--disable` | `bool` | `false` | Disable telemetry completely (alias for `--mode off`) |
+
+### Telemetry modes
+
+| Mode | Behaviour |
+|------|-----------|
+| `shared` | Events stored locally **and** uploaded anonymously for aggregate analysis |
+| `local` | Events stored locally only — no network calls |
+| `off` | Telemetry disabled entirely |
+
+```bash
+# Show current status
+gauntletci telemetry
+
+# Opt in to shared telemetry
+gauntletci telemetry --enable
+
+# Store locally only
+gauntletci telemetry --mode local
+
+# Disable telemetry
+gauntletci telemetry --disable
+```
+
+> The first-run consent prompt is skipped automatically in CI environments (`CI`, `GITHUB_ACTIONS`, `TF_BUILD`). It is also skipped when running `gauntletci telemetry` directly.
+
+---
+
+## postmortem
+
+Analyse a past commit to see what GauntletCI would have caught at pre-commit time. Identical rule set to `analyze`, but targets a historical commit rather than local changes.
+
+```
+gauntletci postmortem --commit <sha> [options]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--commit <sha>` | `string` | **required** | Commit SHA to analyse |
+| `--repo <path>` | `directory` | CWD | Repository root |
+| `--output <format>` | `string` | `text` | Output format: `text` or `json` |
+| `--no-banner` | `bool` | `false` | Disable ASCII banner |
+| `--ascii` | `bool` | `false` | ASCII-only output |
+
+### Examples
+
+```bash
+# See what would have been caught on a specific commit
+gauntletci postmortem --commit abc1234
+
+# JSON output for scripting
+gauntletci postmortem --commit abc1234 --output json
+
+# Run against a repo in a different directory
+gauntletci postmortem --commit abc1234 --repo /path/to/my-repo
+```
+
+Exit codes match `analyze`: `0` = no findings, `1` = findings detected, `2` = error.
+
+---
+
+## init
+
+Create a default `.gauntletci.json` configuration file and install pre-commit hooks in the current git repository.
+
+```
+gauntletci init [options]
+```
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dir <path>` | `directory` | CWD | Directory to create `.gauntletci.json` in |
+| `--force` | `bool` | `false` | Overwrite existing hook files if present |
+| `--no-telemetry` | `bool` | `false` | Skip the telemetry consent prompt during init |
+
+### What it does
+
+1. Creates `.gauntletci.json` in the target directory with all rules enabled (`GCI0001`–`GCI0027`).
+2. Installs `.git/hooks/pre-commit` (bash) and `.git/hooks/pre-commit.ps1` (PowerShell) hooks that run `gauntletci analyze --staged` on every commit.
+3. Prompts for telemetry consent on first run (unless `--no-telemetry` is passed).
+
+### Examples
+
+```bash
+# Initialize in the current directory
+gauntletci init
+
+# Initialize without telemetry prompt (e.g. in automated setup scripts)
+gauntletci init --no-telemetry
+
+# Re-install hooks after updating GauntletCI
+gauntletci init --force
+
+# Initialize in a specific directory
+gauntletci init --dir /path/to/my-repo
+```
+
+---
+
+## ignore
+
+Add a suppression entry to `.gauntletci-ignore` to silence a specific rule globally or for a path pattern.
+
+```
+gauntletci ignore <rule-id> [options]
+```
+
+### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `rule-id` | `string` | **required** — Rule ID to suppress (e.g. `GCI0003`). Case-insensitive; normalized to uppercase. |
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--path <glob>` | `string` | — | Optional glob pattern to restrict suppression to matching paths (e.g. `src/Generated/**`) |
+| `--repo <path>` | `directory` | CWD | Repository root (where `.gauntletci-ignore` lives) |
+
+### Examples
+
+```bash
+# Suppress GCI0003 everywhere in the repo
+gauntletci ignore GCI0003
+
+# Suppress GCI0003 only in generated code
+gauntletci ignore GCI0003 --path src/Generated/**
+
+# Suppress in a specific repo
+gauntletci ignore GCI0007 --path tests/** --repo /path/to/my-repo
+```
+
+> Entries are appended to `.gauntletci-ignore` in the repository root. The file is read on every `analyze` run. To re-enable a rule, remove the relevant line from `.gauntletci-ignore` manually.

--- a/docs/corpus-pipeline.md
+++ b/docs/corpus-pipeline.md
@@ -1,0 +1,418 @@
+# Corpus Pipeline
+
+The corpus pipeline is a six-step workflow that collects real-world pull requests, runs GauntletCI rules against them, applies heuristic labels, and produces per-rule precision/recall scorecards. The resulting fixtures and scores form the training signal for the **Moat** — GauntletCI's feedback loop that calibrates rule confidence over time.
+
+```
+discover → batch-hydrate → run-all → label-all → score → report
+```
+
+---
+
+## Prerequisites
+
+| Requirement | Detail |
+|---|---|
+| .NET 8 SDK | `dotnet --version` should report `8.x` |
+| `GITHUB_TOKEN` | Required for `batch-hydrate` and the `gh-search` discover provider. `gh-archive` works unauthenticated but is rate-limited at 60 req/hr without a token. |
+| Disk space | Allow ~1–5 MB per fixture. A 500-fixture corpus typically uses ~1 GB including raw API snapshots. |
+
+Set the token before running:
+
+```powershell
+$env:GITHUB_TOKEN = "ghp_..."
+```
+
+---
+
+## Quick Start (full pipeline)
+
+The `run-corpus.ps1` script at the repo root orchestrates all six steps with sensible defaults:
+
+```powershell
+.\run-corpus.ps1
+```
+
+Common overrides:
+
+```powershell
+# Discover 200 C# PRs from the last 7 days with at least 3 review comments
+.\run-corpus.ps1 -Limit 200 -Language "C#" -MinComments 3 -StartDate "2025-01-01"
+
+# Resume from step 3 (skip discover + hydrate)
+.\run-corpus.ps1 -SkipTo 3
+
+# Use custom paths
+.\run-corpus.ps1 -Db "./custom/corpus.db" -Fixtures "./custom/fixtures" -Report "./custom/scorecard.md"
+```
+
+**`run-corpus.ps1` parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `-StartDate` | Yesterday (UTC) | Filter PRs merged/created on or after this date |
+| `-Limit` | `50` | Max candidates to discover |
+| `-Language` | _(all)_ | Programming language filter (e.g. `C#`, `Python`) |
+| `-MinComments` | `2` | Minimum review comment count |
+| `-Tier` | `discovery` | Target fixture tier for hydration |
+| `-Db` | `./data/corpus.db` | SQLite database path |
+| `-Fixtures` | `./data/fixtures` | Fixtures root directory |
+| `-Report` | `./data/scorecard.md` | Output path for the markdown report |
+| `-SkipTo` | `1` | Resume from step N (1–6) |
+
+---
+
+## Step 1 — `corpus discover`
+
+Searches for pull request candidates and writes them to the corpus SQLite database. No fixture files are created yet.
+
+```
+gauntletci corpus discover --provider <provider> [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--provider` | _(required)_ | `gh-archive` (no token needed) or `gh-search` (token required) |
+| `--limit` | `100` | Maximum candidates to fetch |
+| `--language` | _(all)_ | Filter by programming language (e.g. `cs`, `python`) |
+| `--min-stars` | `0` | Minimum repository star count |
+| `--min-comments` | `0` | Minimum PR review comment count |
+| `--start-date` | _(none)_ | Earliest merge/event date to include (UTC, e.g. `2025-03-01`) |
+| `--db` | `./data/gauntletci-corpus.db` | SQLite database path |
+| `--fixtures` | `./data/fixtures` | Fixtures root directory |
+
+**Examples:**
+
+```powershell
+# GH Archive — no token, fast, last 24 h
+gauntletci corpus discover --provider gh-archive --limit 100 --start-date 2025-06-01
+
+# GitHub Search — token required, language-filtered
+gauntletci corpus discover --provider gh-search --limit 50 --language cs --min-comments 2
+```
+
+> Candidates already in the database are silently skipped (`INSERT OR IGNORE`).
+
+---
+
+## Step 2 — `corpus batch-hydrate`
+
+Fetches full PR data (diff, metadata, review comments) for pending candidates via the GitHub REST API and writes fixture files to disk.
+
+```
+gauntletci corpus batch-hydrate [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--limit` | `10` | Maximum candidates to hydrate in this run |
+| `--tier` | `discovery` | Fixture tier to assign (`gold`, `silver`, `discovery`) |
+| `--dry-run` | `false` | Print what would be hydrated without writing any files |
+| `--db` | `./data/gauntletci-corpus.db` | SQLite database path |
+| `--fixtures` | `./data/fixtures` | Fixtures root directory |
+
+> **`GITHUB_TOKEN` is required.** Hydration fails immediately if the variable is not set.
+
+**Examples:**
+
+```powershell
+# Hydrate next 20 candidates as discovery fixtures
+gauntletci corpus batch-hydrate --limit 20
+
+# Preview without writing (dry run)
+gauntletci corpus batch-hydrate --limit 50 --dry-run
+
+# Hydrate as silver-tier
+gauntletci corpus batch-hydrate --limit 10 --tier silver
+```
+
+You can also hydrate a single PR directly by URL:
+
+```powershell
+gauntletci corpus add-pr --url https://github.com/owner/repo/pull/123
+```
+
+---
+
+## Step 3 — `corpus run` / `corpus run-all`
+
+Executes all GCI rules against fixture diffs and writes `actual.json` to each fixture folder.
+
+### Single fixture
+
+```
+gauntletci corpus run --fixture <id> [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--fixture` | _(required)_ | Fixture ID, e.g. `torvalds_linux_pr4321` |
+| `--db` | `./data/gauntletci-corpus.db` | SQLite database path |
+| `--fixtures` | `./data/fixtures` | Fixtures root directory |
+
+### All fixtures
+
+```
+gauntletci corpus run-all [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--tier` | _(all tiers)_ | Limit to a single tier (`gold`, `silver`, `discovery`) |
+| `--db` | `./data/gauntletci-corpus.db` | SQLite database path |
+| `--fixtures` | `./data/fixtures` | Fixtures root directory |
+
+**Examples:**
+
+```powershell
+# Run a single fixture
+gauntletci corpus run --fixture torvalds_linux_pr4321
+
+# Run all discovery fixtures
+gauntletci corpus run-all --tier discovery
+
+# Run everything
+gauntletci corpus run-all
+```
+
+Each fixture that has no `diff.patch` is skipped with a `SKIP` log line. Results are saved to `actual.json` (latest) and `actual.{runId}.json` (per-run archive) in the fixture folder.
+
+---
+
+## Step 4 — `corpus label` / `corpus label-all`
+
+Applies silver heuristic labels to `expected.json`. Existing `HumanReview` or `Seed` labels are never overwritten unless `--overwrite` is passed.
+
+### Single fixture
+
+```
+gauntletci corpus label --fixture <id> [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--fixture` | _(required)_ | Fixture ID to label |
+| `--overwrite` | `false` | Replace existing `HumanReview`/`Seed` labels |
+| `--db` | `./data/gauntletci-corpus.db` | SQLite database path |
+| `--fixtures` | `./data/fixtures` | Fixtures root directory |
+
+### All fixtures in a tier
+
+```
+gauntletci corpus label-all [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--tier` | `discovery` | Tier to process (`gold`, `silver`, `discovery`) |
+| `--overwrite` | `false` | Replace existing `HumanReview`/`Seed` labels |
+| `--db` | `./data/gauntletci-corpus.db` | SQLite database path |
+| `--fixtures` | `./data/fixtures` | Fixtures root directory |
+
+**Examples:**
+
+```powershell
+# Label all discovery fixtures
+gauntletci corpus label-all
+
+# Label all tiers, overwriting existing heuristic labels
+gauntletci corpus label-all --tier gold --overwrite
+
+# Label a single fixture
+gauntletci corpus label --fixture torvalds_linux_pr4321
+```
+
+---
+
+## Step 5 — `corpus score`
+
+Reads `expected.json` and `actual.json` from all fixtures and computes per-rule scorecards. Results are printed to stdout and upserted into the `aggregates` table in the corpus database.
+
+```
+gauntletci corpus score [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--rule` | _(all rules)_ | Filter to a single rule ID (e.g. `GCI0007`) |
+| `--tier` | _(all tiers)_ | Filter to a single tier |
+| `--db` | `./data/gauntletci-corpus.db` | SQLite database path |
+| `--fixtures` | `./data/fixtures` | Fixtures root directory |
+
+**Examples:**
+
+```powershell
+# Score all rules across all tiers
+gauntletci corpus score
+
+# Score only GCI0003 on silver fixtures
+gauntletci corpus score --rule GCI0003 --tier silver
+```
+
+> If no `actual.json` files exist, the command reminds you to run `corpus run-all` first.
+
+---
+
+## Step 6 — `corpus report`
+
+Exports the aggregate scorecards as a markdown file.
+
+```
+gauntletci corpus report [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--output` | `./corpus-report.md` | Destination file path |
+| `--db` | `./data/gauntletci-corpus.db` | SQLite database path |
+| `--fixtures` | `./data/fixtures` | Fixtures root directory |
+
+**Example:**
+
+```powershell
+gauntletci corpus report --output ./data/scorecard.md
+```
+
+---
+
+## Silver Heuristics
+
+The `SilverLabelEngine` infers `expected.json` labels from diff content without human review. Labels have `LabelSource: Heuristic` and are never applied over existing `HumanReview` or `Seed` entries unless `--overwrite` is passed.
+
+| Rule | Trigger condition | Expected confidence |
+|---|---|---|
+| **GCI0016** — Sync-over-async | Any added line contains `.Result` or `.Wait()` | 0.60 |
+| **GCI0007** — Secret exposure | Any added line contains `password`, `secret`, `api_key`, or `token` (case-insensitive) | 0.70 |
+| **GCI0003** — Empty catch block | Added lines contain an empty or comment-only `catch { }` block | 0.65 |
+| **GCI0021** — Migration file touched | Any diff path line contains `Migration` or `_migration` (case-insensitive) | 0.60 |
+
+When no heuristic matches, no label is written (an empty `expected.json` is not created).
+
+---
+
+## Scoring Formulas
+
+Scorecards are computed per `(RuleId, Tier)` pair. Fixtures marked `IsInconclusive: true` are excluded from precision/recall but counted in the inconclusive rate.
+
+| Metric | Formula |
+|---|---|
+| **TriggerRate** | `triggered / total` |
+| **Precision** | `TP / (TP + FP)` |
+| **Recall** | `TP / (TP + FN)` |
+| **InconclusiveRate** | `inconclusive / fixtureCount` |
+| **AvgUsefulness** | `AVG(usefulness)` from the `evaluations` table (0–5 scale) |
+
+Where:
+- `total` = conclusive fixture count for this rule/tier
+- `triggered` = fixtures where `actual.json` contains the rule with `DidTrigger: true`
+- `TP` = triggered AND `ShouldTrigger: true`
+- `FP` = triggered AND `ShouldTrigger: false`
+- `FN` = `ShouldTrigger: true` AND not triggered
+
+---
+
+## Fixture Structure
+
+Each fixture is a folder under `{fixtures}/{tier}/{fixtureId}/`.
+
+### Folder layout
+
+```
+data/fixtures/
+├── gold/
+│   └── owner_repo_pr1234/
+│       ├── metadata.json
+│       ├── expected.json
+│       ├── actual.json          ← latest run
+│       ├── actual.<runId>.json  ← per-run archive
+│       ├── diff.patch
+│       ├── notes.md
+│       └── raw/                 ← raw GitHub API snapshots
+├── silver/
+│   └── ...
+└── discovery/
+    └── ...
+```
+
+**Fixture ID format:** `{owner}_{repo}_pr{number}` — all lowercase, `/` and `\` replaced with `_`, spaces replaced with `-`.
+
+Example: `github.com/torvalds/linux/pull/4321` → `torvalds_linux_pr4321`
+
+### `metadata.json`
+
+```json
+{
+  "FixtureId": "torvalds_linux_pr4321",
+  "Tier": "Discovery",
+  "Repo": "torvalds/linux",
+  "PullRequestNumber": 4321,
+  "Language": "C",
+  "RuleIds": [],
+  "Tags": [],
+  "PrSizeBucket": "Large",
+  "FilesChanged": 12,
+  "HasTestsChanged": false,
+  "HasReviewComments": true,
+  "BaseSha": "abc123",
+  "HeadSha": "def456",
+  "Source": "batch",
+  "CreatedAtUtc": "2025-06-01T00:00:00Z"
+}
+```
+
+### `expected.json`
+
+Array of `ExpectedFinding` objects written by `corpus label` / `corpus label-all`:
+
+```json
+[
+  {
+    "RuleId": "GCI0007",
+    "ShouldTrigger": true,
+    "ExpectedConfidence": 0.7,
+    "Reason": "Diff contains credential-related keyword on added lines",
+    "LabelSource": "Heuristic",
+    "IsInconclusive": false
+  }
+]
+```
+
+| Field | Description |
+|---|---|
+| `RuleId` | GCI rule identifier |
+| `ShouldTrigger` | Whether the rule is expected to fire |
+| `ExpectedConfidence` | Heuristic confidence estimate (0–1) |
+| `Reason` | Human-readable justification |
+| `LabelSource` | `Heuristic`, `HumanReview`, or `Seed` |
+| `IsInconclusive` | If `true`, fixture is excluded from precision/recall |
+
+### `actual.json`
+
+Array of `ActualFinding` objects written by `corpus run` / `corpus run-all`:
+
+```json
+[
+  {
+    "RuleId": "GCI0007",
+    "DidTrigger": true,
+    "ActualConfidence": 0.85,
+    "Message": "Possible secret or credential detected",
+    "ChangeImplication": "Credential leak risk",
+    "Evidence": "Line 42: api_key = \"abc123\"",
+    "ExecutionTimeMs": 3
+  }
+]
+```
+
+---
+
+## Tier System
+
+| Tier | Trust level | How fixtures arrive | Label source |
+|---|---|---|---|
+| **Gold** | Highest | Manually curated by a human reviewer | `HumanReview` or `Seed` |
+| **Silver** | Medium | Hydrated and heuristically labeled | `Heuristic` (validated by spot-check) |
+| **Discovery** | Lowest | Freshly hydrated, not yet labeled | None (or heuristic pending review) |
+
+Scoring separates results by tier so that Gold-tier precision/recall can be reported independently of noisier Discovery-tier data. When upgrading a fixture from Discovery → Silver or Silver → Gold, update the `Tier` field in `metadata.json` (or re-run `corpus normalize --tier silver`) and move the folder to the appropriate sub-directory.
+
+Gold labels always take precedence over Silver and Heuristic labels. The `SilverLabelEngine` will never overwrite a `HumanReview` or `Seed` entry unless `--overwrite` is explicitly passed.


### PR DESCRIPTION
Bundles all documentation branches: architecture overview, CLI reference, README v2.0 overhaul (LLM, telemetry, winget/brew, doc links), and corpus pipeline usage guide.