### PR TITLE
[RULE] Fix GCI0036 local var FP and GCI0001 lock file FP

### DIFF
--- a/src/GauntletCI.Core/Rules/Implementations/GCI0001_DiffIntegrity.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0001_DiffIntegrity.cs
@@ -21,6 +21,19 @@ public class GCI0001_DiffIntegrity : RuleBase
     private static readonly string[] CodeExtensions =
         [".cs", ".ts", ".js", ".py", ".go", ".java", ".rb", ".rs", ".cpp", ".c", ".fs"];
 
+    private static readonly HashSet<string> LockFileNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "packages.lock.json", "package-lock.json", "yarn.lock",
+        "pnpm-lock.yaml", "Gemfile.lock", "poetry.lock",
+        "Cargo.lock", "go.sum", "composer.lock",
+    };
+
+    private static bool IsLockFile(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        return LockFileNames.Contains(Path.GetFileName(filePath));
+    }
+
     public override Task<List<Finding>> EvaluateAsync(
         AnalysisContext context, CancellationToken ct = default)
     {
@@ -36,20 +49,18 @@ public class GCI0001_DiffIntegrity : RuleBase
     private void CheckMixedScope(DiffContext diff, IReadOnlyList<ChangedFileAnalysisRecord> skippedFiles, List<Finding> findings)
     {
         bool hasCodeFiles = diff.Files.Count > 0;
-        bool hasNonCodeFiles = skippedFiles.Any(x =>
-            x.Classification is FileEligibilityClassification.KnownNonSource
-                             or FileEligibilityClassification.UnknownUnsupported);
 
-        if (hasCodeFiles && hasNonCodeFiles)
+        var nonCodeFiles = skippedFiles
+            .Where(x => x.Classification is FileEligibilityClassification.KnownNonSource
+                                         or FileEligibilityClassification.UnknownUnsupported)
+            .Where(x => !IsLockFile(x.FilePath))
+            .ToList();
+
+        if (hasCodeFiles && nonCodeFiles.Count > 0)
         {
-            var nonCodeFilePaths = skippedFiles
-                .Where(x => x.Classification is FileEligibilityClassification.KnownNonSource
-                                             or FileEligibilityClassification.UnknownUnsupported)
-                .Select(x => x.FilePath);
-
             findings.Add(CreateFinding(
                 summary: "Diff contains mixed scope: code and non-code files changed together.",
-                evidence: $"Non-code files in diff: {string.Join(", ", nonCodeFilePaths)}",
+                evidence: $"Non-code files in diff: {string.Join(", ", nonCodeFiles.Select(x => x.FilePath))}",
                 whyItMatters: "Mixed-scope diffs are harder to review and increase the risk of unintended changes slipping through.",
                 suggestedAction: "Split into separate PRs: one for code changes, one for docs/config updates.",
                 confidence: Confidence.Medium));

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0036_PureContextMutation.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0036_PureContextMutation.cs
@@ -93,7 +93,7 @@ public class GCI0036_PureContextMutation : RuleBase
                 inGetter = false;
 
             // Check for mutations in pure context (added lines only)
-            if (line.Kind == DiffLineKind.Added && inPureContext && HasAssignment(trimmed))
+            if (line.Kind == DiffLineKind.Added && inPureContext && IsFieldOrPropertyAssignment(trimmed))
             {
                 findings.Add(CreateFinding(
                     file,
@@ -107,18 +107,37 @@ public class GCI0036_PureContextMutation : RuleBase
         }
     }
 
-    private static bool HasAssignment(string content)
+    private static bool IsFieldOrPropertyAssignment(string trimmed)
     {
+        ArgumentNullException.ThrowIfNull(trimmed);
+        // Skip local variable declarations and loop variables
+        if (trimmed.StartsWith("var ", StringComparison.Ordinal)) return false;
+        if (trimmed.StartsWith("for ", StringComparison.Ordinal) ||
+            trimmed.StartsWith("for(", StringComparison.Ordinal)) return false;
+
+        int eqIdx = FindAssignmentIndex(trimmed);
+        if (eqIdx < 0) return false;
+
+        // Strip compound-assignment operator character (+=, -=, etc.) then trim spaces
+        // so "total += x" → lhs = "total" (no space → real field mutation)
+        var lhs = trimmed[..eqIdx].TrimEnd('+', '-', '*', '/', '%', '|', '&', '^', ' ');
+
+        // If LHS still contains a space it's a type declaration (e.g. "int x", "Dictionary<K,V> result")
+        return !lhs.Contains(' ');
+    }
+
+    private static int FindAssignmentIndex(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
         for (int i = 0; i < content.Length; i++)
         {
             if (content[i] != '=') continue;
             char prev = i > 0 ? content[i - 1] : '\0';
             char next = i + 1 < content.Length ? content[i + 1] : '\0';
-            // Skip ==, !=, =>, <=, >=
             if (prev is '=' or '!' or '<' or '>') continue;
             if (next is '=' or '>') continue;
-            return true;
+            return i;
         }
-        return false;
+        return -1;
     }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0001Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0001Tests.cs
@@ -59,4 +59,30 @@ public class GCI0001Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("mixed scope"));
     }
+
+    [Fact]
+    public async Task CodeWithLockFile_ShouldNotFlagMixedScope()
+    {
+        var raw = """
+            diff --git a/src/Foo.cs b/src/Foo.cs
+            index abc..def 100644
+            --- a/src/Foo.cs
+            +++ b/src/Foo.cs
+            @@ -1,1 +1,1 @@
+            -int x = 1;
+            +int x = 2;
+            diff --git a/src/SharpCompress/packages.lock.json b/src/SharpCompress/packages.lock.json
+            index 111..222 100644
+            --- a/src/SharpCompress/packages.lock.json
+            +++ b/src/SharpCompress/packages.lock.json
+            @@ -1,1 +1,1 @@
+            -{}
+            +{ "version": 2 }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("mixed scope"));
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0036Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0036Tests.cs
@@ -106,4 +106,81 @@ public class GCI0036Tests
 
         Assert.Empty(findings);
     }
+
+    [Fact]
+    public async Task LocalVarDeclarationInGetter_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/Foo.cs b/src/Foo.cs
+            index abc..def 100644
+            --- a/src/Foo.cs
+            +++ b/src/Foo.cs
+            @@ -1,6 +1,7 @@
+             public class Foo {
+                 private int _count;
+                 public int Count {
+                     get {
+            +            var result = _count * 2;
+                         return result;
+                     }
+                 }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task ForLoopVarInGetter_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/Foo.cs b/src/Foo.cs
+            index abc..def 100644
+            --- a/src/Foo.cs
+            +++ b/src/Foo.cs
+            @@ -1,6 +1,7 @@
+             public class Foo {
+                 private List<int> _items;
+                 public int Count {
+                     get {
+            +            for (var i = 0; i < _items.Count; i++) { }
+                         return _items.Count;
+                     }
+                 }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task TypeDeclarationInPureMethod_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/Foo.cs b/src/Foo.cs
+            index abc..def 100644
+            --- a/src/Foo.cs
+            +++ b/src/Foo.cs
+            @@ -1,5 +1,7 @@
+             public class Foo {
+                 [Pure]
+                 public Dictionary<string, string> GetMap() {
+            +        Dictionary<string, string> result = new();
+            +        string key = "default";
+                     return result;
+                 }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Empty(findings);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two false positive bugs discovered during corpus-based firing validation.

### GCI0036 – Pure Context Mutation

**Bug:** `HasAssignment()` used a simple `=` scan that fired on local variable declarations, for-loop counters, and type declarations.

**Fix:** New `IsFieldOrPropertyAssignment()` helper that skips `var` prefixes, `for(` prefixes, and any LHS with a space (type declaration vs field/property mutation).

**Tests added:** 3 regression tests.

---

### GCI0001 – Diff Integrity (Mixed Scope)

**Bug:** `packages.lock.json` was classified as `UnknownUnsupported`, causing GCI0001 to fire on every NuGet package update PR.

**Fix:** Added `LockFileNames` HashSet (9 known lock files); `CheckMixedScope` now excludes them.

**Tests added:** 1 regression test.

---

## Test Results

769 passed, 0 failed. Self-audit: 0 findings.
