### PR TITLE
[CONFIG] Move hardcoded Ollama URLs into .gauntletci.json corpus config

### DIFF
--- a/src/GauntletCI.Cli/Commands/CorpusCommand.cs
+++ b/src/GauntletCI.Cli/Commands/CorpusCommand.cs
@@ -12,6 +12,7 @@ using GauntletCI.Corpus.Normalization;
 using GauntletCI.Corpus.Runners;
 using GauntletCI.Corpus.Scoring;
 using GauntletCI.Corpus.Storage;
+using GauntletCI.Core.Configuration;
 using Microsoft.Data.Sqlite;
 
 namespace GauntletCI.Cli.Commands;
@@ -1299,7 +1300,7 @@ public static class CorpusCommand
         var llmLabelOpt     = new Option<bool>  ("--llm-label",    () => false,       "Enable LLM-based Tier 3 labeling");
         var llmProviderOpt  = new Option<string>("--llm-provider", () => "ollama",    "LLM provider: ollama | anthropic | github-models | none");
         var llmModelOpt     = new Option<string>("--llm-model",    () => "",          "Model override (provider default used if empty)");
-        var llmUrlOpt       = new Option<string[]>("--llm-url",    () => ["http://localhost:11434"], "Ollama base URL. Repeat the flag or pass a comma-separated list to use multiple servers.");
+        var llmUrlOpt       = new Option<string[]>("--llm-url",    () => [], "Ollama base URL(s). Repeat the flag or pass a comma-separated list. Falls back to corpus.ollamaUrls in .gauntletci.json.");
         var dbOpt           = new Option<string>("--db",           () => "./data/gauntletci-corpus.db", "Path to corpus SQLite database");
         var fixturesOpt     = new Option<string>("--fixtures",     () => "./data/fixtures",             "Path to fixtures root directory");
 
@@ -1322,7 +1323,27 @@ public static class CorpusCommand
             var llmLabel   = ctx.ParseResult.GetValueForOption(llmLabelOpt);
             var provider   = ctx.ParseResult.GetValueForOption(llmProviderOpt)!;
             var llmModel   = ctx.ParseResult.GetValueForOption(llmModelOpt)!;
-            var llmUrls    = NormalizeOllamaUrls(ctx.ParseResult.GetValueForOption(llmUrlOpt));
+            var rawUrls      = ctx.ParseResult.GetValueForOption(llmUrlOpt) ?? [];
+            // Load .gauntletci.json for Ollama URL/model fallback; returns safe defaults if file absent.
+            var configDir    = FindGitRoot(Environment.CurrentDirectory) ?? Environment.CurrentDirectory;
+            var corpusConfig = ConfigLoader.Load(configDir).Corpus ?? new CorpusConfig();
+            // URL resolution and config fallback are Ollama-only; normalize CLI values first to catch whitespace-only entries.
+            var normalizedCli = NormalizeOllamaUrls(provider == "ollama" ? rawUrls : []);
+            IReadOnlyList<string> llmUrls;
+            if (normalizedCli.Count > 0)
+                llmUrls = normalizedCli;
+            else if (provider == "ollama")
+            {
+                llmUrls = NormalizeOllamaUrls(corpusConfig.OllamaUrls);
+                if (llmUrls.Count > 0)
+                    Console.WriteLine($"[corpus] Using Ollama URLs from .gauntletci.json: {string.Join(", ", llmUrls)}");
+            }
+            else
+                llmUrls = [];
+            // Scope corpus.ollamaModel fallback to Ollama only; other providers use their own defaults when llmModel is empty.
+            var resolvedModel = provider == "ollama" && string.IsNullOrWhiteSpace(llmModel)
+                ? corpusConfig.OllamaModel
+                : (string.IsNullOrWhiteSpace(llmModel) ? null : llmModel);
             var dbPath     = ctx.ParseResult.GetValueForOption(dbOpt)!;
             var fixtures   = ctx.ParseResult.GetValueForOption(fixturesOpt)!;
             var ct         = ctx.GetCancellationToken();
@@ -1338,7 +1359,7 @@ public static class CorpusCommand
             int readyEndpointCount = 0;
             if (llmLabel)
             {
-                string? modelOverride = string.IsNullOrWhiteSpace(llmModel) ? null : llmModel;
+                string? modelOverride = resolvedModel;
 
                 if (provider == "ollama")
                 {
@@ -2139,15 +2160,18 @@ public static class CorpusCommand
     }
 
     private static IReadOnlyList<string> NormalizeOllamaUrls(IEnumerable<string>? rawUrls)
-    {
-        var normalized = (rawUrls ?? [])
-            .SelectMany(url => (url ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            .Where(url => !string.IsNullOrWhiteSpace(url))
-            .Select(url => url.Trim().TrimEnd('/'))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+        => OllamaUrlNormalizer.Normalize(rawUrls);
 
-        return normalized.Length > 0 ? normalized : ["http://localhost:11434"];
+    private static string? FindGitRoot(string startDirectory)
+    {
+        var current = new DirectoryInfo(startDirectory);
+        while (current is not null)
+        {
+            if (Directory.Exists(Path.Combine(current.FullName, ".git")))
+                return current.FullName;
+            current = current.Parent;
+        }
+        return null;
     }
 
     private static bool IsLocalOllamaUrl(string baseUrl)

--- a/src/GauntletCI.Core/Configuration/GauntletConfig.cs
+++ b/src/GauntletCI.Core/Configuration/GauntletConfig.cs
@@ -27,6 +27,9 @@ public class GauntletConfig
     /// Value: list of namespace fragments that the source layer must not import (e.g. ["Infrastructure", "AspNetCore"]).
     /// </summary>
     public Dictionary<string, List<string>>? ForbiddenImports { get; set; }
+
+    /// <summary>Corpus pipeline configuration (local dev tool settings).</summary>
+    public CorpusConfig Corpus { get; set; } = new();
 }
 
 /// <summary>Per-rule configuration overrides.</summary>
@@ -69,4 +72,24 @@ public class LlmConfig
     /// Required to enable CI LLM enrichment.
     /// </summary>
     public string LicenseKeyEnv { get; set; } = "GAUNTLETCI_LICENSE";
+}
+
+/// <summary>
+/// Corpus pipeline configuration. Controls local Ollama endpoints used during silver labeling.
+/// These settings are local to the developer's machine and should not be committed to source control.
+/// </summary>
+public class CorpusConfig
+{
+    /// <summary>
+    /// Ollama base URLs for silver labeling. Multiple URLs enable round-robin load distribution
+    /// across several local or remote Ollama servers.
+    /// Example: ["http://localhost:11434", "http://192.168.1.5:11434"]
+    /// </summary>
+    public string[] OllamaUrls { get; set; } = [];
+
+    /// <summary>
+    /// Default Ollama model override for the corpus pipeline. Null means auto-select based on hardware.
+    /// Example: "phi3:mini"
+    /// </summary>
+    public string? OllamaModel { get; set; }
 }

--- a/src/GauntletCI.Corpus/Labeling/OllamaUrlNormalizer.cs
+++ b/src/GauntletCI.Corpus/Labeling/OllamaUrlNormalizer.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Corpus.Labeling;
+
+/// <summary>
+/// Normalizes raw Ollama URL input (CLI flags or config) into a clean, deduplicated list.
+/// </summary>
+public static class OllamaUrlNormalizer
+{
+    /// <summary>
+    /// Splits comma-separated entries, trims whitespace and trailing slashes, removes blanks,
+    /// and deduplicates case-insensitively. Returns an empty list if input is null or all blank.
+    /// </summary>
+    public static IReadOnlyList<string> Normalize(IEnumerable<string>? rawUrls)
+    {
+        return (rawUrls ?? [])
+            .SelectMany(url => (url ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Where(url => !string.IsNullOrWhiteSpace(url))
+            .Select(url => url.Trim().TrimEnd('/'))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+}

--- a/src/GauntletCI.Tests/ConfigLoaderTests.cs
+++ b/src/GauntletCI.Tests/ConfigLoaderTests.cs
@@ -164,4 +164,56 @@ public class ConfigLoaderTests
             Directory.Delete(tempDir, recursive: true);
         }
     }
+
+    [Fact]
+    public void Load_JsonWithCorpusConfig_DeserializesOllamaUrls()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"gci_cfg_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var json = """
+                {
+                  "corpus": {
+                    "ollamaUrls": ["http://localhost:11434", "http://10.0.0.5:11434"],
+                    "ollamaModel": "phi3:mini"
+                  }
+                }
+                """;
+            File.WriteAllText(Path.Combine(tempDir, ".gauntletci.json"), json);
+
+            var config = ConfigLoader.Load(tempDir);
+
+            Assert.NotNull(config.Corpus);
+            Assert.Equal(2, config.Corpus.OllamaUrls.Length);
+            Assert.Contains("http://localhost:11434", config.Corpus.OllamaUrls);
+            Assert.Contains("http://10.0.0.5:11434", config.Corpus.OllamaUrls);
+            Assert.Equal("phi3:mini", config.Corpus.OllamaModel);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_MissingCorpusSection_ReturnsEmptyOllamaUrls()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"gci_cfg_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, ".gauntletci.json"), "{}");
+
+            var config = ConfigLoader.Load(tempDir);
+
+            Assert.NotNull(config.Corpus);
+            Assert.Empty(config.Corpus.OllamaUrls);
+            Assert.Null(config.Corpus.OllamaModel);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
 }

--- a/src/GauntletCI.Tests/Corpus/CorpusStringHelpersTests.cs
+++ b/src/GauntletCI.Tests/Corpus/CorpusStringHelpersTests.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using GauntletCI.Corpus;
+using GauntletCI.Corpus.Labeling;
 
 namespace GauntletCI.Tests.Corpus;
 
@@ -105,6 +106,53 @@ public class CorpusStringHelpersTests
         using var response = new HttpResponseMessage(HttpStatusCode.Forbidden);
         response.Headers.Add("x-ratelimit-remaining", "5");
         Assert.False(CorpusStringHelpers.IsRateLimited(response));
+    }
+
+    // ── NormalizeOllamaUrls ────────────────────────────────────────────────────
+
+    [Fact]
+    public void NormalizeOllamaUrls_NullInput_ReturnsEmpty()
+    {
+        Assert.Empty(OllamaUrlNormalizer.Normalize(null));
+    }
+
+    [Fact]
+    public void NormalizeOllamaUrls_EmptyInput_ReturnsEmpty()
+    {
+        Assert.Empty(OllamaUrlNormalizer.Normalize([]));
+    }
+
+    [Fact]
+    public void NormalizeOllamaUrls_SingleUrl_ReturnsTrimmedEntry()
+    {
+        var result = OllamaUrlNormalizer.Normalize(["http://localhost:11434/"]);
+        Assert.Single(result);
+        Assert.Equal("http://localhost:11434", result[0]);
+    }
+
+    [Fact]
+    public void NormalizeOllamaUrls_CommaSeparated_SplitsIntoMultipleEntries()
+    {
+        var result = OllamaUrlNormalizer.Normalize(["http://a:11434,http://b:11434"]);
+        Assert.Equal(2, result.Count);
+        Assert.Contains("http://a:11434", result);
+        Assert.Contains("http://b:11434", result);
+    }
+
+    [Fact]
+    public void NormalizeOllamaUrls_DuplicatesCaseInsensitive_Deduplicates()
+    {
+        var result = OllamaUrlNormalizer.Normalize(
+            ["http://Localhost:11434", "http://localhost:11434"]);
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void NormalizeOllamaUrls_BlankEntries_Filtered()
+    {
+        var result = OllamaUrlNormalizer.Normalize(["  ", "", "http://x:11434"]);
+        Assert.Single(result);
+        Assert.Equal("http://x:11434", result[0]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Moves hardcoded Ollama URLs out of C# source and into the .gauntletci.json corpus config section.

## Changes
- GauntletConfig.cs: Added CorpusConfig class (OllamaUrls, OllamaModel) and Corpus property
- CorpusCommand.cs: --llm-url default changed to []; label-all handler resolves URLs via: CLI flag > corpus.ollamaUrls in config > empty list (degrades to NullLlmLabeler)
- OllamaUrlNormalizer.cs (new): Public static class with URL normalization logic
- Tests: 8 new tests (6 for OllamaUrlNormalizer, 2 for CorpusConfig deserialization)

## Usage
Configure in .gauntletci.json:
  corpus.ollamaUrls: ["http://localhost:11434"]
  corpus.ollamaModel: "phi3"

## Pre-commit checks
- GauntletCI analyze: 0 findings
- Core engineering rules: 10 PASS, 2 WARN (non-blocking), 0 FAIL
- All 697 tests pass