### PR TITLE
[TEST] Add Assert.Throws coverage for RoundRobinLlmLabeler guard clauses

### DIFF
--- a/src/GauntletCI.Tests/RoundRobinLlmLabelerTests.cs
+++ b/src/GauntletCI.Tests/RoundRobinLlmLabelerTests.cs
@@ -178,6 +178,38 @@ public sealed class RoundRobinLlmLabelerTests
     }
 
     // ────────────────────────────────────────────────────────────────────────
+    // Constructor guard clauses
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_throws_when_failureThreshold_is_zero()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RoundRobinLlmLabeler([ new LlmEndpoint("e", new FakeLabeler()) ], failureThreshold: 0));
+    }
+
+    [Fact]
+    public void Constructor_throws_when_endpoints_is_null()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new RoundRobinLlmLabeler((IEnumerable<LlmEndpoint>)null!));
+    }
+
+    [Fact]
+    public void Constructor_throws_when_endpoints_is_empty()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new RoundRobinLlmLabeler([]));
+    }
+
+    [Fact]
+    public void Convenience_constructor_throws_when_labelers_is_null()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new RoundRobinLlmLabeler((IEnumerable<ILlmLabeler>)null!));
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
     // IDisposable — disposes underlying labelers that implement IDisposable
     // ────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Adds Assert.Throws coverage for all 4 guard clauses in RoundRobinLlmLabeler constructors. Surfaced by GCI0032 audit on the round-robin PR diff.

New tests:
- Constructor_throws_when_failureThreshold_is_zero
- Constructor_throws_when_endpoints_is_null
- Constructor_throws_when_endpoints_is_empty
- Convenience_constructor_throws_when_labelers_is_null

All 693 tests pass. GauntletCI analyze: 0 findings.