### PR TITLE
[CLI] Add Ollama round-robin failover

### DIFF
--- a/build-corpus.ps1
+++ b/build-corpus.ps1
@@ -1,5 +1,5 @@
 ﻿# GauntletCI Corpus Pipeline Runner
-# Usage: .\build-corpus.ps1 [-Help] [-Provider "gh-search"] [-StartDate "2025-03-01"] [-EndDate "2025-03-31"] [-Limit 50] [-Language "C#"] [-MinComments 2] [-MinStars 500] [-Tier "discovery"] [-Db <path>] [-Fixtures <path>] [-Report <path>] [-SkipTo <step>] [-LlmLabel] [-LlmProvider "ollama"] [-LlmModel <name>] [-LlmUrl <url>] [-SkipSeedQueue]
+# Usage: .\build-corpus.ps1 [-Help] [-Provider "gh-search"] [-StartDate "2025-03-01"] [-EndDate "2025-03-31"] [-Limit 50] [-Language "C#"] [-MinComments 2] [-MinStars 500] [-Tier "discovery"] [-Db <path>] [-Fixtures <path>] [-Report <path>] [-SkipTo <step>] [-LlmLabel] [-LlmProvider "ollama"] [-LlmModel <name>] [-LlmUrl <url[]>] [-SkipSeedQueue]
 
 param(
     [switch] $Help,
@@ -24,7 +24,7 @@ param(
     [switch]$LlmLabel      = $false, # Enable Tier 3 LLM fallback during Step 4 / Step 8 label-all
     [string]$LlmProvider   = "ollama", # LLM provider for label-all: ollama | anthropic | github-models | none
     [string]$LlmModel      = "",    # Optional provider-specific model override for label-all
-    [string]$LlmUrl        = "http://10.0.0.5:11434/", # Ollama base URL for label-all
+    [string[]]$LlmUrl      = @("http://localhost:11434", "http://10.0.0.5:11434/"), # Ollama base URLs for label-all
     [switch]$SkipLabeler    = $false, # Skip launching the labeler Flask app after pipeline completes
     # Known game repositories and other low-signal repos to exclude from discovery.
     # Add owner/repo strings here to prevent them from entering the corpus.
@@ -139,7 +139,8 @@ if ($Help) {
     Write-Host "  -LlmLabel              Enable Tier 3 LLM fallback during Step 4 / Step 8 label-all"
     Write-Host "  -LlmProvider <name>    LLM provider for label-all: ollama | anthropic | github-models | none"
     Write-Host "  -LlmModel <name>       Optional model override for label-all"
-    Write-Host "  -LlmUrl <url>          Ollama base URL for label-all (default: http://10.0.0.5:11434/)"
+    Write-Host "  -LlmUrl <url[]>        Ollama base URL(s) for label-all. Repeat values to use multiple servers."
+    Write-Host "                         Defaults to: http://localhost:11434, http://10.0.0.5:11434/"
     Write-Host "  -SkipLabeler           Skip launching the labeler app after pipeline completes"
     Write-Host "  -SeedQueueLimit <n>    Max fired findings to queue for labeling (default: 150)"
     Write-Host "  -SeedQueueNonFired <n> Non-fired probe tasks per queue seed run (default: 30)"
@@ -220,8 +221,12 @@ function Get-LabelAllArgs {
         if ($LlmModel -ne "") {
             $labelArgs += "--llm-model", $LlmModel
         }
-        if ($LlmProvider -eq "ollama" -and $LlmUrl -ne "") {
-            $labelArgs += "--llm-url", $LlmUrl
+        if ($LlmProvider -eq "ollama") {
+            foreach ($url in $LlmUrl) {
+                if (-not [string]::IsNullOrWhiteSpace($url)) {
+                    $labelArgs += "--llm-url", $url
+                }
+            }
         }
     }
 

--- a/src/GauntletCI.Cli/Commands/CorpusCommand.cs
+++ b/src/GauntletCI.Cli/Commands/CorpusCommand.cs
@@ -1297,7 +1297,7 @@ public static class CorpusCommand
         var llmLabelOpt     = new Option<bool>  ("--llm-label",    () => false,       "Enable LLM-based Tier 3 labeling");
         var llmProviderOpt  = new Option<string>("--llm-provider", () => "ollama",    "LLM provider: ollama | anthropic | github-models | none");
         var llmModelOpt     = new Option<string>("--llm-model",    () => "",          "Model override (provider default used if empty)");
-        var llmUrlOpt       = new Option<string>("--llm-url",      () => "http://localhost:11434", "Ollama base URL");
+        var llmUrlOpt       = new Option<string[]>("--llm-url",    () => ["http://localhost:11434"], "Ollama base URL. Repeat the flag or pass a comma-separated list to use multiple servers.");
         var dbOpt           = new Option<string>("--db",           () => "./data/gauntletci-corpus.db", "Path to corpus SQLite database");
         var fixturesOpt     = new Option<string>("--fixtures",     () => "./data/fixtures",             "Path to fixtures root directory");
 
@@ -1320,7 +1320,7 @@ public static class CorpusCommand
             var llmLabel   = ctx.ParseResult.GetValueForOption(llmLabelOpt);
             var provider   = ctx.ParseResult.GetValueForOption(llmProviderOpt)!;
             var llmModel   = ctx.ParseResult.GetValueForOption(llmModelOpt)!;
-            var llmUrl     = ctx.ParseResult.GetValueForOption(llmUrlOpt)!;
+            var llmUrls    = NormalizeOllamaUrls(ctx.ParseResult.GetValueForOption(llmUrlOpt));
             var dbPath     = ctx.ParseResult.GetValueForOption(dbOpt)!;
             var fixtures   = ctx.ParseResult.GetValueForOption(fixturesOpt)!;
             var ct         = ctx.GetCancellationToken();
@@ -1336,18 +1336,19 @@ public static class CorpusCommand
             if (llmLabel)
             {
                 string? modelOverride = string.IsNullOrWhiteSpace(llmModel) ? null : llmModel;
-                string? urlOverride   = (provider == "ollama") ? llmUrl : null;
 
                 if (provider == "ollama")
                 {
-                    llmLabeler = await SetupOllamaLabelerAsync(modelOverride, urlOverride ?? llmUrl, ct);
+                    llmLabeler = await SetupOllamaLabelerAsync(modelOverride, llmUrls, ct);
                 }
                 else
                 {
-                    llmLabeler = LlmLabelerFactory.Create(provider, modelOverride, urlOverride);
+                    llmLabeler = LlmLabelerFactory.Create(provider, modelOverride, null);
                     Console.WriteLine($"[corpus] LLM labeling enabled via {provider}");
                 }
             }
+
+            using var llmLabelerLease = llmLabeler as IDisposable;
 
             var (db, store, _) = await BuildPipeline(dbPath, fixtures, ct);
             using (db)
@@ -1364,45 +1365,84 @@ public static class CorpusCommand
                 int skipped = 0;
                 int totalLabels = 0;
                 var engine = new SilverLabelEngine(store, llmLabeler);
+                var parallelism = GetLabelAllParallelism(llmLabel, provider, llmUrls.Count);
+                var consoleLock = new object();
 
-                foreach (var metadata in allFixtures)
+                if (parallelism > 1)
+                    Console.WriteLine($"[corpus] Parallel LLM labeling enabled: {parallelism} workers across {llmUrls.Count} Ollama endpoints.");
+
+                if (parallelism == 1)
                 {
-                    var fixturePath = FixtureIdHelper.GetFixturePath(fixtures, metadata.Tier, metadata.FixtureId);
-                    var diffPath    = Path.Combine(fixturePath, "diff.patch");
-
-                    if (!File.Exists(diffPath))
-                    {
-                        Console.WriteLine($"[corpus] SKIP {metadata.FixtureId,-40} — diff.patch not found");
-                        skipped++;
-                        continue;
-                    }
-
-                    try
-                    {
-                        var diffText      = await File.ReadAllTextAsync(diffPath, ct);
-                        var labelsWritten = await engine.ApplyToFixtureAsync(metadata.FixtureId, diffText, overwrite, ct);
-
-                        totalLabels += labelsWritten;
-                        labeled++;
-
-                        Console.WriteLine($"[corpus] OK   {metadata.FixtureId,-40} {labelsWritten,3} label(s)");
-
-                        if (verbose)
+                    foreach (var metadata in allFixtures)
+                        await ProcessFixtureAsync(metadata, ct);
+                }
+                else
+                {
+                    await Parallel.ForEachAsync(
+                        allFixtures,
+                        new ParallelOptions
                         {
-                            var labelDetails = await store.ReadExpectedFindingsAsync(metadata.FixtureId, ct);
-                            foreach (var label in labelDetails.OrderBy(l => l.RuleId))
-                                Console.WriteLine($"    {label.RuleId,-10}  {(label.ShouldTrigger ? "TRUE" : "false"),-6}  {label.LabelSource,-22}  {label.Reason}");
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.Error.WriteLine($"[corpus] ERR  {metadata.FixtureId}: {ex.Message}");
-                        skipped++;
-                    }
+                            MaxDegreeOfParallelism = parallelism,
+                            CancellationToken = ct,
+                        },
+                        ProcessFixtureAsync);
                 }
 
                 Console.WriteLine();
                 Console.WriteLine($"[corpus] label-all complete: {labeled} labeled, {skipped} skipped, {totalLabels} total labels written");
+
+                async ValueTask ProcessFixtureAsync(FixtureMetadata metadata, CancellationToken token)
+                {
+                    var fixturePath = FixtureIdHelper.GetFixturePath(fixtures, metadata.Tier, metadata.FixtureId);
+                    var diffPath    = Path.Combine(fixturePath, "diff.patch");
+                    var output      = new List<(bool IsError, string Line)>();
+
+                    if (!File.Exists(diffPath))
+                    {
+                        Interlocked.Increment(ref skipped);
+                        output.Add((false, $"[corpus] SKIP {metadata.FixtureId,-40} — diff.patch not found"));
+                        FlushOutput(output);
+                        return;
+                    }
+
+                    try
+                    {
+                        var diffText      = await File.ReadAllTextAsync(diffPath, token);
+                        var labelsWritten = await engine.ApplyToFixtureAsync(metadata.FixtureId, diffText, overwrite, token);
+
+                        Interlocked.Add(ref totalLabels, labelsWritten);
+                        Interlocked.Increment(ref labeled);
+                        output.Add((false, $"[corpus] OK   {metadata.FixtureId,-40} {labelsWritten,3} label(s)"));
+
+                        if (verbose)
+                        {
+                            var labelDetails = await store.ReadExpectedFindingsAsync(metadata.FixtureId, token);
+                            foreach (var label in labelDetails.OrderBy(l => l.RuleId))
+                                output.Add((false, $"    {label.RuleId,-10}  {(label.ShouldTrigger ? "TRUE" : "false"),-6}  {label.LabelSource,-22}  {label.Reason}"));
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Interlocked.Increment(ref skipped);
+                        output.Add((true, $"[corpus] ERR  {metadata.FixtureId}: {ex.Message}"));
+                    }
+
+                    FlushOutput(output);
+                }
+
+                void FlushOutput(IEnumerable<(bool IsError, string Line)> lines)
+                {
+                    lock (consoleLock)
+                    {
+                        foreach (var (isError, line) in lines)
+                        {
+                            if (isError)
+                                Console.Error.WriteLine(line);
+                            else
+                                Console.WriteLine(line);
+                        }
+                    }
+                }
             }
         });
 
@@ -2006,8 +2046,10 @@ public static class CorpusCommand
     /// Falls back to <see cref="NullLlmLabeler"/> with a console message on any failure.
     /// </summary>
     private static async Task<ILlmLabeler> SetupOllamaLabelerAsync(
-        string? modelOverride, string baseUrl, CancellationToken ct)
+        string? modelOverride, IReadOnlyList<string> baseUrls, CancellationToken ct)
     {
+        var normalizedUrls = NormalizeOllamaUrls(baseUrls);
+
         // 1. Hardware detection — pick best model if user didn't specify one
         var hw = HardwareProfile.Detect();
         var model = !string.IsNullOrWhiteSpace(modelOverride)
@@ -2017,47 +2059,108 @@ public static class CorpusCommand
         Console.WriteLine($"[corpus] Hardware: {hw.ToSummaryString()}");
         Console.WriteLine($"[corpus] Selected model: {model}{(modelOverride != null ? " (user-specified)" : " (auto-selected)")}");
 
-        // 2. Check Ollama is installed
-        if (!OllamaLlmLabeler.IsInstalled())
+        var hasOllamaCli = OllamaLlmLabeler.IsInstalled();
+        var readyEndpoints = new List<LlmEndpoint>();
+
+        foreach (var baseUrl in normalizedUrls)
         {
-            Console.Error.WriteLine("[corpus] Ollama is not installed. Install from https://ollama.com and re-run.");
+            var labeler = new OllamaLlmLabeler(model, baseUrl);
+            var isLocalEndpoint = IsLocalOllamaUrl(baseUrl);
+
+            if (!await labeler.IsServerRunningAsync(ct))
+            {
+                if (isLocalEndpoint && hasOllamaCli)
+                {
+                    Console.WriteLine($"[corpus] Ollama endpoint {baseUrl} not running — attempting to start...");
+                    if (!await labeler.TryStartServerAsync(ct: ct))
+                    {
+                        Console.Error.WriteLine($"[corpus] Could not start Ollama at {baseUrl}. Skipping endpoint.");
+                        labeler.Dispose();
+                        continue;
+                    }
+
+                    Console.WriteLine($"[corpus] Ollama endpoint {baseUrl} started.");
+                }
+                else
+                {
+                    Console.Error.WriteLine($"[corpus] Ollama endpoint unavailable: {baseUrl}. Skipping endpoint.");
+                    labeler.Dispose();
+                    continue;
+                }
+            }
+
+            if (!await labeler.IsModelAvailableAsync(ct))
+            {
+                if (isLocalEndpoint && hasOllamaCli)
+                {
+                    Console.WriteLine($"[corpus] Model '{model}' not found at {baseUrl} — pulling (this may take several minutes)...");
+                    var pulled = await labeler.TryPullModelAsync(
+                        line => Console.WriteLine($"         {line}"), ct);
+
+                    if (!pulled)
+                    {
+                        Console.Error.WriteLine($"[corpus] Failed to pull model '{model}' for {baseUrl}. Skipping endpoint.");
+                        labeler.Dispose();
+                        continue;
+                    }
+
+                    Console.WriteLine($"[corpus] Model '{model}' ready at {baseUrl}.");
+                }
+                else
+                {
+                    Console.Error.WriteLine($"[corpus] Model '{model}' is unavailable at {baseUrl}. Skipping endpoint.");
+                    labeler.Dispose();
+                    continue;
+                }
+            }
+
+            readyEndpoints.Add(new LlmEndpoint(baseUrl, labeler));
+        }
+
+        if (readyEndpoints.Count == 0)
+        {
+            Console.Error.WriteLine("[corpus] No Ollama endpoints are ready. Falling back to NullLlmLabeler.");
             return new NullLlmLabeler();
         }
 
-        var labeler = new OllamaLlmLabeler(model, baseUrl);
-
-        // 3. Ensure the server is running (try to auto-start if not)
-        if (!await labeler.IsServerRunningAsync(ct))
+        var enabledUrls = string.Join(", ", readyEndpoints.Select(e => e.Name));
+        if (readyEndpoints.Count == 1)
         {
-            Console.WriteLine("[corpus] Ollama server not running — attempting to start...");
-            if (!await labeler.TryStartServerAsync(ct: ct))
-            {
-                Console.Error.WriteLine("[corpus] Could not start Ollama server. Run 'ollama serve' in another terminal.");
-                labeler.Dispose();
-                return new NullLlmLabeler();
-            }
-            Console.WriteLine("[corpus] Ollama server started.");
+            Console.WriteLine($"[corpus] LLM labeling enabled via Ollama ({enabledUrls}, model: {model})");
+            return readyEndpoints[0].Labeler;
         }
 
-        // 4. Ensure model is pulled locally
-        if (!await labeler.IsModelAvailableAsync(ct))
-        {
-            Console.WriteLine($"[corpus] Model '{model}' not found locally — pulling (this may take several minutes)...");
-            var pulled = await labeler.TryPullModelAsync(
-                line => Console.WriteLine($"         {line}"), ct);
-
-            if (!pulled)
-            {
-                Console.Error.WriteLine($"[corpus] Failed to pull model '{model}'. Run 'ollama pull {model}' manually.");
-                labeler.Dispose();
-                return new NullLlmLabeler();
-            }
-            Console.WriteLine($"[corpus] Model '{model}' ready.");
-        }
-
-        Console.WriteLine($"[corpus] LLM labeling enabled via Ollama ({baseUrl}, model: {model})");
-        return labeler;
+        Console.WriteLine($"[corpus] LLM labeling enabled via Ollama ({readyEndpoints.Count} endpoints, model: {model})");
+        Console.WriteLine($"[corpus] Ollama endpoints: {enabledUrls}");
+        return new RoundRobinLlmLabeler(readyEndpoints);
     }
+
+    private static IReadOnlyList<string> NormalizeOllamaUrls(IEnumerable<string>? rawUrls)
+    {
+        var normalized = (rawUrls ?? [])
+            .SelectMany(url => (url ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Where(url => !string.IsNullOrWhiteSpace(url))
+            .Select(url => url.Trim().TrimEnd('/'))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return normalized.Length > 0 ? normalized : ["http://localhost:11434"];
+    }
+
+    private static bool IsLocalOllamaUrl(string baseUrl)
+    {
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri))
+            return false;
+
+        return uri.IsLoopback
+            || uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.Equals(Environment.MachineName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int GetLabelAllParallelism(bool llmLabel, string provider, int ollamaUrlCount)
+        => llmLabel && provider.Equals("ollama", StringComparison.OrdinalIgnoreCase)
+            ? Math.Max(1, ollamaUrlCount)
+            : 1;
 
     private static void PrintMetadata(GauntletCI.Corpus.Models.FixtureMetadata m)
     {

--- a/src/GauntletCI.Cli/Commands/CorpusCommand.cs
+++ b/src/GauntletCI.Cli/Commands/CorpusCommand.cs
@@ -1333,13 +1333,14 @@ public static class CorpusCommand
             }
 
             ILlmLabeler llmLabeler = new NullLlmLabeler();
+            int readyEndpointCount = 0;
             if (llmLabel)
             {
                 string? modelOverride = string.IsNullOrWhiteSpace(llmModel) ? null : llmModel;
 
                 if (provider == "ollama")
                 {
-                    llmLabeler = await SetupOllamaLabelerAsync(modelOverride, llmUrls, ct);
+                    (llmLabeler, readyEndpointCount) = await SetupOllamaLabelerAsync(modelOverride, llmUrls, ct);
                 }
                 else
                 {
@@ -1365,11 +1366,11 @@ public static class CorpusCommand
                 int skipped = 0;
                 int totalLabels = 0;
                 var engine = new SilverLabelEngine(store, llmLabeler);
-                var parallelism = GetLabelAllParallelism(llmLabel, provider, llmUrls.Count);
+                var parallelism = GetLabelAllParallelism(llmLabel, provider, readyEndpointCount);
                 var consoleLock = new object();
 
                 if (parallelism > 1)
-                    Console.WriteLine($"[corpus] Parallel LLM labeling enabled: {parallelism} workers across {llmUrls.Count} Ollama endpoints.");
+                    Console.WriteLine($"[corpus] Parallel LLM labeling enabled: {parallelism} workers across {readyEndpointCount} Ollama endpoints.");
 
                 if (parallelism == 1)
                 {
@@ -1408,7 +1409,7 @@ public static class CorpusCommand
                     try
                     {
                         var diffText      = await File.ReadAllTextAsync(diffPath, token);
-                        var labelsWritten = await engine.ApplyToFixtureAsync(metadata.FixtureId, diffText, overwrite, token);
+                        var labelsWritten = await engine.ApplyToFixtureAsync(metadata.FixtureId, diffText, overwrite, token, line => output.Add((false, line)));
 
                         Interlocked.Add(ref totalLabels, labelsWritten);
                         Interlocked.Increment(ref labeled);
@@ -2045,7 +2046,7 @@ public static class CorpusCommand
     /// pulls the model if needed, and returns a ready <see cref="ILlmLabeler"/>.
     /// Falls back to <see cref="NullLlmLabeler"/> with a console message on any failure.
     /// </summary>
-    private static async Task<ILlmLabeler> SetupOllamaLabelerAsync(
+    private static async Task<(ILlmLabeler Labeler, int ReadyCount)> SetupOllamaLabelerAsync(
         string? modelOverride, IReadOnlyList<string> baseUrls, CancellationToken ct)
     {
         var normalizedUrls = NormalizeOllamaUrls(baseUrls);
@@ -2120,19 +2121,19 @@ public static class CorpusCommand
         if (readyEndpoints.Count == 0)
         {
             Console.Error.WriteLine("[corpus] No Ollama endpoints are ready. Falling back to NullLlmLabeler.");
-            return new NullLlmLabeler();
+            return (new NullLlmLabeler(), 0);
         }
 
         var enabledUrls = string.Join(", ", readyEndpoints.Select(e => e.Name));
         if (readyEndpoints.Count == 1)
         {
             Console.WriteLine($"[corpus] LLM labeling enabled via Ollama ({enabledUrls}, model: {model})");
-            return readyEndpoints[0].Labeler;
+            return (readyEndpoints[0].Labeler, 1);
         }
 
         Console.WriteLine($"[corpus] LLM labeling enabled via Ollama ({readyEndpoints.Count} endpoints, model: {model})");
         Console.WriteLine($"[corpus] Ollama endpoints: {enabledUrls}");
-        return new RoundRobinLlmLabeler(readyEndpoints);
+        return (new RoundRobinLlmLabeler(readyEndpoints), readyEndpoints.Count);
     }
 
     private static IReadOnlyList<string> NormalizeOllamaUrls(IEnumerable<string>? rawUrls)

--- a/src/GauntletCI.Corpus/Labeling/OllamaLlmLabeler.cs
+++ b/src/GauntletCI.Corpus/Labeling/OllamaLlmLabeler.cs
@@ -28,6 +28,8 @@ public sealed class OllamaLlmLabeler : ILlmLabeler, IDisposable
             new MediaTypeWithQualityHeaderValue("application/json"));
     }
 
+    public string BaseUrl => _baseUrl;
+
     // -----------------------------------------------------------------------
     // Readiness checks
     // -----------------------------------------------------------------------

--- a/src/GauntletCI.Corpus/Labeling/OllamaLlmLabeler.cs
+++ b/src/GauntletCI.Corpus/Labeling/OllamaLlmLabeler.cs
@@ -28,7 +28,6 @@ public sealed class OllamaLlmLabeler : ILlmLabeler, IDisposable
             new MediaTypeWithQualityHeaderValue("application/json"));
     }
 
-    public string BaseUrl => _baseUrl;
 
     // -----------------------------------------------------------------------
     // Readiness checks

--- a/src/GauntletCI.Corpus/Labeling/RoundRobinLlmLabeler.cs
+++ b/src/GauntletCI.Corpus/Labeling/RoundRobinLlmLabeler.cs
@@ -63,7 +63,8 @@ public sealed class RoundRobinLlmLabeler : ILlmLabeler, IDisposable
         string diffSnippet,
         CancellationToken ct = default)
     {
-        var startIndex = Math.Abs(Interlocked.Increment(ref _nextIndex));
+        // Cast to uint before modulo to avoid OverflowException when _nextIndex wraps to int.MinValue.
+        var startIndex = (int)((uint)Interlocked.Increment(ref _nextIndex) % (uint)_endpoints.Count);
         var attemptedHealthyEndpoint = false;
 
         for (var offset = 0; offset < _endpoints.Count; offset++)
@@ -132,6 +133,8 @@ public sealed class RoundRobinLlmLabeler : ILlmLabeler, IDisposable
                 return false;
 
             state.DisabledUntilUtc = DateTime.UtcNow.Add(_cooldown);
+            // Reset so the endpoint gets a full failure window after cooldown expires.
+            state.ConsecutiveFailures = 0;
             return true;
         }
     }

--- a/src/GauntletCI.Corpus/Labeling/RoundRobinLlmLabeler.cs
+++ b/src/GauntletCI.Corpus/Labeling/RoundRobinLlmLabeler.cs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Labeling;
+
+public sealed record LlmEndpoint(string Name, ILlmLabeler Labeler);
+
+/// <summary>
+/// Distributes LLM classification requests across multiple underlying labelers while
+/// failing over when one endpoint returns no result. Repeatedly unhealthy endpoints are
+/// temporarily removed from rotation and retried after a cooldown.
+/// </summary>
+public sealed class RoundRobinLlmLabeler : ILlmLabeler, IDisposable
+{
+    private sealed class EndpointState(LlmEndpoint endpoint)
+    {
+        public LlmEndpoint Endpoint { get; } = endpoint;
+        public object SyncRoot { get; } = new();
+        public int ConsecutiveFailures { get; set; }
+        public DateTime DisabledUntilUtc { get; set; }
+    }
+
+    private readonly IReadOnlyList<EndpointState> _endpoints;
+    private readonly IReadOnlyList<IDisposable> _disposables;
+    private readonly TimeSpan _cooldown;
+    private readonly int _failureThreshold;
+    private int _nextIndex = -1;
+
+    public RoundRobinLlmLabeler(
+        IEnumerable<LlmEndpoint> endpoints,
+        int failureThreshold = 3,
+        TimeSpan? cooldown = null)
+    {
+        if (failureThreshold < 1)
+            throw new ArgumentOutOfRangeException(nameof(failureThreshold), "Failure threshold must be at least 1.");
+
+        _endpoints = (endpoints ?? throw new ArgumentNullException(nameof(endpoints)))
+            .Select(endpoint => new EndpointState(endpoint))
+            .ToArray();
+
+        if (_endpoints.Count == 0)
+            throw new ArgumentException("At least one labeler is required.", nameof(endpoints));
+
+        _disposables = _endpoints
+            .Select(state => state.Endpoint.Labeler)
+            .OfType<IDisposable>()
+            .ToArray();
+
+        _failureThreshold = failureThreshold;
+        _cooldown = cooldown ?? TimeSpan.FromMinutes(1);
+    }
+
+    public RoundRobinLlmLabeler(IEnumerable<ILlmLabeler> labelers)
+        : this((labelers ?? throw new ArgumentNullException(nameof(labelers)))
+            .Select((labeler, index) => new LlmEndpoint($"endpoint-{index + 1}", labeler)))
+    {
+    }
+
+    public async Task<LlmLabelResult?> ClassifyAsync(
+        string ruleId,
+        string findingMessage,
+        string evidence,
+        string? filePath,
+        IEnumerable<string> reviewCommentBodies,
+        string diffSnippet,
+        CancellationToken ct = default)
+    {
+        var startIndex = Math.Abs(Interlocked.Increment(ref _nextIndex));
+        var attemptedHealthyEndpoint = false;
+
+        for (var offset = 0; offset < _endpoints.Count; offset++)
+        {
+            var endpointIndex = (startIndex + offset) % _endpoints.Count;
+            var state = _endpoints[endpointIndex];
+            if (!IsAvailable(state, DateTime.UtcNow))
+                continue;
+
+            attemptedHealthyEndpoint = true;
+            var result = await state.Endpoint.Labeler.ClassifyAsync(
+                ruleId,
+                findingMessage,
+                evidence,
+                filePath,
+                reviewCommentBodies,
+                diffSnippet,
+                ct);
+
+            if (result is not null)
+            {
+                RegisterSuccess(state);
+                return result;
+            }
+
+            if (RegisterFailure(state))
+            {
+                Console.Error.WriteLine(
+                    $"[llm] Endpoint {state.Endpoint.Name} disabled for {_cooldown.TotalSeconds:0}s after {_failureThreshold} consecutive failures.");
+            }
+        }
+
+        if (!attemptedHealthyEndpoint)
+        {
+            var nextRetryAt = _endpoints
+                .Select(state =>
+                {
+                    lock (state.SyncRoot)
+                    {
+                        return state.DisabledUntilUtc;
+                    }
+                })
+                .Min();
+
+            Console.Error.WriteLine(
+                $"[llm] All endpoints are temporarily disabled. Next retry after {nextRetryAt:O}.");
+        }
+
+        return null;
+    }
+
+    private static bool IsAvailable(EndpointState state, DateTime nowUtc)
+    {
+        lock (state.SyncRoot)
+        {
+            return state.DisabledUntilUtc <= nowUtc;
+        }
+    }
+
+    private bool RegisterFailure(EndpointState state)
+    {
+        lock (state.SyncRoot)
+        {
+            state.ConsecutiveFailures++;
+            if (state.ConsecutiveFailures < _failureThreshold || state.DisabledUntilUtc > DateTime.UtcNow)
+                return false;
+
+            state.DisabledUntilUtc = DateTime.UtcNow.Add(_cooldown);
+            return true;
+        }
+    }
+
+    private static void RegisterSuccess(EndpointState state)
+    {
+        lock (state.SyncRoot)
+        {
+            state.ConsecutiveFailures = 0;
+            state.DisabledUntilUtc = DateTime.MinValue;
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var disposable in _disposables)
+            disposable.Dispose();
+    }
+}

--- a/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
+++ b/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
@@ -125,7 +125,7 @@ public sealed class SilverLabelEngine
     /// </summary>
     /// <returns>Total number of labels written to <c>expected.json</c>.</returns>
     public async Task<int> ApplyToFixtureAsync(
-        string fixtureId, string diffText, bool overwriteExisting = false, CancellationToken ct = default)
+        string fixtureId, string diffText, bool overwriteExisting = false, CancellationToken ct = default, Action<string>? log = null)
     {
         // ── Tier 1: Diff + comment heuristics ────────────────────────────────
         var inferred = (await InferLabelsAsync(fixtureId, diffText, ct)).ToList();
@@ -211,7 +211,7 @@ public sealed class SilverLabelEngine
                 if (positiveRuleIdsAfterTier12.Contains(finding.RuleId)) continue;
 
                 var diffSnippet = ExtractFileDiffHunk(diffText, finding.FilePath);
-                Console.WriteLine($"  [llm] Tier 3 calling {_llmLabeler.GetType().Name} for rule {finding.RuleId}");
+                (log ?? Console.WriteLine)($"  [llm] Tier 3 calling {_llmLabeler.GetType().Name} for rule {finding.RuleId}");
 
                 var result = await _llmLabeler.ClassifyAsync(
                     finding.RuleId,

--- a/src/GauntletCI.Tests/RoundRobinLlmLabelerTests.cs
+++ b/src/GauntletCI.Tests/RoundRobinLlmLabelerTests.cs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Labeling;
+using GauntletCI.Corpus.Interfaces;
+
+namespace GauntletCI.Tests;
+
+public sealed class RoundRobinLlmLabelerTests
+{
+    // Fake labeler that returns a fixed result or null, and tracks call order.
+    private sealed class FakeLabeler(LlmLabelResult? returnValue = null) : ILlmLabeler
+    {
+        public int CallCount { get; private set; }
+        public string Name { get; init; } = "fake";
+
+        public Task<LlmLabelResult?> ClassifyAsync(
+            string ruleId, string findingMessage, string evidence,
+            string? filePath, IEnumerable<string> reviewCommentBodies,
+            string diffSnippet, CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromResult(returnValue);
+        }
+    }
+
+    private static LlmLabelResult SomeResult() =>
+        new(true, 0.9, "test", false);
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Round-robin rotation
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Calls_endpoints_in_round_robin_order()
+    {
+        var a = new FakeLabeler(SomeResult()) { Name = "a" };
+        var b = new FakeLabeler(SomeResult()) { Name = "b" };
+        var c = new FakeLabeler(SomeResult()) { Name = "c" };
+
+        var rr = new RoundRobinLlmLabeler(
+        [
+            new LlmEndpoint("a", a),
+            new LlmEndpoint("b", b),
+            new LlmEndpoint("c", c),
+        ]);
+
+        // Six calls → each endpoint gets exactly 2 turns.
+        for (var i = 0; i < 6; i++)
+            await rr.ClassifyAsync("GCI0001", "", "", null, [], "", default);
+
+        Assert.Equal(2, a.CallCount);
+        Assert.Equal(2, b.CallCount);
+        Assert.Equal(2, c.CallCount);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Disable-after-threshold
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Disables_endpoint_after_consecutive_failures()
+    {
+        var bad  = new FakeLabeler(null) { Name = "bad" };   // always fails
+        var good = new FakeLabeler(SomeResult()) { Name = "good" };
+
+        // threshold=2: bad is disabled after 2 consecutive failures.
+        // With 2 endpoints, bad is tried on startIndex=0 calls (odd iterations).
+        // 3 calls → bad is tried on calls 1 and 3 → 2 failures → disabled.
+        var rr = new RoundRobinLlmLabeler(
+        [
+            new LlmEndpoint("bad",  bad),
+            new LlmEndpoint("good", good),
+        ],
+        failureThreshold: 2,
+        cooldown: TimeSpan.FromHours(1));
+
+        for (var i = 0; i < 3; i++)
+        {
+            var result = await rr.ClassifyAsync("GCI0001", "", "", null, [], "", default);
+            Assert.NotNull(result);  // good always rescues
+        }
+
+        // bad should now be disabled for 1 hour.
+        var badCallsBefore = bad.CallCount;
+        for (var i = 0; i < 10; i++)
+            await rr.ClassifyAsync("GCI0001", "", "", null, [], "", default);
+
+        Assert.Equal(badCallsBefore, bad.CallCount);  // bad received no further calls
+        Assert.True(good.CallCount > badCallsBefore);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // ConsecutiveFailures reset on disable — endpoint gets full window on re-entry
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Resets_consecutive_failures_on_disable()
+    {
+        // Use a very short cooldown so we can test re-entry in-process.
+        var bad  = new FakeLabeler(null) { Name = "bad" };
+        var good = new FakeLabeler(SomeResult()) { Name = "good" };
+
+        // threshold=2; drive bad to disable via 3 calls (bad hit on calls 1 and 3).
+        var rr = new RoundRobinLlmLabeler(
+        [
+            new LlmEndpoint("bad",  bad),
+            new LlmEndpoint("good", good),
+        ],
+        failureThreshold: 2,
+        cooldown: TimeSpan.FromMilliseconds(50));
+
+        for (var i = 0; i < 3; i++)
+            await rr.ClassifyAsync("GCI0001", "", "", null, [], "", default);
+
+        var badCallsAfterDisable = bad.CallCount;
+
+        // Wait for cooldown to expire, then make one more call.
+        // If ConsecutiveFailures was NOT reset on disable, bad would be disabled
+        // immediately again on the first null result (counter still >= threshold).
+        // With the fix, bad.CF was reset to 0 on disable, so it gets a full
+        // threshold window before being disabled again.
+        await Task.Delay(100);
+
+        // Make 2 calls — the round-robin counter alternates between index 0 (bad)
+        // and index 1 (good), so at least one of the two will route through bad.
+        await rr.ClassifyAsync("GCI0001", "", "", null, [], "", default);
+        await rr.ClassifyAsync("GCI0001", "", "", null, [], "", default);
+
+        // bad should have been called at least once (it re-entered rotation).
+        Assert.True(bad.CallCount > badCallsAfterDisable,
+            "bad endpoint should have been called at least once after cooldown expired");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // All endpoints disabled → returns null
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Returns_null_when_all_endpoints_disabled()
+    {
+        var bad = new FakeLabeler(null) { Name = "bad" };
+
+        var rr = new RoundRobinLlmLabeler(
+        [
+            new LlmEndpoint("bad", bad),
+        ],
+        failureThreshold: 1,
+        cooldown: TimeSpan.FromHours(1));
+
+        // First call disables the only endpoint; result is null (no healthy fallback).
+        var first = await rr.ClassifyAsync("GCI0001", "", "", null, [], "", default);
+        Assert.Null(first);
+
+        // Second call — all disabled; should return null immediately.
+        var second = await rr.ClassifyAsync("GCI0001", "", "", null, [], "", default);
+        Assert.Null(second);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // No overflow on int.MinValue wrap-around
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Does_not_throw_when_internal_counter_wraps_around()
+    {
+        var labeler = new FakeLabeler(SomeResult());
+        var rr = new RoundRobinLlmLabeler([ new LlmEndpoint("e", labeler) ]);
+
+        // Force _nextIndex close to int.MaxValue by reflection so the very
+        // next Increment wraps to int.MinValue, previously triggering Math.Abs overflow.
+        var field = typeof(RoundRobinLlmLabeler)
+            .GetField("_nextIndex", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        field.SetValue(rr, int.MaxValue - 1);
+
+        var exception = await Record.ExceptionAsync(
+            () => rr.ClassifyAsync("GCI0001", "", "", null, [], "", default));
+
+        Assert.Null(exception);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // IDisposable — disposes underlying labelers that implement IDisposable
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Dispose_disposes_underlying_labelers()
+    {
+        var disposableLabeler = new DisposableFakeLabeler();
+        var rr = new RoundRobinLlmLabeler([ new LlmEndpoint("e", disposableLabeler) ]);
+        rr.Dispose();
+        Assert.True(disposableLabeler.Disposed);
+    }
+
+    private sealed class DisposableFakeLabeler : ILlmLabeler, IDisposable
+    {
+        public bool Disposed { get; private set; }
+        public void Dispose() => Disposed = true;
+        public Task<LlmLabelResult?> ClassifyAsync(string ruleId, string findingMessage,
+            string evidence, string? filePath, IEnumerable<string> reviewCommentBodies,
+            string diffSnippet, CancellationToken ct = default)
+            => Task.FromResult<LlmLabelResult?>(null);
+    }
+}

--- a/src/GauntletCI.Tests/Rules/GCI0004Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0004Tests.cs
@@ -95,4 +95,66 @@ public class GCI0004Tests
             f.Summary.Contains("Calculate") &&
             f.Confidence == Confidence.Medium);
     }
+
+    [Fact]
+    public async Task OnlyAddedPublicMethod_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/Calculator.cs b/src/Calculator.cs
+            index abc..def 100644
+            --- a/src/Calculator.cs
+            +++ b/src/Calculator.cs
+            @@ -1,2 +1,3 @@
+             // calculator
+            +public int Add(int x, int y)
+             // end
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("Public API removed"));
+    }
+
+    [Fact]
+    public async Task RemovedPrivateMethod_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/Calculator.cs b/src/Calculator.cs
+            index abc..def 100644
+            --- a/src/Calculator.cs
+            +++ b/src/Calculator.cs
+            @@ -1,3 +1,2 @@
+             // calculator
+            -private void ComputeInternal(int x)
+             // end
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task SamePublicSignatureRemovedAndReadded_ShouldNotFlag()
+    {
+        // Same name AND same content re-added (e.g., just moved within file).
+        var raw = """
+            diff --git a/src/Service.cs b/src/Service.cs
+            index abc..def 100644
+            --- a/src/Service.cs
+            +++ b/src/Service.cs
+            @@ -1,3 +1,3 @@
+             // service
+            -public void Execute(int id)
+            +public void Execute(int id)
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("Public API removed"));
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("Public API signature changed"));
+    }
 }


### PR DESCRIPTION
## Summary
- let `corpus label-all` accept multiple `--llm-url` values for Ollama
- add a health-aware round-robin labeler that temporarily ejects failing endpoints and retries them after a cooldown
- parallelize LLM-backed `label-all` work so multiple Ollama servers can actually improve throughput
- update `build-corpus.ps1` to forward multiple Ollama URLs and default to both local and remote endpoints

## What this changes
This turns the prior single-endpoint Ollama path into a small endpoint pool. `label-all` now normalizes repeated or comma-separated URLs, probes each endpoint, uses the healthy ones, and distributes work across them. If one endpoint starts returning null results repeatedly, it is removed from rotation for a cooldown period instead of slowing every request.

## Validation
- `dotnet build GauntletCI.slnx -v quiet --nologo`
- `dotnet test GauntletCI.slnx --no-build --nologo -q -m:1`
- `powershell -File .\build-corpus.ps1 -Help`
- `dotnet run --project src\GauntletCI.Cli --no-build -- corpus label-all --help`

## Follow-up
This PR wires multi-endpoint failover and concurrency, but it does not yet include a dedicated throughput benchmark comparing one Ollama endpoint vs multiple endpoints.