### PR TITLE
[INFRA] Persist corpus repo reject memory

### DIFF
--- a/build-corpus.ps1
+++ b/build-corpus.ps1
@@ -47,7 +47,6 @@ param(
         # Removed: IdentityServer/IdentityServer4 (archived)
         "JamesNK/Newtonsoft.Json",
         # Removed: JetBrains/Annotations (too small, <5 review-commented PRs)
-        "MediatR/MediatR",
         "NLog/NLog",
         "PowerShell/PowerShell",
         "RicoSuter/NJsonSchema",
@@ -73,7 +72,8 @@ param(
         "googleapis/google-api-dotnet-client",
         "grpc/grpc-dotnet",
         "icsharpcode/SharpZipLib",
-        # Removed: jbogard/MediatR (duplicate of MediatR/MediatR after org rename)
+        # Removed: MediatR/MediatR (repo now rejects as deleted/private)
+        # Removed: jbogard/MediatR (duplicate of former MediatR org home)
         "jellyfin/jellyfin",
         "joshclose/CsvHelper",
         "mgravell/Pipelines.Sockets.Unofficial",
@@ -95,6 +95,7 @@ param(
         "akkadotnet/akka.net",           # Actor-model framework, ~5k stars, active reviews
         "AngleSharp/AngleSharp",         # HTML/CSS parser, ~4.5k stars, active
         "ClosedXML/ClosedXML",           # Excel manipulation, ~4k stars, active
+        "icsharpcode/ILSpy",             # Mature .NET toolchain project, strong contributor/review activity
         "morelinq/MoreLINQ",             # LINQ extensions, ~3.7k stars, active
         "spectreconsole/spectre.console" # Rich console UI, ~10k stars, very active
     )
@@ -198,6 +199,28 @@ Write-Host "Building solution..." -ForegroundColor Yellow
 dotnet build GauntletCI.slnx --nologo -v quiet
 if ($LASTEXITCODE -ne 0) { throw "Build failed" }
 
+$effectiveRepoBlocklist = @($RepoBlocklist)
+$dynamicRepoRejects = @()
+if (Test-Path $Db) {
+    $dynamicRepoRejects = @(
+        & dotnet run --project src/GauntletCI.Cli --no-build -- corpus rejected-repos --db $Db --names-only 2>$null |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Could not load persisted rejected repos from $Db — continuing with static blocklist only."
+        $dynamicRepoRejects = @()
+    }
+}
+if ($dynamicRepoRejects.Count -gt 0) {
+    Write-Host "Loaded $($dynamicRepoRejects.Count) persisted rejected repos into the discovery filter." -ForegroundColor Yellow
+}
+$effectiveRepoBlocklist = @($RepoBlocklist + $dynamicRepoRejects | Sort-Object -Unique)
+$effectiveRepoAllowlist = @($RepoAllowlist | Where-Object { $effectiveRepoBlocklist -notcontains $_ })
+if ($effectiveRepoAllowlist.Count -lt $RepoAllowlist.Count) {
+    $removed = @($RepoAllowlist | Where-Object { $effectiveRepoBlocklist -contains $_ } | Sort-Object -Unique)
+    Write-Host "Excluded from effective allowlist: $($removed -join ', ')" -ForegroundColor Yellow
+}
+
 # ── Step 1: Discover ──────────────────────────────────────────────────────────
 if ($SkipTo -le 1) {
     Step 1 "Discover PR candidates from GH Archive"
@@ -217,10 +240,10 @@ if ($SkipTo -le 1) {
     if ($RepoAllowlist.Count -eq 0 -and $MinStars -gt 0) {
         $discoverArgs += "--min-stars", $MinStars
     }
-    foreach ($allowed in $RepoAllowlist) {
+    foreach ($allowed in $effectiveRepoAllowlist) {
         $discoverArgs += "--repo-allowlist", $allowed
     }
-    foreach ($blocked in $RepoBlocklist) {
+    foreach ($blocked in $effectiveRepoBlocklist) {
         $discoverArgs += "--repo-blocklist", $blocked
     }
 
@@ -269,7 +292,7 @@ if ($SkipTo -le 2) {
         "--fixtures", $Fixtures
     )
     if ($Language -ne "") { $purgeArgs += "--language", $Language }
-    foreach ($blocked in $RepoBlocklist) {
+    foreach ($blocked in $effectiveRepoBlocklist) {
         $purgeArgs += "--repo-blocklist", $blocked
     }
 

--- a/docs/corpus-pipeline.md
+++ b/docs/corpus-pipeline.md
@@ -62,6 +62,8 @@ Common overrides:
 | `-Report` | `./data/scorecard.md` | Output path for the markdown report |
 | `-SkipTo` | `1` | Resume from step N (1–6) |
 
+`run-corpus.ps1` also folds in any repositories previously recorded in the corpus DB as permanent hydration rejects (for example deleted/private repos) so later runs stop rediscovering and rehydrating them.
+
 ---
 
 ## Step 1 — `corpus discover`

--- a/src/GauntletCI.Cli/Commands/CorpusCommand.cs
+++ b/src/GauntletCI.Cli/Commands/CorpusCommand.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.CommandLine;
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using GauntletCI.Corpus.Discovery;
@@ -46,6 +47,7 @@ public static class CorpusCommand
         corpus.AddCommand(CreateResetStats());
         corpus.AddCommand(CreatePurge());
         corpus.AddCommand(CreateErrors());
+        corpus.AddCommand(CreateRejectedRepos());
         corpus.AddCommand(CreateDoctor());
 
         var issues = new Command("issues", "GitHub Issues corpus operations");
@@ -761,10 +763,28 @@ public static class CorpusCommand
 
                 int success = 0;
                 int total   = candidates.Count;
+                var rejectedRepos = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                using var hydrator = GitHubRestHydrator.CreateDefault(fixtures);
 
                 foreach (var (owner, repo, prNumber) in candidates)
                 {
                     var url = $"https://github.com/{owner}/{repo}/pull/{prNumber}";
+                    var candidateId = $"{owner}/{repo}#{prNumber}";
+                    var repoSpec = $"{owner}/{repo}";
+
+                    if (rejectedRepos.TryGetValue(repoSpec, out var cachedRejectReason))
+                    {
+                        await UpsertHydrationStatusAsync(
+                            db.Connection,
+                            candidateId,
+                            "PermanentFailure",
+                            $"Skipped because repo was rejected earlier in this run: {cachedRejectReason}",
+                            hydrated: null,
+                            ct);
+                        Console.WriteLine($"[corpus] Skip {owner}/{repo}#{prNumber} — repo already rejected ({cachedRejectReason})");
+                        continue;
+                    }
 
                     if (dryRun)
                     {
@@ -778,12 +798,11 @@ public static class CorpusCommand
 
                     try
                     {
-                        using var hydrator = GitHubRestHydrator.CreateDefault(fixtures);
                         var hydrated = await hydrator.HydrateFromUrlAsync(url, ct);
                         await pipeline.NormalizeAsync(hydrated, source: "batch", tier: tier, ct: ct);
+                        await UpsertHydrationStatusAsync(db.Connection, candidateId, "Completed", null, hydrated, ct);
 
                         // Persist actual review comment count back to candidates so purge can use it
-                        var candidateId = $"{owner}/{repo}#{prNumber}";
                         using var updateCmd = db.Connection.CreateCommand();
                         updateCmd.CommandText = "UPDATE candidates SET review_comment_count = $count WHERE id = $id";
                         updateCmd.Parameters.AddWithValue("$count", hydrated.ReviewComments.Count);
@@ -799,6 +818,32 @@ public static class CorpusCommand
                     }
                     catch (Exception ex)
                     {
+                        var failureStatus = IsPermanentHydrationFailure(ex) ? "PermanentFailure" : "Failed";
+                        var repoRejectReason = failureStatus == "PermanentFailure"
+                            ? await hydrator.GetPermanentRepoRejectReasonAsync(owner, repo, ct)
+                            : null;
+
+                        await UpsertHydrationStatusAsync(
+                            db.Connection,
+                            candidateId,
+                            failureStatus,
+                            repoRejectReason is null ? ex.Message : $"{ex.Message} | repo reject: {repoRejectReason}",
+                            hydrated: null,
+                            ct);
+
+                        if (repoRejectReason is not null)
+                        {
+                            rejectedRepos[repoSpec] = repoRejectReason;
+                            await UpsertRepoRejectionAsync(
+                                db.Connection,
+                                owner,
+                                repo,
+                                repoRejectReason,
+                                source: "batch-hydrate",
+                                ct);
+                            Console.Error.WriteLine($"[corpus] Recorded repo reject {owner}/{repo}: {repoRejectReason}");
+                        }
+
                         Console.Error.WriteLine($"[corpus] Error hydrating {owner}/{repo}#{prNumber}: {ex.Message}");
                     }
                 }
@@ -821,7 +866,14 @@ public static class CorpusCommand
                 replace(replace(replace(lower(c.repo_owner), '/', '_'), '\', '_'), ' ', '-') || '_' ||
                 replace(replace(replace(lower(c.repo_name),  '/', '_'), '\', '_'), ' ', '-') || '_pr' || c.pr_number
             )
+            LEFT JOIN hydrations h
+                ON h.candidate_id = c.id
+            LEFT JOIN repo_rejections rr
+                ON rr.repo_owner = c.repo_owner
+               AND rr.repo_name = c.repo_name
             WHERE f.fixture_id IS NULL
+              AND rr.repo_owner IS NULL
+              AND COALESCE(h.status, 'Pending') NOT IN ('Completed', 'PermanentFailure')
             ORDER BY c.discovered_at_utc DESC
             LIMIT $limit
             """;
@@ -833,6 +885,74 @@ public static class CorpusCommand
             results.Add((reader.GetString(0), reader.GetString(1), reader.GetInt32(2)));
 
         return results;
+    }
+
+    private static bool IsPermanentHydrationFailure(Exception ex) =>
+        ex is HttpRequestException httpEx &&
+        httpEx.StatusCode is HttpStatusCode.NotFound
+            or HttpStatusCode.Gone
+            or HttpStatusCode.MovedPermanently;
+
+    private static async Task UpsertHydrationStatusAsync(
+        SqliteConnection conn,
+        string candidateId,
+        string status,
+        string? errorMessage,
+        HydratedPullRequest? hydrated,
+        CancellationToken ct)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO hydrations
+                (id, candidate_id, base_sha, head_sha, files_changed_count, additions, deletions, hydrated_at_utc, status, error_message)
+            VALUES
+                ($id, $candidateId, $baseSha, $headSha, $filesChangedCount, $additions, $deletions, datetime('now'), $status, $errorMessage)
+            ON CONFLICT(id) DO UPDATE SET
+                base_sha            = excluded.base_sha,
+                head_sha            = excluded.head_sha,
+                files_changed_count = excluded.files_changed_count,
+                additions           = excluded.additions,
+                deletions           = excluded.deletions,
+                hydrated_at_utc     = excluded.hydrated_at_utc,
+                status              = excluded.status,
+                error_message       = excluded.error_message
+            """;
+        cmd.Parameters.AddWithValue("$id", candidateId);
+        cmd.Parameters.AddWithValue("$candidateId", candidateId);
+        cmd.Parameters.AddWithValue("$baseSha",           (object?)hydrated?.BaseSha ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$headSha",           (object?)hydrated?.HeadSha ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$filesChangedCount", hydrated?.FilesChangedCount ?? 0);
+        cmd.Parameters.AddWithValue("$additions",         hydrated?.Additions ?? 0);
+        cmd.Parameters.AddWithValue("$deletions",         hydrated?.Deletions ?? 0);
+        cmd.Parameters.AddWithValue("$status", status);
+        cmd.Parameters.AddWithValue("$errorMessage", (object?)errorMessage ?? DBNull.Value);
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task UpsertRepoRejectionAsync(
+        SqliteConnection conn,
+        string owner,
+        string repo,
+        string reason,
+        string source,
+        CancellationToken ct)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO repo_rejections
+                (repo_owner, repo_name, reason, source)
+            VALUES
+                ($owner, $repo, $reason, $source)
+            ON CONFLICT(repo_owner, repo_name) DO UPDATE SET
+                reason                = excluded.reason,
+                source                = excluded.source,
+                last_rejected_at_utc  = datetime('now')
+            """;
+        cmd.Parameters.AddWithValue("$owner", owner);
+        cmd.Parameters.AddWithValue("$repo", repo);
+        cmd.Parameters.AddWithValue("$reason", reason);
+        cmd.Parameters.AddWithValue("$source", source);
+        await cmd.ExecuteNonQueryAsync(ct);
     }
 
     // ── gauntletci corpus run --fixture <id> ─────────────────────────────────
@@ -1428,9 +1548,26 @@ public static class CorpusCommand
             await db.InitializeAsync(ct);
             using (db)
             {
+                var rejectedRepos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                using (var rejectedCmd = db.Connection.CreateCommand())
+                {
+                    rejectedCmd.CommandText = "SELECT repo_owner || '/' || repo_name FROM repo_rejections";
+                    using var rejectedReader = await rejectedCmd.ExecuteReaderAsync(ct);
+                    while (await rejectedReader.ReadAsync(ct))
+                        rejectedRepos.Add(rejectedReader.GetString(0));
+                }
+
                 int inserted = 0;
+                int rejected = 0;
                 foreach (var c in candidates)
                 {
+                    var repoSpec = $"{c.RepoOwner}/{c.RepoName}";
+                    if (rejectedRepos.Contains(repoSpec))
+                    {
+                        rejected++;
+                        continue;
+                    }
+
                     var id = $"{c.RepoOwner}/{c.RepoName}#{c.PullRequestNumber}";
                     using var insertCmd = db.Connection.CreateCommand();
                     insertCmd.CommandText = """
@@ -1457,8 +1594,8 @@ public static class CorpusCommand
                     if (rows > 0) inserted++;
                 }
 
-                var skipped = candidates.Count - inserted;
-                Console.WriteLine($"[corpus/issues] Found {candidates.Count} candidates ({inserted} new, {skipped} already known)");
+                var skipped = candidates.Count - inserted - rejected;
+                Console.WriteLine($"[corpus/issues] Found {candidates.Count} candidates ({inserted} new, {skipped} already known, {rejected} rejected repo)");
             }
         });
 
@@ -1742,6 +1879,56 @@ public static class CorpusCommand
                 tx.Commit();
 
                 Console.WriteLine($"[corpus] purge: removed {removed} fixture(s) from DB and disk.");
+            }
+        });
+
+        return cmd;
+    }
+
+    // ── gauntletci corpus rejected-repos ──────────────────────────────────────
+
+    private static Command CreateRejectedRepos()
+    {
+        var dbOpt       = new Option<string>("--db", () => "./data/gauntletci-corpus.db", "Path to corpus SQLite database");
+        var namesOnlyOpt = new Option<bool>("--names-only", () => false, "Print only owner/repo names, one per line");
+
+        var cmd = new Command("rejected-repos", "List repositories permanently rejected during corpus hydration");
+        cmd.AddOption(dbOpt);
+        cmd.AddOption(namesOnlyOpt);
+
+        cmd.SetHandler(async (ctx) =>
+        {
+            var dbPath    = ctx.ParseResult.GetValueForOption(dbOpt)!;
+            var namesOnly = ctx.ParseResult.GetValueForOption(namesOnlyOpt);
+            var ct        = ctx.GetCancellationToken();
+
+            var db = new CorpusDb(dbPath);
+            await db.InitializeAsync(ct);
+            using (db)
+            {
+                using var listCmd = db.Connection.CreateCommand();
+                listCmd.CommandText = """
+                    SELECT repo_owner, repo_name, reason, source, first_rejected_at_utc, last_rejected_at_utc
+                    FROM repo_rejections
+                    ORDER BY repo_owner, repo_name
+                    """;
+
+                using var reader = await listCmd.ExecuteReaderAsync(ct);
+                while (await reader.ReadAsync(ct))
+                {
+                    var repoSpec = $"{reader.GetString(0)}/{reader.GetString(1)}";
+                    if (namesOnly)
+                    {
+                        Console.WriteLine(repoSpec);
+                        continue;
+                    }
+
+                    var reason    = reader.GetString(2);
+                    var source    = reader.GetString(3);
+                    var firstSeen = reader.GetString(4);
+                    var lastSeen  = reader.GetString(5);
+                    Console.WriteLine($"{repoSpec} | {reason} | source={source} | first={firstSeen} | last={lastSeen}");
+                }
             }
         });
 

--- a/src/GauntletCI.Corpus/Hydration/GitHubRestHydrator.cs
+++ b/src/GauntletCI.Corpus/Hydration/GitHubRestHydrator.cs
@@ -164,6 +164,47 @@ public sealed class GitHubRestHydrator : IPullRequestHydrator, IDisposable
         };
     }
 
+    /// <summary>
+    /// Checks whether the repository itself is permanently unsuitable for corpus hydration.
+    /// Returns a short reject reason for deleted, moved, or archived repositories; otherwise null.
+    /// </summary>
+    public async Task<string?> GetPermanentRepoRejectReasonAsync(
+        string owner, string repo, CancellationToken ct = default)
+    {
+        using var response = await _http.GetAsync($"https://api.github.com/repos/{owner}/{repo}", ct);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return "repo not found (deleted, private, or never existed)";
+
+        if (response.StatusCode == HttpStatusCode.Gone)
+            return "repo is gone";
+
+        if (response.StatusCode == HttpStatusCode.MovedPermanently || (int)response.StatusCode == 301)
+            return "repo has moved permanently (update allowlist with new owner/name)";
+
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("archived", out var archivedEl) && archivedEl.GetBoolean())
+            return "repo is archived";
+
+        if (root.TryGetProperty("full_name", out var fullNameEl))
+        {
+            var fullName = fullNameEl.GetString();
+            if (!string.IsNullOrWhiteSpace(fullName) &&
+                !string.Equals(fullName, $"{owner}/{repo}", StringComparison.OrdinalIgnoreCase))
+            {
+                return "repo has moved permanently (update allowlist with new owner/name)";
+            }
+        }
+
+        return null;
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private async Task<T> GetJsonAsync<T>(string url, CancellationToken ct)

--- a/src/GauntletCI.Corpus/Storage/CorpusDb.cs
+++ b/src/GauntletCI.Corpus/Storage/CorpusDb.cs
@@ -116,6 +116,16 @@ internal static class SchemaInitializer
             error_message       TEXT
         );
 
+        CREATE TABLE IF NOT EXISTS repo_rejections (
+            repo_owner           TEXT NOT NULL,
+            repo_name            TEXT NOT NULL,
+            reason               TEXT NOT NULL,
+            source               TEXT NOT NULL,
+            first_rejected_at_utc TEXT NOT NULL DEFAULT (datetime('now')),
+            last_rejected_at_utc  TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (repo_owner, repo_name)
+        );
+
         CREATE TABLE IF NOT EXISTS fixtures (
             id                  TEXT PRIMARY KEY,
             fixture_id          TEXT NOT NULL UNIQUE,

--- a/src/GauntletCI.Tests/Corpus/CorpusIngestionTests.cs
+++ b/src/GauntletCI.Tests/Corpus/CorpusIngestionTests.cs
@@ -516,4 +516,50 @@ public sealed class CandidateDeduplicationTests : IDisposable
 
         Assert.Equal(3, count);
     }
+
+    [Fact]
+    public async Task RepoRejectionsTable_UpsertByRepo_KeepsSingleRow()
+    {
+        const string upsertSql = """
+            INSERT INTO repo_rejections
+                (repo_owner, repo_name, reason, source)
+            VALUES
+                ($owner, $repo, $reason, $source)
+            ON CONFLICT(repo_owner, repo_name) DO UPDATE SET
+                reason               = excluded.reason,
+                source               = excluded.source,
+                last_rejected_at_utc = datetime('now')
+            """;
+
+        using (var cmd = _db.Connection.CreateCommand())
+        {
+            cmd.CommandText = upsertSql;
+            cmd.Parameters.AddWithValue("$owner", "dead");
+            cmd.Parameters.AddWithValue("$repo", "repo");
+            cmd.Parameters.AddWithValue("$reason", "repo not found");
+            cmd.Parameters.AddWithValue("$source", "batch-hydrate");
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        using (var cmd = _db.Connection.CreateCommand())
+        {
+            cmd.CommandText = upsertSql;
+            cmd.Parameters.AddWithValue("$owner", "dead");
+            cmd.Parameters.AddWithValue("$repo", "repo");
+            cmd.Parameters.AddWithValue("$reason", "repo is archived");
+            cmd.Parameters.AddWithValue("$source", "batch-hydrate");
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        using var countCmd = _db.Connection.CreateCommand();
+        countCmd.CommandText = "SELECT COUNT(*) FROM repo_rejections WHERE repo_owner='dead' AND repo_name='repo'";
+        var count = (long)(await countCmd.ExecuteScalarAsync())!;
+
+        using var reasonCmd = _db.Connection.CreateCommand();
+        reasonCmd.CommandText = "SELECT reason FROM repo_rejections WHERE repo_owner='dead' AND repo_name='repo'";
+        var reason = (string)(await reasonCmd.ExecuteScalarAsync())!;
+
+        Assert.Equal(1, count);
+        Assert.Equal("repo is archived", reason);
+    }
 }

--- a/src/GauntletCI.Tests/GitHubRestHydratorTests.cs
+++ b/src/GauntletCI.Tests/GitHubRestHydratorTests.cs
@@ -174,4 +174,64 @@ public class GitHubRestHydratorTests : IDisposable
         var commit = Assert.Single(result.Commits);
         Assert.Equal("def123", commit);
     }
+
+    [Fact]
+    public async Task GetPermanentRepoRejectReasonAsync_NotFoundRepo_ReturnsRejectReason()
+    {
+        using var handler = new FakeHttpHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        using var http = new HttpClient(handler);
+        http.DefaultRequestHeaders.Add("User-Agent", "GauntletCI-Test");
+
+        var store = new RawSnapshotStore(_tempDir);
+        using var sut = new GitHubRestHydrator(http, store);
+
+        var result = await sut.GetPermanentRepoRejectReasonAsync("missing", "repo");
+
+        Assert.Equal("repo not found (deleted, private, or never existed)", result);
+    }
+
+    [Fact]
+    public async Task GetPermanentRepoRejectReasonAsync_ArchivedRepo_ReturnsRejectReason()
+    {
+        using var handler = new FakeHttpHandler(_ => Ok("""{"full_name":"owner/repo","archived":true}"""));
+        using var http = new HttpClient(handler);
+        http.DefaultRequestHeaders.Add("User-Agent", "GauntletCI-Test");
+
+        var store = new RawSnapshotStore(_tempDir);
+        using var sut = new GitHubRestHydrator(http, store);
+
+        var result = await sut.GetPermanentRepoRejectReasonAsync("owner", "repo");
+
+        Assert.Equal("repo is archived", result);
+    }
+
+    [Fact]
+    public async Task GetPermanentRepoRejectReasonAsync_RenamedRepo_ReturnsRejectReason()
+    {
+        using var handler = new FakeHttpHandler(_ => Ok("""{"full_name":"new-owner/new-repo","archived":false}"""));
+        using var http = new HttpClient(handler);
+        http.DefaultRequestHeaders.Add("User-Agent", "GauntletCI-Test");
+
+        var store = new RawSnapshotStore(_tempDir);
+        using var sut = new GitHubRestHydrator(http, store);
+
+        var result = await sut.GetPermanentRepoRejectReasonAsync("old-owner", "old-repo");
+
+        Assert.Equal("repo has moved permanently (update allowlist with new owner/name)", result);
+    }
+
+    [Fact]
+    public async Task GetPermanentRepoRejectReasonAsync_HealthyRepo_ReturnsNull()
+    {
+        using var handler = new FakeHttpHandler(_ => Ok("""{"full_name":"owner/repo","archived":false}"""));
+        using var http = new HttpClient(handler);
+        http.DefaultRequestHeaders.Add("User-Agent", "GauntletCI-Test");
+
+        var store = new RawSnapshotStore(_tempDir);
+        using var sut = new GitHubRestHydrator(http, store);
+
+        var result = await sut.GetPermanentRepoRejectReasonAsync("owner", "repo");
+
+        Assert.Null(result);
+    }
 }


### PR DESCRIPTION
Record permanent repo-level hydration rejects, filter them out of future discovery and hydration runs, and replace dead allowlist entries so the corpus pipeline stops burning API budget on known-bad repositories.