### PR TITLE
[INFRA] Fix 3 critical audit findings

### DIFF
--- a/src/GauntletCI.Cli/Commands/CorpusCommand.cs
+++ b/src/GauntletCI.Cli/Commands/CorpusCommand.cs
@@ -611,6 +611,8 @@ public static class CorpusCommand
                 return;
             }
 
+            using var providerLifetime = provider as IDisposable;
+
             var languages = string.IsNullOrWhiteSpace(language)
                 ? Array.Empty<string>()
                 : new[] { language };

--- a/src/GauntletCI.Cli/Telemetry/TelemetryStore.cs
+++ b/src/GauntletCI.Cli/Telemetry/TelemetryStore.cs
@@ -105,7 +105,8 @@ public static class TelemetryStore
         try
         {
             acquired = mutex.WaitOne(TimeSpan.FromSeconds(10));
-            action();
+            if (acquired)
+                action();
         }
         finally
         {

--- a/src/GauntletCI.Corpus/Discovery/GitHubSearchDiscoveryProvider.cs
+++ b/src/GauntletCI.Corpus/Discovery/GitHubSearchDiscoveryProvider.cs
@@ -6,7 +6,7 @@ using GauntletCI.Corpus.Models;
 
 namespace GauntletCI.Corpus.Discovery;
 
-public sealed class GitHubSearchDiscoveryProvider : IDiscoveryProvider
+public sealed class GitHubSearchDiscoveryProvider : IDiscoveryProvider, IDisposable
 {
     private const int ThrottleThreshold = 5;
 
@@ -29,6 +29,8 @@ public sealed class GitHubSearchDiscoveryProvider : IDiscoveryProvider
         _http.DefaultRequestHeaders.Add("Accept", "application/vnd.github+json");
         _errorCallback = errorCallback;
     }
+
+    public void Dispose() => _http.Dispose();
 
     public string GetProviderName() => "gh-search";
 

--- a/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
+++ b/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
@@ -36,8 +36,8 @@ public sealed class SilverLabelEngine
     /// </summary>
     public static readonly IReadOnlySet<string> RulesWithHeuristics = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
-        "GCI0003", "GCI0004", "GCI0006", "GCI0007",
-        "GCI0010", "GCI0016", "GCI0021", "GCI0023",
+        "GCI0003", "GCI0004", "GCI0006", "GCI0010",
+        "GCI0012", "GCI0016", "GCI0021", "GCI0023",
     };
 
     // Review comment keyword -> (ruleId, reason, confidence) mapping
@@ -58,7 +58,7 @@ public sealed class SilverLabelEngine
         (["thread safe", "thread-safe", "race condition", "concurrent", "lock"],
             "GCI0016", "Review comment mentions thread safety concern", 0.6),
         (["secret", "password", "credential", "api key", "api_key"],
-            "GCI0007", "Review comment mentions credential/secret concern", 0.75),
+            "GCI0012", "Review comment mentions credential/secret concern", 0.75),
         (["large file", "file size", "binary file", "binary blob"],
             "GCI0022", "Review comment mentions large or binary file", 0.6),
         (["migration", "schema change", "db migration", "database migration"],
@@ -278,12 +278,12 @@ public sealed class SilverLabelEngine
             labels.Add(MakeLabel("GCI0016", "Diff contains .Result or .Wait() on added lines (sync-over-async)", 0.6));
         }
 
-        // GCI0007 -- Secret/credential exposure
+        // GCI0012 -- Secret/credential exposure
         // Tightened: exclude CancellationToken, require assignment to literal string value
         // to avoid flagging benign token/password parameter names.
         if (addedLines.Any(IsCredentialAssignment))
         {
-            labels.Add(MakeLabel("GCI0007", "Diff contains credential keyword assigned to a literal string value on added lines", 0.7));
+            labels.Add(MakeLabel("GCI0012", "Diff contains credential keyword assigned to a literal string value on added lines", 0.7));
         }
 
         // GCI0003 -- Empty catch block

--- a/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
+++ b/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
@@ -37,7 +37,7 @@ public sealed class SilverLabelEngine
     public static readonly IReadOnlySet<string> RulesWithHeuristics = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
         "GCI0003", "GCI0004", "GCI0006", "GCI0010",
-        "GCI0012", "GCI0016", "GCI0021", "GCI0023",
+        "GCI0012", "GCI0016", "GCI0021", "GCI0022", "GCI0023",
     };
 
     // Review comment keyword -> (ruleId, reason, confidence) mapping

--- a/src/GauntletCI.Tests/SilverLabelEngineTests.cs
+++ b/src/GauntletCI.Tests/SilverLabelEngineTests.cs
@@ -174,7 +174,7 @@ public sealed class SilverLabelEngineTests
         var expected = new[]
         {
             "GCI0003", "GCI0004", "GCI0006", "GCI0010",
-            "GCI0012", "GCI0016", "GCI0021", "GCI0023",
+            "GCI0012", "GCI0016", "GCI0021", "GCI0022", "GCI0023",
         };
 
         // Assert — every expected rule is present and the set is exactly this size

--- a/src/GauntletCI.Tests/SilverLabelEngineTests.cs
+++ b/src/GauntletCI.Tests/SilverLabelEngineTests.cs
@@ -75,7 +75,7 @@ public sealed class SilverLabelEngineTests
     }
 
     [Fact]
-    public async Task InferLabelsFromComments_CommentMentioningSecret_EmitsGCI0007Label()
+    public async Task InferLabelsFromComments_CommentMentioningSecret_EmitsGCI0012Label()
     {
         // Arrange
         var json = CommentsJson("Are you sure you want to commit this password here?");
@@ -84,7 +84,7 @@ public sealed class SilverLabelEngineTests
         var labels = await _engine.InferLabelsFromCommentsAsync(json);
 
         // Assert
-        var label = Assert.Single(labels, l => l.RuleId == "GCI0007");
+        var label = Assert.Single(labels, l => l.RuleId == "GCI0012");
         Assert.True(label.ShouldTrigger);
     }
 
@@ -173,8 +173,8 @@ public sealed class SilverLabelEngineTests
         // Arrange
         var expected = new[]
         {
-            "GCI0003", "GCI0004", "GCI0006", "GCI0007",
-            "GCI0010", "GCI0016", "GCI0021", "GCI0023",
+            "GCI0003", "GCI0004", "GCI0006", "GCI0010",
+            "GCI0012", "GCI0016", "GCI0021", "GCI0023",
         };
 
         // Assert — every expected rule is present and the set is exactly this size
@@ -222,7 +222,7 @@ public sealed class SilverLabelEngineTests
     }
 
     [Fact]
-    public async Task InferLabels_DiffWithCredentialAssignment_EmitsGCI0007Label()
+    public async Task InferLabels_DiffWithCredentialAssignment_EmitsGCI0012Label()
     {
         // Arrange — added line assigns a literal string to a credential keyword variable
         var diff = """
@@ -236,7 +236,7 @@ public sealed class SilverLabelEngineTests
         var labels = await _engine.InferLabelsAsync("fix-001", diff);
 
         // Assert
-        Assert.Contains(labels, l => l.RuleId == "GCI0007" && l.ShouldTrigger);
+        Assert.Contains(labels, l => l.RuleId == "GCI0012" && l.ShouldTrigger);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Three correctness bugs identified during a full codebase audit against core engineering invariants.

## Fixes

### 1. TelemetryStore — mutex timeout not guarding action
WithMutex() called ction() unconditionally after mutex.WaitOne(). If WaitOne timed out (returned false), the action still ran without the cross-process lock — two processes could simultaneously Load→Add→Save with last writer winning.
**Fix:** Wrap ction() in if (acquired) guard.

### 2. GitHubSearchDiscoveryProvider — HttpClient leak
HttpClient _http was constructed in the constructor and stored as a field, but the class never implemented IDisposable. Socket leak on every corpus discovery run.
**Fix:** Implement IDisposable, dispose _http.

### 3. SilverLabelEngine — credential patterns mapped to wrong rule
Comment heuristic and diff heuristic both mapped credential/secret patterns to GCI0007 (Error Handling Integrity) instead of GCI0012 (Security Risk). Corrupted precision/recall scorecards for both rules.
**Fix:** Remap to GCI0012 in CommentRules, ApplyDiffHeuristics, and RulesWithHeuristics. Update tests accordingly.

## Validation
- dotnet build GauntletCI.slnx --nologo -q
- dotnet test src/GauntletCI.Tests/GauntletCI.Tests.csproj --no-build --nologo -q → 689 passed