### PR TITLE
[CORPUS] Color-highlight diff additions/deletions in labeler task view

### DIFF
--- a/src/GauntletCI.Corpus/GauntletCI_Labeler_App/static/style.css
+++ b/src/GauntletCI.Corpus/GauntletCI_Labeler_App/static/style.css
@@ -172,6 +172,9 @@ pre {
   max-height:300px;
 }
 pre.diff { max-height: 640px; }
+pre.diff .diff-add { background: rgba(70, 200, 120, 0.12); color: #7ef0c8; display: block; }
+pre.diff .diff-del { background: rgba(255, 80, 80, 0.12); color: #ff7c7c; display: block; }
+pre.diff .diff-hunk { color: #7ab4f5; display: block; }
 .flash-stack { margin-bottom: 14px; }
 .flash { padding: 12px 14px; border-radius: 12px; margin-bottom: 10px; }
 .flash.success { background: rgba(126, 240, 200, 0.12); border: 1px solid rgba(126, 240, 200, 0.5); }

--- a/src/GauntletCI.Corpus/GauntletCI_Labeler_App/templates/task.html
+++ b/src/GauntletCI.Corpus/GauntletCI_Labeler_App/templates/task.html
@@ -210,5 +210,24 @@
       }
     });
   });
+
+  (function () {
+    const pre = document.getElementById('diff-preview');
+    if (!pre) return;
+    const lines = pre.textContent.split('\n');
+    pre.textContent = '';
+    lines.forEach(function (line) {
+      const span = document.createElement('span');
+      if (line.startsWith('+') && !line.startsWith('+++')) {
+        span.className = 'diff-add';
+      } else if (line.startsWith('-') && !line.startsWith('---')) {
+        span.className = 'diff-del';
+      } else if (line.startsWith('@@')) {
+        span.className = 'diff-hunk';
+      }
+      span.textContent = line + '\n';
+      pre.appendChild(span);
+    });
+  })();
 </script>
 {% endblock %}


### PR DESCRIPTION
Parses the diff preview line-by-line in JS: additions (+) highlighted green, deletions (-) red, hunk headers (@@ lines) blue. Copy button is unaffected (reads textContent). No external dependencies.