### PR TITLE
[EXP] Add experimental engineering policy LLM evaluation step

### DIFF
--- a/src/GauntletCI.Cli/Analysis/EngineeringPolicyEvaluator.cs
+++ b/src/GauntletCI.Cli/Analysis/EngineeringPolicyEvaluator.cs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.Json;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+using GauntletCI.Llm;
+
+namespace GauntletCI.Cli.Analysis;
+
+/// <summary>
+/// Evaluates a diff against the structured engineering policy document using an LLM.
+/// Produces Advisory-severity findings for any detected policy violations.
+/// </summary>
+internal static class EngineeringPolicyEvaluator
+{
+    private const int MaxDiffChars = 12_000;
+
+    /// <summary>
+    /// Evaluates the diff against the policy file at <paramref name="policyPath"/> using the provided LLM.
+    /// Returns an empty list if the LLM is unavailable, the policy file is missing, or no violations are found.
+    /// </summary>
+    internal static async Task<IReadOnlyList<Finding>> EvaluateAsync(
+        DiffContext diff,
+        string policyPath,
+        ILlmEngine llm,
+        CancellationToken ct = default)
+    {
+        if (!llm.IsAvailable)
+            return [];
+
+        if (!File.Exists(policyPath))
+        {
+            Console.Error.WriteLine($"[GauntletCI] Engineering policy file not found: {policyPath}. Skipping policy evaluation.");
+            return [];
+        }
+
+        var policy = await File.ReadAllTextAsync(policyPath, ct);
+        var diffText = BuildDiffText(diff);
+
+        var prompt = BuildPrompt(policy, diffText);
+
+        string raw;
+        try
+        {
+            raw = await llm.CompleteAsync(prompt, ct);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[GauntletCI] Engineering policy LLM call failed: {ex.Message}");
+            return [];
+        }
+
+        return ParseFindings(raw);
+    }
+
+    private static string BuildDiffText(DiffContext diff)
+    {
+        var lines = diff.Files
+            .SelectMany(f => f.Hunks)
+            .SelectMany(h => h.Lines)
+            .Where(l => l.Kind == DiffLineKind.Added)
+            .Select(l => l.Content);
+
+        var text = string.Join("\n", lines);
+        return text.Length > MaxDiffChars ? text[..MaxDiffChars] + "\n... (truncated)" : text;
+    }
+
+    private static string BuildPrompt(string policy, string diffText) => $$"""
+        You are a code reviewer evaluating a git diff against an engineering policy.
+
+        ## Engineering Policy
+        {{policy}}
+
+        ## Diff (added lines only)
+        {{diffText}}
+
+        ## Instructions
+        Review the diff against each engineering invariant above.
+        For each violation, return a JSON array. Return [] if there are no violations.
+        Return ONLY valid JSON — no explanation, no markdown fences.
+
+        Schema:
+        [
+          {
+            "ruleId": "EP004",
+            "ruleName": "Failure Handling",
+            "summary": "One sentence describing the violation.",
+            "evidence": "FileName.cs:42 — the offending snippet",
+            "whyItMatters": "One sentence on the risk.",
+            "suggestedAction": "One sentence on how to fix it."
+          }
+        ]
+        """;
+
+    private static IReadOnlyList<Finding> ParseFindings(string raw)
+    {
+        try
+        {
+            var trimmed = raw.Trim();
+
+            // Strip markdown fences if the model wrapped the JSON anyway
+            if (trimmed.StartsWith("```"))
+            {
+                var start = trimmed.IndexOf('[');
+                var end   = trimmed.LastIndexOf(']');
+                if (start >= 0 && end > start)
+                    trimmed = trimmed[start..(end + 1)];
+            }
+
+            var records = JsonSerializer.Deserialize<PolicyFinding[]>(trimmed,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            if (records is null || records.Length == 0)
+                return [];
+
+            return records.Select(r => new Finding
+            {
+                RuleId          = r.RuleId ?? "EP000",
+                RuleName        = r.RuleName ?? "Engineering Policy",
+                Summary         = r.Summary ?? string.Empty,
+                Evidence        = r.Evidence ?? string.Empty,
+                WhyItMatters    = r.WhyItMatters ?? string.Empty,
+                SuggestedAction = r.SuggestedAction ?? string.Empty,
+                Severity        = RuleSeverity.Advisory,
+                Confidence      = Confidence.Medium,
+            }).ToList();
+        }
+        catch
+        {
+            // LLM returned non-JSON — skip silently
+            return [];
+        }
+    }
+
+    private sealed record PolicyFinding(
+        string? RuleId,
+        string? RuleName,
+        string? Summary,
+        string? Evidence,
+        string? WhyItMatters,
+        string? SuggestedAction);
+}

--- a/src/GauntletCI.Cli/Analysis/EngineeringPolicyEvaluator.cs
+++ b/src/GauntletCI.Cli/Analysis/EngineeringPolicyEvaluator.cs
@@ -97,14 +97,11 @@ internal static class EngineeringPolicyEvaluator
         {
             var trimmed = raw.Trim();
 
-            // Strip markdown fences if the model wrapped the JSON anyway
-            if (trimmed.StartsWith("```"))
-            {
-                var start = trimmed.IndexOf('[');
-                var end   = trimmed.LastIndexOf(']');
-                if (start >= 0 && end > start)
-                    trimmed = trimmed[start..(end + 1)];
-            }
+            // Extract JSON array regardless of preamble text or markdown fences
+            var start = trimmed.IndexOf('[');
+            var end   = trimmed.LastIndexOf(']');
+            if (start >= 0 && end > start)
+                trimmed = trimmed[start..(end + 1)];
 
             var records = JsonSerializer.Deserialize<PolicyFinding[]>(trimmed,
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });

--- a/src/GauntletCI.Cli/Analysis/EngineeringPolicyEvaluator.cs
+++ b/src/GauntletCI.Cli/Analysis/EngineeringPolicyEvaluator.cs
@@ -33,7 +33,16 @@ internal static class EngineeringPolicyEvaluator
             return [];
         }
 
-        var policy = await File.ReadAllTextAsync(policyPath, ct);
+        string policy;
+        try
+        {
+            policy = await File.ReadAllTextAsync(policyPath, ct);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[GauntletCI] Engineering policy file could not be read: {ex.Message}. Skipping policy evaluation.");
+            return [];
+        }
         var diffText = BuildDiffText(diff);
 
         var prompt = BuildPrompt(policy, diffText);

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.CommandLine;
 using System.Text.Json;
+using GauntletCI.Cli.Analysis;
 using GauntletCI.Cli.Audit;
 using GauntletCI.Cli.LlmDaemon;
 using GauntletCI.Cli.Output;
@@ -146,6 +147,15 @@ public static class AnalyzeCommand
                         var adjudicator    = new GauntletCI.Llm.Embeddings.LlmAdjudicator(embedEng, store);
                         await adjudicator.AdjudicateAsync(result.Findings, ct);
                     }
+                }
+
+                // Engineering policy evaluation (experimental — config-driven, LLM-required)
+                if (config.Experimental.EngineeringPolicy.Enabled && llm.IsAvailable)
+                {
+                    var policyPath = Path.Combine(repo.FullName, config.Experimental.EngineeringPolicy.Path);
+                    var policyFindings = await EngineeringPolicyEvaluator.EvaluateAsync(
+                        diff, policyPath, llm, ctx.GetCancellationToken());
+                    result.Findings.AddRange(policyFindings);
                 }
 
                 if ((output ?? "text").Equals("json", StringComparison.OrdinalIgnoreCase))

--- a/src/GauntletCI.Cli/GauntletCI.Cli.csproj
+++ b/src/GauntletCI.Cli/GauntletCI.Cli.csproj
@@ -25,6 +25,12 @@
     <EmbeddedResource Include="Hooks\gauntletci-hook.sh" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>GauntletCI.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/GauntletCI.Cli/Output/ConsoleReporter.cs
+++ b/src/GauntletCI.Cli/Output/ConsoleReporter.cs
@@ -83,15 +83,26 @@ public static class ConsoleReporter
 
         if (!anyVisible)
         {
-            AnsiConsole.MarkupLine("[grey]  All findings are below the current severity threshold. Use --verbose to see Info findings.[/]");
+            // Only print "below threshold" if there are also no Advisory findings being shown
+            var advisoryFindings = result.Findings.Where(f => f.Severity == RuleSeverity.Advisory).ToList();
+            if (advisoryFindings.Count == 0)
+                AnsiConsole.MarkupLine("[grey]  All findings are below the current severity threshold. Use --verbose to see Info findings.[/]");
+
+            if (advisoryFindings.Count > 0)
+            {
+                AnsiConsole.MarkupLine($"[blue]{string.Format(sep, "ADVISORY", advisoryFindings.Count)}[/]");
+                foreach (var finding in advisoryFindings)
+                    PrintFinding(finding, "blue");
+            }
+            return;
         }
 
         // Advisory findings (LLM policy) — always shown, never gated by minSeverity
-        var advisoryFindings = result.Findings.Where(f => f.Severity == RuleSeverity.Advisory).ToList();
-        if (advisoryFindings.Count > 0)
+        var advisoryFindingsFinal = result.Findings.Where(f => f.Severity == RuleSeverity.Advisory).ToList();
+        if (advisoryFindingsFinal.Count > 0)
         {
-            AnsiConsole.MarkupLine($"[blue]{string.Format(sep, "ADVISORY", advisoryFindings.Count)}[/]");
-            foreach (var finding in advisoryFindings)
+            AnsiConsole.MarkupLine($"[blue]{string.Format(sep, "ADVISORY", advisoryFindingsFinal.Count)}[/]");
+            foreach (var finding in advisoryFindingsFinal)
                 PrintFinding(finding, "blue");
         }
     }

--- a/src/GauntletCI.Cli/Output/ConsoleReporter.cs
+++ b/src/GauntletCI.Cli/Output/ConsoleReporter.cs
@@ -32,6 +32,8 @@ public static class ConsoleReporter
 
     /// <summary>
     /// Prints a formatted risk-analysis report to the console, grouped by severity level.
+    /// Block (red), Warn (yellow), and Info (grey) findings are gated by minSeverity.
+    /// Advisory findings (blue) from LLM policy evaluation are always shown regardless of minSeverity.
     /// </summary>
     /// <param name="result">The evaluation result containing findings to display.</param>
     /// <param name="ascii">Use ASCII box characters instead of Unicode for limited terminals.</param>
@@ -82,6 +84,15 @@ public static class ConsoleReporter
         if (!anyVisible)
         {
             AnsiConsole.MarkupLine("[grey]  All findings are below the current severity threshold. Use --verbose to see Info findings.[/]");
+        }
+
+        // Advisory findings (LLM policy) — always shown, never gated by minSeverity
+        var advisoryFindings = result.Findings.Where(f => f.Severity == RuleSeverity.Advisory).ToList();
+        if (advisoryFindings.Count > 0)
+        {
+            AnsiConsole.MarkupLine($"[blue]{string.Format(sep, "ADVISORY", advisoryFindings.Count)}[/]");
+            foreach (var finding in advisoryFindings)
+                PrintFinding(finding, "blue");
         }
     }
 

--- a/src/GauntletCI.Core/Configuration/GauntletConfig.cs
+++ b/src/GauntletCI.Core/Configuration/GauntletConfig.cs
@@ -123,12 +123,12 @@ public class EngineeringPolicyConfig
     /// <summary>
     /// Self-documenting description of this feature.
     /// Evaluates diffs against a structured engineering policy document using an LLM.
-    /// Requires a configured LLM endpoint. Findings are emitted as Advisory severity —
+    /// Requires an LLM to be available (local model or CI endpoint). Findings are emitted as Advisory severity —
     /// always shown in output but never block a commit.
     /// </summary>
     public string Description { get; set; } =
         "Evaluates diffs against a structured engineering policy document using an LLM. " +
-        "Requires a configured LLM endpoint. Findings are emitted as Advisory severity — " +
+        "Requires an LLM to be available (local model or CI endpoint). Findings are emitted as Advisory severity — " +
         "shown in output but never block a commit.";
 
     /// <summary>

--- a/src/GauntletCI.Core/Configuration/GauntletConfig.cs
+++ b/src/GauntletCI.Core/Configuration/GauntletConfig.cs
@@ -30,6 +30,9 @@ public class GauntletConfig
 
     /// <summary>Corpus pipeline configuration (local dev tool settings).</summary>
     public CorpusConfig Corpus { get; set; } = new();
+
+    /// <summary>Experimental feature flags. Settings here may change or be removed without notice.</summary>
+    public ExperimentalConfig Experimental { get; set; } = new();
 }
 
 /// <summary>Per-rule configuration overrides.</summary>
@@ -92,4 +95,39 @@ public class CorpusConfig
     /// Example: "phi3:mini"
     /// </summary>
     public string? OllamaModel { get; set; }
+}
+
+/// <summary>Experimental features. Settings here may change or be removed without notice.</summary>
+public class ExperimentalConfig
+{
+    /// <summary>LLM-powered engineering policy evaluation step.</summary>
+    public EngineeringPolicyConfig EngineeringPolicy { get; set; } = new();
+}
+
+/// <summary>
+/// Configuration for the experimental LLM-powered engineering policy evaluation step.
+/// When enabled, GauntletCI sends the diff and a structured policy document to the configured
+/// LLM and emits Advisory-severity findings for any detected policy violations.
+/// </summary>
+public class EngineeringPolicyConfig
+{
+    /// <summary>Enable the engineering policy evaluation step. Requires an LLM to be available.</summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>
+    /// Self-documenting description of this feature.
+    /// Evaluates diffs against a structured engineering policy document using an LLM.
+    /// Requires a configured LLM endpoint. Findings are emitted as Advisory severity —
+    /// always shown in output but never block a commit.
+    /// </summary>
+    public string Description { get; set; } =
+        "Evaluates diffs against a structured engineering policy document using an LLM. " +
+        "Requires a configured LLM endpoint. Findings are emitted as Advisory severity — " +
+        "shown in output but never block a commit.";
+
+    /// <summary>
+    /// Path to the engineering policy markdown file, relative to the repository root.
+    /// Defaults to .misc/engineering-policy.md.
+    /// </summary>
+    public string Path { get; set; } = ".misc/engineering-policy.md";
 }

--- a/src/GauntletCI.Core/Model/RuleSeverity.cs
+++ b/src/GauntletCI.Core/Model/RuleSeverity.cs
@@ -16,4 +16,6 @@ public enum RuleSeverity
     Warn = 2,
     /// <summary>Blocking — always shown; causes a non-zero exit code by default.</summary>
     Block = 3,
+    /// <summary>Advisory — always shown; produced by LLM policy evaluation; never causes a non-zero exit code.</summary>
+    Advisory = 4,
 }

--- a/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
+++ b/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
@@ -266,7 +266,7 @@ public class EvaluationResult
     /// </summary>
     public bool ShouldBlock(string exitOn = "Block") =>
         exitOn.Equals("Warn", StringComparison.OrdinalIgnoreCase)
-            ? Findings.Any(f => f.Severity >= RuleSeverity.Warn)
+            ? Findings.Any(f => f.Severity is RuleSeverity.Warn or RuleSeverity.Block)
             : Findings.Any(f => f.Severity == RuleSeverity.Block);
 }
 

--- a/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
+++ b/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
@@ -261,7 +261,7 @@ public class EvaluationResult
     /// the configured <paramref name="exitOn"/> policy.
     /// <list type="bullet">
     ///   <item><description><c>"Block"</c> (default): true when any <see cref="RuleSeverity.Block"/> finding exists.</description></item>
-    ///   <item><description><c>"Warn"</c>: true when any <see cref="RuleSeverity.Warn"/> or higher finding exists.</description></item>
+    ///   <item><description><c>"Warn"</c>: true when any <see cref="RuleSeverity.Warn"/> or <see cref="RuleSeverity.Block"/> finding exists. <see cref="RuleSeverity.Advisory"/> findings are never blocking regardless of this setting.</description></item>
     /// </list>
     /// </summary>
     public bool ShouldBlock(string exitOn = "Block") =>

--- a/src/GauntletCI.Tests/EngineeringPolicyEvaluatorTests.cs
+++ b/src/GauntletCI.Tests/EngineeringPolicyEvaluatorTests.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Cli.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+using GauntletCI.Llm;
+
+namespace GauntletCI.Tests;
+
+public class EngineeringPolicyEvaluatorTests
+{
+    private static DiffContext EmptyDiff() => DiffParser.Parse(string.Empty);
+
+    [Fact]
+    public async Task EvaluateAsync_returns_empty_when_llm_not_available()
+    {
+        var llm = new StubLlmEngine(isAvailable: false, response: "[]");
+
+        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
+            EmptyDiff(), "nonexistent.md", llm);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_returns_empty_when_policy_file_missing()
+    {
+        var llm = new StubLlmEngine(isAvailable: true, response: "[]");
+
+        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
+            EmptyDiff(), Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".md"), llm);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_returns_advisory_findings_from_llm_response()
+    {
+        var policyFile = Path.GetTempFileName();
+        await File.WriteAllTextAsync(policyFile, "## EP001 · Correctness and Intent · High");
+
+        var llm = new StubLlmEngine(isAvailable: true, response: """
+            [
+              {
+                "ruleId": "EP001",
+                "ruleName": "Correctness and Intent",
+                "summary": "TODO comment left in added code.",
+                "evidence": "Foo.cs:10 — // TODO: implement",
+                "whyItMatters": "Implies incomplete implementation.",
+                "suggestedAction": "Remove TODO or implement before merging."
+              }
+            ]
+            """);
+
+        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
+            EmptyDiff(), policyFile, llm);
+
+        File.Delete(policyFile);
+
+        Assert.Single(result);
+        Assert.Equal("EP001", result[0].RuleId);
+        Assert.Equal(RuleSeverity.Advisory, result[0].Severity);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_returns_empty_when_llm_returns_empty_array()
+    {
+        var policyFile = Path.GetTempFileName();
+        await File.WriteAllTextAsync(policyFile, "## EP001");
+
+        var llm = new StubLlmEngine(isAvailable: true, response: "[]");
+
+        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
+            EmptyDiff(), policyFile, llm);
+
+        File.Delete(policyFile);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_returns_empty_when_llm_returns_invalid_json()
+    {
+        var policyFile = Path.GetTempFileName();
+        await File.WriteAllTextAsync(policyFile, "## EP001");
+
+        var llm = new StubLlmEngine(isAvailable: true, response: "not json at all");
+
+        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
+            EmptyDiff(), policyFile, llm);
+
+        File.Delete(policyFile);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_strips_markdown_fences_from_llm_response()
+    {
+        var policyFile = Path.GetTempFileName();
+        await File.WriteAllTextAsync(policyFile, "## EP001");
+
+        var llm = new StubLlmEngine(isAvailable: true, response: """
+            ```json
+            [{"ruleId":"EP001","ruleName":"Correctness","summary":"s","evidence":"e","whyItMatters":"w","suggestedAction":"a"}]
+            ```
+            """);
+
+        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
+            EmptyDiff(), policyFile, llm);
+
+        File.Delete(policyFile);
+
+        Assert.Single(result);
+        Assert.Equal("EP001", result[0].RuleId);
+    }
+
+    private sealed class StubLlmEngine(bool isAvailable, string response) : ILlmEngine
+    {
+        public bool IsAvailable => isAvailable;
+        public Task<string> CompleteAsync(string prompt, CancellationToken ct = default) => Task.FromResult(response);
+        public Task<string> EnrichFindingAsync(Finding finding, CancellationToken ct = default) => Task.FromResult(string.Empty);
+        public Task<string> SummarizeReportAsync(IEnumerable<Finding> findings, CancellationToken ct = default) => Task.FromResult(string.Empty);
+        public void Dispose() { }
+    }
+}

--- a/src/GauntletCI.Tests/EngineeringPolicyEvaluatorTests.cs
+++ b/src/GauntletCI.Tests/EngineeringPolicyEvaluatorTests.cs
@@ -36,102 +36,96 @@ public class EngineeringPolicyEvaluatorTests
     public async Task EvaluateAsync_returns_advisory_findings_from_llm_response()
     {
         var policyFile = Path.GetTempFileName();
-        await File.WriteAllTextAsync(policyFile, "## EP001 · Correctness and Intent · High");
+        try
+        {
+            await File.WriteAllTextAsync(policyFile, "## EP001 · Correctness and Intent · High");
 
-        var llm = new StubLlmEngine(isAvailable: true, response: """
-            [
-              {
-                "ruleId": "EP001",
-                "ruleName": "Correctness and Intent",
-                "summary": "TODO comment left in added code.",
-                "evidence": "Foo.cs:10 — // TODO: implement",
-                "whyItMatters": "Implies incomplete implementation.",
-                "suggestedAction": "Remove TODO or implement before merging."
-              }
-            ]
-            """);
+            var llm = new StubLlmEngine(isAvailable: true, response: """
+                [
+                  {
+                    "ruleId": "EP001",
+                    "ruleName": "Correctness and Intent",
+                    "summary": "TODO comment left in added code.",
+                    "evidence": "Foo.cs:10 — // TODO: implement",
+                    "whyItMatters": "Implies incomplete implementation.",
+                    "suggestedAction": "Remove TODO or implement before merging."
+                  }
+                ]
+                """);
 
-        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
-            EmptyDiff(), policyFile, llm);
+            var result = await EngineeringPolicyEvaluator.EvaluateAsync(
+                EmptyDiff(), policyFile, llm);
 
-        File.Delete(policyFile);
-
-        Assert.Single(result);
-        Assert.Equal("EP001", result[0].RuleId);
-        Assert.Equal(RuleSeverity.Advisory, result[0].Severity);
+            Assert.Single(result);
+            Assert.Equal("EP001", result[0].RuleId);
+            Assert.Equal(RuleSeverity.Advisory, result[0].Severity);
+        }
+        finally { File.Delete(policyFile); }
     }
 
     [Fact]
     public async Task EvaluateAsync_returns_empty_when_llm_returns_empty_array()
     {
         var policyFile = Path.GetTempFileName();
-        await File.WriteAllTextAsync(policyFile, "## EP001");
-
-        var llm = new StubLlmEngine(isAvailable: true, response: "[]");
-
-        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
-            EmptyDiff(), policyFile, llm);
-
-        File.Delete(policyFile);
-
-        Assert.Empty(result);
+        try
+        {
+            await File.WriteAllTextAsync(policyFile, "## EP001");
+            var llm = new StubLlmEngine(isAvailable: true, response: "[]");
+            var result = await EngineeringPolicyEvaluator.EvaluateAsync(EmptyDiff(), policyFile, llm);
+            Assert.Empty(result);
+        }
+        finally { File.Delete(policyFile); }
     }
 
     [Fact]
     public async Task EvaluateAsync_returns_empty_when_llm_returns_invalid_json()
     {
         var policyFile = Path.GetTempFileName();
-        await File.WriteAllTextAsync(policyFile, "## EP001");
-
-        var llm = new StubLlmEngine(isAvailable: true, response: "not json at all");
-
-        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
-            EmptyDiff(), policyFile, llm);
-
-        File.Delete(policyFile);
-
-        Assert.Empty(result);
+        try
+        {
+            await File.WriteAllTextAsync(policyFile, "## EP001");
+            var llm = new StubLlmEngine(isAvailable: true, response: "not json at all");
+            var result = await EngineeringPolicyEvaluator.EvaluateAsync(EmptyDiff(), policyFile, llm);
+            Assert.Empty(result);
+        }
+        finally { File.Delete(policyFile); }
     }
 
     [Fact]
     public async Task EvaluateAsync_strips_markdown_fences_from_llm_response()
     {
         var policyFile = Path.GetTempFileName();
-        await File.WriteAllTextAsync(policyFile, "## EP001");
-
-        var llm = new StubLlmEngine(isAvailable: true, response: """
-            ```json
-            [{"ruleId":"EP001","ruleName":"Correctness","summary":"s","evidence":"e","whyItMatters":"w","suggestedAction":"a"}]
-            ```
-            """);
-
-        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
-            EmptyDiff(), policyFile, llm);
-
-        File.Delete(policyFile);
-
-        Assert.Single(result);
-        Assert.Equal("EP001", result[0].RuleId);
+        try
+        {
+            await File.WriteAllTextAsync(policyFile, "## EP001");
+            var llm = new StubLlmEngine(isAvailable: true, response: """
+                ```json
+                [{"ruleId":"EP001","ruleName":"Correctness","summary":"s","evidence":"e","whyItMatters":"w","suggestedAction":"a"}]
+                ```
+                """);
+            var result = await EngineeringPolicyEvaluator.EvaluateAsync(EmptyDiff(), policyFile, llm);
+            Assert.Single(result);
+            Assert.Equal("EP001", result[0].RuleId);
+        }
+        finally { File.Delete(policyFile); }
     }
 
     [Fact]
     public async Task EvaluateAsync_parses_json_when_response_has_preamble_text()
     {
         var policyFile = Path.GetTempFileName();
-        await File.WriteAllTextAsync(policyFile, "## EP001");
-
-        var llm = new StubLlmEngine(isAvailable: true, response: """
-            Here are the findings I found:
-            [{"ruleId":"EP001","ruleName":"Correctness","summary":"s","evidence":"e","whyItMatters":"w","suggestedAction":"a"}]
-            """);
-
-        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
-            EmptyDiff(), policyFile, llm);
-
-        File.Delete(policyFile);
-
-        Assert.Single(result);
-        Assert.Equal("EP001", result[0].RuleId);
+        try
+        {
+            await File.WriteAllTextAsync(policyFile, "## EP001");
+            var llm = new StubLlmEngine(isAvailable: true, response: """
+                Here are the findings I found:
+                [{"ruleId":"EP001","ruleName":"Correctness","summary":"s","evidence":"e","whyItMatters":"w","suggestedAction":"a"}]
+                """);
+            var result = await EngineeringPolicyEvaluator.EvaluateAsync(EmptyDiff(), policyFile, llm);
+            Assert.Single(result);
+            Assert.Equal("EP001", result[0].RuleId);
+        }
+        finally { File.Delete(policyFile); }
     }
 
     private sealed class StubLlmEngine(bool isAvailable, string response) : ILlmEngine

--- a/src/GauntletCI.Tests/EngineeringPolicyEvaluatorTests.cs
+++ b/src/GauntletCI.Tests/EngineeringPolicyEvaluatorTests.cs
@@ -114,12 +114,32 @@ public class EngineeringPolicyEvaluatorTests
         Assert.Equal("EP001", result[0].RuleId);
     }
 
+    [Fact]
+    public async Task EvaluateAsync_parses_json_when_response_has_preamble_text()
+    {
+        var policyFile = Path.GetTempFileName();
+        await File.WriteAllTextAsync(policyFile, "## EP001");
+
+        var llm = new StubLlmEngine(isAvailable: true, response: """
+            Here are the findings I found:
+            [{"ruleId":"EP001","ruleName":"Correctness","summary":"s","evidence":"e","whyItMatters":"w","suggestedAction":"a"}]
+            """);
+
+        var result = await EngineeringPolicyEvaluator.EvaluateAsync(
+            EmptyDiff(), policyFile, llm);
+
+        File.Delete(policyFile);
+
+        Assert.Single(result);
+        Assert.Equal("EP001", result[0].RuleId);
+    }
+
     private sealed class StubLlmEngine(bool isAvailable, string response) : ILlmEngine
     {
         public bool IsAvailable => isAvailable;
-        public Task<string> CompleteAsync(string prompt, CancellationToken ct = default) => Task.FromResult(response);
-        public Task<string> EnrichFindingAsync(Finding finding, CancellationToken ct = default) => Task.FromResult(string.Empty);
-        public Task<string> SummarizeReportAsync(IEnumerable<Finding> findings, CancellationToken ct = default) => Task.FromResult(string.Empty);
+        public Task<string> CompleteAsync(string prompt, CancellationToken ct) => Task.FromResult(response);
+        public Task<string> EnrichFindingAsync(Finding finding, CancellationToken ct) => Task.FromResult(string.Empty);
+        public Task<string> SummarizeReportAsync(IEnumerable<Finding> findings, CancellationToken ct) => Task.FromResult(string.Empty);
         public void Dispose() { }
     }
 }


### PR DESCRIPTION
Adds an experimental LLM-powered engineering policy evaluation step to the analyze pipeline.

## What's new

- **Advisory severity** (RuleSeverity.Advisory = 4) — always shown, never blocks a commit
- **experimental.engineeringPolicy** config section in .gauntletci.json — enabled, description, path
- **.misc/engineering-policy.md** — 15 structured invariants (EP001-EP015)
- **EngineeringPolicyEvaluator** — reads policy file, sends diff + policy to LLM, parses structured JSON findings
- Auto-activates when experimental.engineeringPolicy.enabled = true AND an LLM is available
- Graceful skip when policy file is missing or LLM unavailable

## ShouldBlock fix
Advisory excluded from blocking via 'is RuleSeverity.Warn or RuleSeverity.Block' pattern.

- GauntletCI analyze: 0 findings
- All 743 tests pass
