### PR TITLE
[INFRA] Remove hardcoded Ollama URLs from build-corpus.ps1

### DIFF
--- a/build-corpus.ps1
+++ b/build-corpus.ps1
@@ -24,7 +24,7 @@ param(
     [switch]$LlmLabel      = $false, # Enable Tier 3 LLM fallback during Step 4 / Step 8 label-all
     [string]$LlmProvider   = "ollama", # LLM provider for label-all: ollama | anthropic | github-models | none
     [string]$LlmModel      = "",    # Optional provider-specific model override for label-all
-    [string[]]$LlmUrl      = @("http://localhost:11434", "http://10.0.0.5:11434/"), # Ollama base URLs for label-all
+    [string[]]$LlmUrl      = @(), # Ollama base URL(s) for label-all; when empty, falls back to corpus.ollamaUrls in .gauntletci.json (see feature/audit-ollama-url-hardcoded)
     [switch]$SkipLabeler    = $false, # Skip launching the labeler Flask app after pipeline completes
     # Known game repositories and other low-signal repos to exclude from discovery.
     # Add owner/repo strings here to prevent them from entering the corpus.


### PR DESCRIPTION
Removes hardcoded Ollama URLs from build-corpus.ps1 -LlmUrl parameter default.

Default changed from @('http://localhost:11434', 'http://10.0.0.5:11434/') to @().
URLs are now configured via corpus.ollamaUrls in .gauntletci.json (companion to PR #82).

Kept as separate PR from #82 to avoid GCI0001 (mixed .ps1 + .cs files in same diff).

- GauntletCI analyze: 0 findings