### PR TITLE
[RULE] Track 1 precision fixes: test file exclusion, event handler ex…

### DIFF
--- a/src/GauntletCI.Core/Configuration/GauntletConfig.cs
+++ b/src/GauntletCI.Core/Configuration/GauntletConfig.cs
@@ -31,6 +31,9 @@ public class GauntletConfig
     /// <summary>Corpus pipeline configuration (local dev tool settings).</summary>
     public CorpusConfig Corpus { get; set; } = new();
 
+    /// <summary>Pattern consistency configuration.</summary>
+    public PatternConsistencyConfig PatternConsistency { get; set; } = new();
+
     /// <summary>Experimental feature flags. Settings here may change or be removed without notice.</summary>
     public ExperimentalConfig Experimental { get; set; } = new();
 }
@@ -181,4 +184,18 @@ public class OllamaEndpoint
 
     /// <summary>Whether this endpoint is active. Disabled endpoints are skipped during round-robin. Defaults to true.</summary>
     public bool Enabled { get; set; } = true;
+}
+
+/// <summary>
+/// Configuration for GCI0046 Pattern Consistency Deviation.
+/// </summary>
+public class PatternConsistencyConfig
+{
+    /// <summary>
+    /// Method base names for which a sync-only implementation is intentional.
+    /// GCI0046 will not flag a finding when both <c>Foo</c> and <c>FooAsync</c>
+    /// are added in the same diff and <c>Foo</c> appears in this list.
+    /// Example: ["Subscribe", "Unsubscribe", "Register", "Deregister"]
+    /// </summary>
+    public string[] AllowedSyncAsyncPairs { get; set; } = [];
 }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0016_ConcurrencyAndStateRisk.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0016_ConcurrencyAndStateRisk.cs
@@ -40,7 +40,10 @@ public class GCI0016_ConcurrencyAndStateRisk : RuleBase
 
         // Don't flag event handlers (common legitimate use)
         bool isEventHandler = content.Contains("EventHandler", StringComparison.Ordinal) ||
-                               content.Contains("sender", StringComparison.Ordinal);
+                               content.Contains("object sender", StringComparison.Ordinal) ||
+                               content.Contains("EventArgs", StringComparison.Ordinal) ||
+                               content.Contains("sender,", StringComparison.Ordinal) ||
+                               content.Contains("sender)", StringComparison.Ordinal);
         if (isEventHandler) return;
 
         findings.Add(CreateFinding(

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0022_IdempotencyRetrySafety.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0022_IdempotencyRetrySafety.cs
@@ -117,6 +117,9 @@ public class GCI0022_IdempotencyRetrySafety : RuleBase
             if (!content.Contains("Event") && !content.Contains("Handler") &&
                 !content.Contains("Listener") && !content.Contains("Callback")) continue;
 
+            // Exempt += inside a static constructor (runs exactly once — inherently idempotent)
+            if (IsInsideStaticConstructor(allLines, i)) continue;
+
             // Look for deduplication guard nearby (unsubscribe or bool guard)
             int start = Math.Max(0, i - 5);
             int end = Math.Min(allLines.Count, i + 10);
@@ -140,5 +143,42 @@ public class GCI0022_IdempotencyRetrySafety : RuleBase
                     line: line));
             }
         }
+    }
+
+    /// <summary>
+    /// Returns true when the line at <paramref name="idx"/> appears to be inside a static constructor,
+    /// which is inherently idempotent (runs exactly once per AppDomain lifetime).
+    /// Detects the pattern <c>static ClassName()</c> or <c>static()</c> within the preceding 20 lines.
+    /// </summary>
+    private static bool IsInsideStaticConstructor(List<DiffLine> allLines, int idx)
+    {
+        int searchStart = Math.Max(0, idx - 20);
+        for (int j = idx - 1; j >= searchStart; j--)
+        {
+            var trimmed = allLines[j].Content.Trim();
+            // Static constructors: no access modifier before "static", followed by TypeName()
+            // Pattern: optional whitespace + "static" + whitespace + word + "()"
+            // Regular static methods have a return type keyword (void, Task, bool, etc.) before the name
+            if (!trimmed.StartsWith("static ")) continue;
+            // Must look like a constructor signature: "static TypeName()" or "static TypeName(){"
+            // A static method would be "static void/Task/bool/..." which has a keyword after "static "
+            var afterStatic = trimmed["static ".Length..].TrimStart();
+            // If the next token is a C# keyword that can be a return type, it's a method not a constructor
+            if (afterStatic.StartsWith("void ", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("Task", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("bool ", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("int ", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("string ", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("async ", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("readonly ", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("class ", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("IEnumerable", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("List<", StringComparison.Ordinal) ||
+                afterStatic.StartsWith("Dictionary<", StringComparison.Ordinal))
+                continue;
+            // The remainder should look like "TypeName()" — contains "()"
+            if (afterStatic.Contains("()")) return true;
+        }
+        return false;
     }
 }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
@@ -4,6 +4,7 @@ using GauntletCI.Core.Analysis;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.StaticAnalysis;
+using GauntletCI.Core.Rules;
 
 namespace GauntletCI.Core.Rules.Implementations;
 
@@ -61,6 +62,8 @@ public class GCI0024_ResourceLifecycle : RuleBase
 
     private void CheckUnguardedDisposables(DiffFile file, List<Finding> findings)
     {
+        if (WellKnownPatterns.IsTestFile(file.NewPath)) return;
+
         var allLines = file.Hunks.SelectMany(h => h.Lines).ToList();
 
         for (int i = 0; i < allLines.Count; i++)

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0029_PiiLoggingLeak.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0029_PiiLoggingLeak.cs
@@ -21,9 +21,13 @@ public class GCI0029_PiiLoggingLeak : RuleBase
     [
         "email", "ssn", "socialsecurity", "phonenumber", "creditcard", "cardnumber",
         "dateofbirth", "passport", "nationalid", "taxid", "bankaccount",
-        "name", "address", "dob", "birthdate", "username", "zipcode", "postalcode",
+        "address", "dob", "birthdate", "username", "zipcode", "postalcode",
         "geolocation", "ipaddress", "deviceid", "token"
     ];
+
+    // "name" is weak — only fires when it appears in an assignment/interpolation context
+    // (e.g. name=, {name}, .name, "name") to avoid false positives on prose like "by name"
+    private static readonly string[] WeakPiiTerms = ["name"];
 
     private static readonly string[] LogPrefixes =
     [
@@ -56,6 +60,16 @@ public class GCI0029_PiiLoggingLeak : RuleBase
                 {
                     if (ContainsPiiTerm(content, term))
                     { matchedTerm = term; break; }
+                }
+
+                // Weak terms require assignment/interpolation context to reduce prose FPs
+                if (matchedTerm is null)
+                {
+                    foreach (var term in WeakPiiTerms)
+                    {
+                        if (ContainsPiiTerm(content, term) && ContainsWeakTermInContext(content, term))
+                        { matchedTerm = term; break; }
+                    }
                 }
                 if (matchedTerm is null) continue;
 
@@ -91,4 +105,17 @@ public class GCI0029_PiiLoggingLeak : RuleBase
     }
 
     private static bool IsWordChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    /// <summary>
+    /// Returns true when a weak PII term (e.g. "name") appears in an assignment or interpolation
+    /// context rather than prose. Requires one of: .name, name=, name:, {name, "name" (quoted).
+    /// </summary>
+    private static bool ContainsWeakTermInContext(string content, string term)
+    {
+        return content.Contains($".{term}", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains($"{term}=", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains($"{term}:", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains($"{{{term}", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains($"\"{term}\"", StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0036_PureContextMutation.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0036_PureContextMutation.cs
@@ -2,6 +2,7 @@
 using GauntletCI.Core.Analysis;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
 
 namespace GauntletCI.Core.Rules.Implementations;
 
@@ -30,6 +31,8 @@ public class GCI0036_PureContextMutation : RuleBase
 
     private void CheckPureContextMutations(DiffFile file, List<Finding> findings)
     {
+        if (WellKnownPatterns.IsTestFile(file.NewPath)) return;
+
         var allLines = file.Hunks.SelectMany(h => h.Lines).ToList();
 
         int braceDepth = 0;

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0043_NullabilityTypeSafety.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0043_NullabilityTypeSafety.cs
@@ -109,6 +109,9 @@ public class GCI0043_NullabilityTypeSafety : RuleBase
             var content = addedLines[i].Content;
             if (!content.Contains(" as ", StringComparison.Ordinal)) continue;
 
+            // Skip XML doc comment lines — they contain "as" in natural prose
+            if (content.TrimStart().StartsWith("///")) continue;
+
             // Check the same line and ±2 neighboring added lines for null checks
             int start = Math.Max(0, i - 2);
             int end = Math.Min(addedLines.Count - 1, i + 2);

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0045_ComplexityControl.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0045_ComplexityControl.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using GauntletCI.Core.Analysis;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
 
 namespace GauntletCI.Core.Rules.Implementations;
 
@@ -114,6 +115,8 @@ public class GCI0045_ComplexityControl : RuleBase
     {
         foreach (var file in diff.Files)
         {
+            if (WellKnownPatterns.IsTestFile(file.NewPath)) continue;
+
             var delegatingMethods = file.AddedLines
                 .Where(l => DelegationCallRegex.IsMatch(l.Content))
                 .ToList();

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0046_PatternConsistencyDeviation.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0046_PatternConsistencyDeviation.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.Text.RegularExpressions;
 using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Configuration;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
 
@@ -10,7 +11,7 @@ namespace GauntletCI.Core.Rules.Implementations;
 /// GCI0046 – Pattern Consistency Deviation
 /// Detects service locator anti-patterns and mixed sync/async naming within the same file.
 /// </summary>
-public class GCI0046_PatternConsistencyDeviation : RuleBase
+public class GCI0046_PatternConsistencyDeviation : RuleBase, IConfigurableRule
 {
     public override string Id => "GCI0046";
     public override string Name => "Pattern Consistency Deviation";
@@ -32,6 +33,15 @@ public class GCI0046_PatternConsistencyDeviation : RuleBase
         return string.Equals(fileName, "Program.cs", StringComparison.OrdinalIgnoreCase)
             || string.Equals(fileName, "Startup.cs", StringComparison.OrdinalIgnoreCase)
             || fileName.EndsWith("Extensions.cs", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private HashSet<string> _allowedSyncAsyncPairs = new(StringComparer.Ordinal);
+
+    public void Configure(GauntletConfig config)
+    {
+        _allowedSyncAsyncPairs = new HashSet<string>(
+            config.PatternConsistency.AllowedSyncAsyncPairs,
+            StringComparer.Ordinal);
     }
 
     public override Task<List<Finding>> EvaluateAsync(
@@ -86,6 +96,9 @@ public class GCI0046_PatternConsistencyDeviation : RuleBase
         foreach (var baseName in asyncMethodBases)
         {
             if (!addedMethodNames.Contains(baseName)) continue;
+
+            // Skip pairs that are intentionally sync+async (configured allowlist)
+            if (_allowedSyncAsyncPairs.Contains(baseName)) continue;
 
             findings.Add(CreateFinding(
                 file,

--- a/src/GauntletCI.Tests/Rules/GCI0016Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0016Tests.cs
@@ -100,4 +100,22 @@ public class GCI0016Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("lock"));
     }
+
+    [Fact]
+    public async Task AsyncVoidEventHandlerWithSender_ShouldNotFlag()
+    {
+        var diff = MakeDiff("    private async void OnClick(object sender, EventArgs e) { await DoWorkAsync(); }");
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("async void"));
+    }
+
+    [Fact]
+    public async Task AsyncVoidEventHandlerWithEventArgs_ShouldNotFlag()
+    {
+        var diff = MakeDiff("    private async void OnChanged(object sender, PropertyChangedEventArgs e) { }");
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("async void"));
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0022Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0022Tests.cs
@@ -96,4 +96,28 @@ public class GCI0022Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("Raw INSERT without upsert"));
     }
+
+    [Fact]
+    public async Task EventPlusEqualsInStaticConstructor_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/AppEvents.cs b/src/AppEvents.cs
+            index abc..def 100644
+            --- a/src/AppEvents.cs
+            +++ b/src/AppEvents.cs
+            @@ -1,3 +1,8 @@
+             public class AppEvents {
+            +    static AppEvents()
+            +    {
+            +        AppDomain.CurrentDomain.UnhandledException += GlobalExceptionHandler;
+            +        AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+            +    }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("deduplication"));
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0024Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0024Tests.cs
@@ -116,4 +116,45 @@ public class GCI0024Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("HttpClient"));
     }
+
+    [Fact]
+    public async Task MemoryStreamInTestFile_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/GauntletCI.Tests/FileProcessorTests.cs b/src/GauntletCI.Tests/FileProcessorTests.cs
+            index abc..def 100644
+            --- a/src/GauntletCI.Tests/FileProcessorTests.cs
+            +++ b/src/GauntletCI.Tests/FileProcessorTests.cs
+            @@ -1,2 +1,4 @@
+             public class FileProcessorTests {
+            +    var ms = new MemoryStream();
+            +    ms.Write(new byte[] { 1, 2, 3 }, 0, 3);
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("MemoryStream"));
+    }
+
+    [Fact]
+    public async Task MemoryStreamInProductionFile_ShouldFlag()
+    {
+        var raw = """
+            diff --git a/src/DataExporter.cs b/src/DataExporter.cs
+            index abc..def 100644
+            --- a/src/DataExporter.cs
+            +++ b/src/DataExporter.cs
+            @@ -1,2 +1,3 @@
+             public class DataExporter {
+            +    var ms = new MemoryStream();
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.Summary.Contains("MemoryStream"));
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0029Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0029Tests.cs
@@ -109,4 +109,44 @@ public class GCI0029Tests
 
         Assert.Empty(findings);
     }
+
+    [Fact]
+    public async Task NameInProse_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/UserService.cs b/src/UserService.cs
+            index abc..def 100644
+            --- a/src/UserService.cs
+            +++ b/src/UserService.cs
+            @@ -1,3 +1,4 @@
+             public class UserService {
+            +    _logger.LogInformation("Getting user by name");
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("name"));
+    }
+
+    [Fact]
+    public async Task NamePropertyInLogCall_ShouldFlag()
+    {
+        var raw = """
+            diff --git a/src/UserService.cs b/src/UserService.cs
+            index abc..def 100644
+            --- a/src/UserService.cs
+            +++ b/src/UserService.cs
+            @@ -1,3 +1,4 @@
+             public class UserService {
+            +    _logger.LogInformation("User {name}", user.name);
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.Summary.Contains("name"));
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0036Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0036Tests.cs
@@ -183,4 +183,30 @@ public class GCI0036Tests
 
         Assert.Empty(findings);
     }
+
+    [Fact]
+    public async Task AssignmentInGetterInTestFile_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/GauntletCI.Tests/FooTests.cs b/src/GauntletCI.Tests/FooTests.cs
+            index abc..def 100644
+            --- a/src/GauntletCI.Tests/FooTests.cs
+            +++ b/src/GauntletCI.Tests/FooTests.cs
+            @@ -1,7 +1,8 @@
+             public class FooTests {
+                 private int _count;
+                 public int Count {
+                     get {
+            +            _count = 42;
+                         return _count;
+                     }
+                 }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("mutation") || f.Summary.Contains("getter"));
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0043Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0043Tests.cs
@@ -184,4 +184,25 @@ public class GCI0043Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("Null-forgiving"));
     }
+
+    [Fact]
+    public async Task XmlDocCommentWithAs_ShouldNotFire()
+    {
+        var raw = """
+            diff --git a/src/OrderService.cs b/src/OrderService.cs
+            index abc..def 100644
+            --- a/src/OrderService.cs
+            +++ b/src/OrderService.cs
+            @@ -1,3 +1,5 @@
+             public class OrderService {
+            +    /// <summary>Returns the result reported as a string.</summary>
+            +    public string GetReported() => "ok";
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("as-cast"));
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0045Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0045Tests.cs
@@ -168,4 +168,27 @@ public class GCI0045Tests
 
         Assert.Contains(findings, f => f.Summary.Contains("delegation") || f.Summary.Contains("wrapper"));
     }
+
+    [Fact]
+    public async Task DelegationWrapperInTestFile_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/GauntletCI.Tests/FakeServiceTests.cs b/src/GauntletCI.Tests/FakeServiceTests.cs
+            index abc..def 100644
+            --- a/src/GauntletCI.Tests/FakeServiceTests.cs
+            +++ b/src/GauntletCI.Tests/FakeServiceTests.cs
+            @@ -1,3 +1,9 @@
+             public class FakeService {
+            +    public string GetA() => return _inner.GetA();
+            +    public string GetB() => return _inner.GetB();
+            +    public string GetC() => return _inner.GetC();
+            +    public string GetD() => return _inner.GetD();
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("delegation") || f.Summary.Contains("wrapper"));
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0046Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0046Tests.cs
@@ -125,4 +125,37 @@ public class GCI0046Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("sync/async") || f.Summary.Contains("Async"));
     }
+
+    [Fact]
+    public async Task AllowlistedSyncAsyncPair_ShouldNotFire()
+    {
+        var raw = """
+            diff --git a/src/EventBus.cs b/src/EventBus.cs
+            index abc..def 100644
+            --- a/src/EventBus.cs
+            +++ b/src/EventBus.cs
+            @@ -1,3 +1,7 @@
+             public class EventBus {
+            +    public void Subscribe(string topic, Action handler) {
+            +        _handlers[topic] = handler;
+            +    }
+            +    public async Task SubscribeAsync(string topic, Func<Task> handler) {
+            +        await _store.RegisterAsync(topic, handler);
+            +    }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var rule = new GCI0046_PatternConsistencyDeviation();
+        rule.Configure(new GauntletCI.Core.Configuration.GauntletConfig
+        {
+            PatternConsistency = new GauntletCI.Core.Configuration.PatternConsistencyConfig
+            {
+                AllowedSyncAsyncPairs = ["Subscribe"]
+            }
+        });
+        var findings = await rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("Subscribe"));
+    }
 }


### PR DESCRIPTION
GCI0010 CheckSecrets:
- content.Contains('=') matched == operators; replaced with HasAssignment() which skips ==, !=, <=, >= and => lambdas
- Secret keyword was checked against the full line; now only checked against the left-hand side of the assignment to avoid type names like HtmlTokenType

GCI0021 CheckRemovedSerializationAttributes:
- [Key] pattern used Contains() with OrdinalIgnoreCase, matching dictionary[key] and similar indexer accesses; changed to StartsWith() since attributes always begin a line after trimming

Tests: added 5 regression cases covering both bugs
AGENTS.md: added branch-per-change rule to Pre-Commit & Push Rules