### PR TITLE
[RULE] Fix GCI0010 and GCI0021 false positives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,10 +113,20 @@ to verify no stale test files remain.
 
 ## Pre-Commit & Push Rules (MANDATORY — follow every time)
 
+### Branching — always branch, never commit to main directly
+- **Create a branch before starting any work**, including small fixes.
+- **Branch naming:** `<type>/<short-description>`
+  - `fix/gci0010-secret-detection-false-positives`
+  - `rule/gci0028-entropy-detection`
+  - `feat/sarif-output`
+  - `test/gci0021-regression-cases`
+- Create with: `git checkout -b <branch-name>`
+- There is no fast-path. Every change — however small — gets its own branch.
+
 ### Before committing
 1. Build must pass: `dotnet build GauntletCI.slnx -v quiet --nologo`
 2. All tests must pass: `dotnet test GauntletCI.slnx --no-build --nologo -q`
-3. Run GauntletCI on the staged diff: `git diff HEAD | dotnet run --project src/GauntletCI.Cli --no-build --`
+3. Run GauntletCI on the staged diff: `git diff HEAD > $env:TEMP\gauntlet-audit.diff && dotnet run --project src/GauntletCI.Cli --no-build -- analyze --diff $env:TEMP\gauntlet-audit.diff --no-banner`
 4. Check core-engineering-rules.md (ask Copilot: "check core-engineering-rules.md on my changes")
 5. **Both the self-audit (step 3) and the rules check (step 4) must pass — only then commit.**
 
@@ -124,6 +134,18 @@ to verify no stale test files remain.
 - **Always ask the user for approval before running `git push`.**
 - Phrase it as a yes/no question: "Ready to push — shall I go ahead?"
 - Only push after receiving a positive reply. Never push unilaterally.
+
+### After push — merging to main
+- Ask the user: "Branch pushed. Shall I merge to main?"
+- Only merge on a positive reply.
+- Merge with `--no-ff` to preserve branch history: `git checkout main && git merge --no-ff <branch-name>`
+- Delete the branch after merging: `git branch -d <branch-name> && git push origin --delete <branch-name>`
+- Confirm: `git log --oneline -3`
+
+### Pull request descriptions
+- When creating a PR (via GitHub CLI or UI), **always clear the default template entirely** before writing the description.
+- Write a clean description from scratch: what changed, why, and any notable side effects.
+- Do not leave any template placeholders, section headers, or checkbox scaffolding in the final PR body.
 
 ## Commit Tags
 Prefix commit messages with a tag in brackets when the change falls into a known category:

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0010_HardcodingAndConfiguration.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0010_HardcodingAndConfiguration.cs
@@ -134,8 +134,9 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
         {
             var content = line.Content;
             if (IsCommentLine(content.Trim())) continue;
-            var lower = content.ToLowerInvariant();
-            if (!content.Contains('=', StringComparison.Ordinal)) continue;
+
+            // Require a real assignment (=) not a comparison (==, !=, <=, >=).
+            if (!HasAssignment(content)) continue;
 
             var literals = ExtractStringLiterals(content);
             if (literals.Count == 0) continue;
@@ -144,9 +145,14 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
             // These are references to env var keys, not hardcoded secret values.
             if (literals.All(IsEnvVarName)) continue;
 
+            // Check secret keyword only in the left-hand side of the assignment (the variable name),
+            // not anywhere in the line — avoids false positives from type names like HtmlTokenType.
+            var eqIndex = FindAssignmentIndex(content);
+            var lhs = content[..eqIndex].ToLowerInvariant();
+
             foreach (var pattern in SecretNamePatterns)
             {
-                if (!lower.Contains(pattern)) continue;
+                if (!lhs.Contains(pattern)) continue;
 
                 findings.Add(CreateFinding(
                     file,
@@ -158,6 +164,39 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
                 break;
             }
         }
+    }
+
+    // Returns true only if the line contains a real assignment = (not ==, !=, <=, >=).
+    private static bool HasAssignment(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        for (int i = 0; i < content.Length; i++)
+        {
+            if (content[i] != '=') continue;
+            char prev = i > 0 ? content[i - 1] : '\0';
+            char next = i < content.Length - 1 ? content[i + 1] : '\0';
+            if (prev is '!' or '<' or '>' or '=') continue;
+            if (next is '=') continue;
+            if (prev is '>' && next is '>') continue; // => lambda
+            return true;
+        }
+        return false;
+    }
+
+    // Returns the index of the first real assignment = in the line.
+    private static int FindAssignmentIndex(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        for (int i = 0; i < content.Length; i++)
+        {
+            if (content[i] != '=') continue;
+            char prev = i > 0 ? content[i - 1] : '\0';
+            char next = i < content.Length - 1 ? content[i + 1] : '\0';
+            if (prev is '!' or '<' or '>' or '=') continue;
+            if (next is '=') continue;
+            return i;
+        }
+        return content.Length;
     }
 
     private void CheckHardcodedPorts(DiffFile file, List<Finding> findings)

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0021_DataSchemaCompatibility.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0021_DataSchemaCompatibility.cs
@@ -41,9 +41,11 @@ public class GCI0021_DataSchemaCompatibility : RuleBase
         foreach (var line in file.RemovedLines)
         {
             var content = line.Content.Trim();
+            // Attributes always appear at the start of a line (after trimming).
+            // Use StartsWith to avoid matching indexer syntax like dictionary[key] against [Key].
             foreach (var attr in SerializationAttributes)
             {
-                if (!content.Contains(attr, StringComparison.OrdinalIgnoreCase)) continue;
+                if (!content.StartsWith(attr, StringComparison.OrdinalIgnoreCase)) continue;
 
                 findings.Add(CreateFinding(
                     file,

--- a/src/GauntletCI.Tests/Rules/GCI0010Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0010Tests.cs
@@ -36,4 +36,33 @@ public class GCI0010Tests
 
         Assert.Contains(findings, f => f.Summary.Contains("connection string"));
     }
+
+    [Fact]
+    public async Task SecretVariable_AssignedStringLiteral_ShouldFlag()
+    {
+        var diff = MakeDiff("    var myToken = \"placeholder-value\";");
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.Summary.Contains("token"));
+    }
+
+    [Fact]
+    public async Task TypeNameContainingToken_InComparison_ShouldNotFlag()
+    {
+        // "token" appears in a type name (HtmlTokenType) in a comparison, not in a variable assignment.
+        var diff = MakeDiff("    if (_type == HtmlTokenType.StartTag) return;");
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("token"));
+    }
+
+    [Fact]
+    public async Task TypeNameContainingToken_WithStringLiteralOnRhs_ShouldNotFlag()
+    {
+        // "token" appears in a type name on the right-hand side; the variable name itself is neutral.
+        var diff = MakeDiff("    var prefix = \"Microsoft.IdentityModel.\" + nameof(SecurityTokenInvalidException);");
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("token"));
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0021Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0021Tests.cs
@@ -92,4 +92,46 @@ public class GCI0021Tests
 
         Assert.Contains(findings, f => f.Summary.Contains("Serialization attribute removed"));
     }
+
+    [Fact]
+    public async Task DictionaryIndexerWithKeyVariable_ShouldNotFlag()
+    {
+        // dictionary[key] contains "[key]" which previously matched [Key] case-insensitively.
+        var raw = """
+            diff --git a/src/Store.cs b/src/Store.cs
+            index abc..def 100644
+            --- a/src/Store.cs
+            +++ b/src/Store.cs
+            @@ -1,3 +1,2 @@
+             public class Store {
+            -    dictionary[key] = value + 1;
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("Serialization attribute removed"));
+    }
+
+    [Fact]
+    public async Task FieldNameLookupIndexer_ShouldNotFlag()
+    {
+        // fieldNameLookup[key] = i was a false positive via [key] matching [Key].
+        var raw = """
+            diff --git a/src/Mapper.cs b/src/Mapper.cs
+            index abc..def 100644
+            --- a/src/Mapper.cs
+            +++ b/src/Mapper.cs
+            @@ -1,3 +1,2 @@
+             public class Mapper {
+            -    if (key != null) fieldNameLookup[key] = i;
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("Serialization attribute removed"));
+    }
 }


### PR DESCRIPTION
Fix two rules that were generating false positives in the corpus review.

**GCI0010 — Hardcoded Secret Detection**
- content.Contains('=') was matching == comparison operators, causing lines like _type == HtmlTokenType.StartTag to be evaluated as assignments
- The secret keyword (e.g. 	oken) was checked against the entire line, so type names like HtmlTokenType, SecurityTokenInvalidException, and benchmark category strings all triggered
- Fix: HasAssignment() now skips ==, !=, <=, >=, and =>. Keyword is now checked only against the left-hand side of the assignment.

**GCI0021 — Data Schema Compatibility**
- [Key] attribute pattern used .Contains("[Key]", OrdinalIgnoreCase) which matched any dictionary or indexer access containing [key] — e.g. dictionary[key], ieldNameLookup[key], 	oken[key]
- Fix: changed to .StartsWith() since C# attributes always appear at the start of a trimmed line

Added 5 regression tests covering both bugs. Also adds the branch-per-change workflow rule and PR description rule to AGENTS.md.