### PR TITLE
[INFRA] Fix critical audit findings: mutex timeout, HttpClient leak, wrong rule mapping

### DIFF
--- a/src/GauntletCI.Cli/Telemetry/TelemetryStore.cs
+++ b/src/GauntletCI.Cli/Telemetry/TelemetryStore.cs
@@ -104,7 +104,15 @@ public static class TelemetryStore
         var acquired = false;
         try
         {
-            acquired = mutex.WaitOne(TimeSpan.FromSeconds(10));
+            try
+            {
+                acquired = mutex.WaitOne(TimeSpan.FromSeconds(10));
+            }
+            catch (AbandonedMutexException)
+            {
+                // Another process died while holding the mutex; it is now ours.
+                acquired = true;
+            }
             if (acquired)
                 action();
         }


### PR DESCRIPTION
## Summary

Addresses three real findings surfaced by GauntletCI's own rule engine during a self-audit:

- Mutex timeout: fixed improper timeout handling that could cause indefinite blocking
- HttpClient leak: corrected a missing disposal path for an HttpClient instance
- Wrong rule mapping: fixed an incorrect rule-to-label mapping that produced misleading output

Also incorporates review feedback from PR #81.

## Testing

All existing tests pass.