### PR TITLE
[INFRA] Skip null Tier 3 LLM fallback logging

### DIFF
--- a/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
+++ b/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
@@ -202,36 +202,39 @@ public sealed class SilverLabelEngine
             .Select(l => l.RuleId)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var finding in actualFindings)
+        if (_llmLabeler is not NullLlmLabeler)
         {
-            if (!finding.DidTrigger) continue;
-            if (!RulesWithHeuristics.Contains(finding.RuleId)) continue;
-            if (positiveRuleIdsAfterTier12.Contains(finding.RuleId)) continue;
-
-            var diffSnippet = ExtractFileDiffHunk(diffText, finding.FilePath);
-            Console.WriteLine($"  [llm] Tier 3 calling {_llmLabeler.GetType().Name} for rule {finding.RuleId}");
-
-            var result = await _llmLabeler.ClassifyAsync(
-                finding.RuleId,
-                finding.Message,
-                finding.Evidence,
-                finding.FilePath,
-                commentBodies,
-                diffSnippet,
-                ct);
-
-            if (result is not null && !result.IsInconclusive)
+            foreach (var finding in actualFindings)
             {
-                inferred.Add(new ExpectedFinding
+                if (!finding.DidTrigger) continue;
+                if (!RulesWithHeuristics.Contains(finding.RuleId)) continue;
+                if (positiveRuleIdsAfterTier12.Contains(finding.RuleId)) continue;
+
+                var diffSnippet = ExtractFileDiffHunk(diffText, finding.FilePath);
+                Console.WriteLine($"  [llm] Tier 3 calling {_llmLabeler.GetType().Name} for rule {finding.RuleId}");
+
+                var result = await _llmLabeler.ClassifyAsync(
+                    finding.RuleId,
+                    finding.Message,
+                    finding.Evidence,
+                    finding.FilePath,
+                    commentBodies,
+                    diffSnippet,
+                    ct);
+
+                if (result is not null && !result.IsInconclusive)
                 {
-                    RuleId             = finding.RuleId,
-                    ShouldTrigger      = result.ShouldTrigger,
-                    ExpectedConfidence = result.Confidence,
-                    Reason             = $"[llm] {result.Reason}",
-                    LabelSource        = LabelSource.LlmReview,
-                    IsInconclusive     = false,
-                });
-                positiveRuleIdsAfterTier12.Add(finding.RuleId);
+                    inferred.Add(new ExpectedFinding
+                    {
+                        RuleId             = finding.RuleId,
+                        ShouldTrigger      = result.ShouldTrigger,
+                        ExpectedConfidence = result.Confidence,
+                        Reason             = $"[llm] {result.Reason}",
+                        LabelSource        = LabelSource.LlmReview,
+                        IsInconclusive     = false,
+                    });
+                    positiveRuleIdsAfterTier12.Add(finding.RuleId);
+                }
             }
         }
 

--- a/src/GauntletCI.Tests/Corpus/CorpusAutoLabelTests.cs
+++ b/src/GauntletCI.Tests/Corpus/CorpusAutoLabelTests.cs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
+using System.IO;
 using GauntletCI.Corpus.Interfaces;
 using GauntletCI.Corpus.Labeling;
 using GauntletCI.Corpus.Models;
@@ -178,6 +179,31 @@ public sealed class CorpusAutoLabelTests
         var result = await labeler.ClassifyAsync("", "", "", null, [], "", CancellationToken.None);
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ApplyToFixture_NullLlmLabeler_DoesNotEmitTier3Log()
+    {
+        var actualFindings = new List<ActualFinding>
+        {
+            new() { RuleId = "GCI0004", DidTrigger = true, FilePath = "Src/PublicApi.cs", Message = "Breaking change risk" },
+        };
+
+        var store  = new FakeFixtureStore(actualFindings);
+        var engine = new SilverLabelEngine(store, new NullLlmLabeler());
+        var sw = new StringWriter();
+        var original = Console.Out;
+        Console.SetOut(sw);
+        try
+        {
+            await engine.ApplyToFixtureAsync("test-fixture", "--- a/Src/PublicApi.cs\n+++ b/Src/PublicApi.cs\n@@ -1 +1 @@\n+public class PublicApi {}");
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        Assert.DoesNotContain("Tier 3 calling NullLlmLabeler", sw.ToString());
     }
 
     // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Only run and log Tier 3 LLM fallback when a real labeler is configured so heuristic labeling no longer prints misleading NullLlmLabeler calls.