### PR TITLE
[CONFIG] Remove stale config fields; wire llm.modelPath to LocalLlmEngine

### DIFF
--- a/.gauntletci.json
+++ b/.gauntletci.json
@@ -1,6 +1,4 @@
 {
-  "version": 2,
-  "test_command": "dotnet test",
   "rules": {
     "GCI0001": { "enabled": true },
     "GCI0002": { "enabled": true },
@@ -23,9 +21,7 @@
     "GCI0019": { "enabled": true },
     "GCI0020": { "enabled": true }
   },
-  "blocking_rules": ["GCI0012", "GCI0004"],
   "llm": {
-    "enabled": false,
-    "model_path": "~/.gauntletci/models/phi3-mini"
+    "modelPath": "~/.gauntletci/models/phi3-mini"
   }
 }

--- a/src/GauntletCI.Cli/LlmDaemon/LlmEngineSelector.cs
+++ b/src/GauntletCI.Cli/LlmDaemon/LlmEngineSelector.cs
@@ -39,7 +39,7 @@ internal static class LlmEngineSelector
             return daemon;
 
         // Daemon unavailable (model not cached or spawn failed) — direct load, silent
-        return new LocalLlmEngine();
+        return new LocalLlmEngine(config.Llm?.ModelPath);
     }
 
     private static ILlmEngine ResolveForCi(GauntletConfig config)

--- a/src/GauntletCI.Core/Configuration/GauntletConfig.cs
+++ b/src/GauntletCI.Core/Configuration/GauntletConfig.cs
@@ -62,6 +62,12 @@ public class LlmConfig
     public string CiModel { get; set; } = "gpt-4o-mini";
 
     /// <summary>
+    /// Path to the local ONNX model directory used by <c>LocalLlmEngine</c>.
+    /// Defaults to <c>~/.gauntletci/models/phi3-mini</c> when null or absent.
+    /// </summary>
+    public string? ModelPath { get; set; }
+
+    /// <summary>
     /// Name of the environment variable that holds the API key for the CI endpoint.
     /// The key is never stored in config — always read from the environment at runtime.
     /// </summary>


### PR DESCRIPTION
Cleans up silently-ignored fields in .gauntletci.json and wires the previously-dead model_path field.

## Removed (stale)
- version — schema versioning never implemented
- test_command — never read
- blocking_rules — redundant with per-rule severity: Block config
- llm.enabled — LLM enablement is controlled by --with-llm flag, not config

## Added
- LlmConfig.ModelPath — now wired to LocalLlmEngine via LlmEngineSelector
- Users can configure a custom local ONNX model path in .gauntletci.json

- GauntletCI analyze: 0 findings
- All 737 tests pass
