### PR TITLE
[DOCS] Fix empty name/short_name in site.webmanifest

### DIFF
--- a/docs/site.webmanifest
+++ b/docs/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"GauntletCI","short_name":"GauntletCI","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
Fixes the empty \
ame\ and \short_name\ fields in \site.webmanifest\ flagged in PR #104 review.

Sets both to \GauntletCI\ so browsers display a proper label when users add the docs site to their home screen or install it as a PWA.