### PR TITLE
[RULE][CLI] TFM-aware rule messages and SARIF 2.1.0 output

### DIFF
--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -34,7 +34,7 @@ public static class AnalyzeCommand
         var outputOption = new Option<string>(
             "--output",
             () => "text",
-            "Output format: text or json");
+            "Output format: text, json, or sarif");
         var noLlmFlag = new Option<bool>("--no-llm", "Disable LLM enrichment (deprecated — LLM is now opt-in via --with-llm)") { IsHidden = true };
         var withLlmFlag = new Option<bool>("--with-llm", "Enable LLM enrichment of High-confidence findings (requires 'gauntletci model download', adds latency)");
         var asciiFlag = new Option<bool>("--ascii", "Use ASCII-only output (for terminals without Unicode support)");
@@ -119,7 +119,8 @@ public static class AnalyzeCommand
                 return;
             }
 
-            if (prCommentSuggest && "json".Equals(output, StringComparison.OrdinalIgnoreCase))
+            if (prCommentSuggest && ("json".Equals(output, StringComparison.OrdinalIgnoreCase)
+                || "sarif".Equals(output, StringComparison.OrdinalIgnoreCase)))
             {
                 Console.Error.WriteLine("[GauntletCI] Error: --pr-comment-suggest cannot be combined with --output json (produces invalid output). Use --output text or omit --output.");
                 ctx.ExitCode = 1;
@@ -131,7 +132,6 @@ public static class AnalyzeCommand
                 NoBanner = noBanner,
                 OutputFormat = output ?? "text",
             });
-
             try
             {
                 var diff = diffFile is not null
@@ -170,8 +170,9 @@ public static class AnalyzeCommand
 
                 using ILlmEngine llm = await LlmEngineSelector.ResolveAsync(config, withLlm && !noLlm);
 
-                var isJsonOutput = (output ?? "text").Equals("json", StringComparison.OrdinalIgnoreCase);
-                var showSpinner  = llm.IsAvailable && !isJsonOutput && !Console.IsOutputRedirected;
+                var isJsonOutput  = (output ?? "text").Equals("json", StringComparison.OrdinalIgnoreCase);
+                var isSarifOutput = (output ?? "text").Equals("sarif", StringComparison.OrdinalIgnoreCase);
+                var showSpinner   = llm.IsAvailable && !isJsonOutput && !isSarifOutput && !Console.IsOutputRedirected;
 
                 async Task RunLlmStepsAsync(Action<string>? setStatus = null)
                 {
@@ -231,7 +232,11 @@ public static class AnalyzeCommand
                 else
                     await RunLlmStepsAsync();
 
-                if ((output ?? "text").Equals("json", StringComparison.OrdinalIgnoreCase))
+                if (isSarifOutput)
+                {
+                    SarifWriter.Write(result);
+                }
+                else if ((output ?? "text").Equals("json", StringComparison.OrdinalIgnoreCase))
                 {
                     // Always emit a consistent schema regardless of baseline suppression.
                     // RuleMetrics FindingCount is recomputed from remaining (non-suppressed) findings.

--- a/src/GauntletCI.Cli/Output/SarifWriter.cs
+++ b/src/GauntletCI.Cli/Output/SarifWriter.cs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+
+namespace GauntletCI.Cli.Output;
+
+/// <summary>
+/// Serialises an <see cref="EvaluationResult"/> to SARIF 2.1.0 format so findings can be
+/// consumed by GitHub Advanced Security, DefectDojo, and other SARIF-compatible tools.
+/// </summary>
+public static class SarifWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>Writes a SARIF 2.1.0 document to <see cref="Console.Out"/>.</summary>
+    public static void Write(EvaluationResult result)
+        => Console.WriteLine(Serialize(result));
+
+    /// <summary>Builds and returns the SARIF 2.1.0 JSON string.</summary>
+    public static string Serialize(EvaluationResult result)
+    {
+        var rules = result.Findings
+            .Select(f => new { f.RuleId, f.RuleName })
+            .DistinctBy(r => r.RuleId)
+            .OrderBy(r => r.RuleId)
+            .Select(r => (object)new
+            {
+                id = r.RuleId,
+                name = SanitizeName(r.RuleName),
+                shortDescription = new { text = r.RuleName },
+                helpUri = $"https://gauntletci.com/rules/{r.RuleId}",
+            })
+            .ToList();
+
+        var results = result.Findings.Select(f => BuildResult(f)).ToList();
+
+        var sarif = new
+        {
+            @__schema = "https://json.schemastore.org/sarif-2.1.0.json",
+            version = "2.1.0",
+            runs = new[]
+            {
+                new
+                {
+                    tool = new
+                    {
+                        driver = new
+                        {
+                            name = "GauntletCI",
+                            version = "2.0.0",
+                            informationUri = "https://gauntletci.com",
+                            rules,
+                        }
+                    },
+                    results,
+                }
+            }
+        };
+
+        // Rename __schema → $schema after serialization (JsonSerializer can't emit $ keys)
+        var json = JsonSerializer.Serialize(sarif, JsonOptions);
+        return json.Replace("\"__schema\"", "\"$schema\"");
+    }
+
+    private static object BuildResult(Finding finding)
+    {
+        var level = finding.Severity switch
+        {
+            RuleSeverity.Block    => "error",
+            RuleSeverity.Warn     => "warning",
+            _                     => "note",
+        };
+
+        var message = string.IsNullOrWhiteSpace(finding.WhyItMatters)
+            ? finding.Summary
+            : $"{finding.Summary} — {finding.WhyItMatters}";
+
+        if (!string.IsNullOrWhiteSpace(finding.SuggestedAction))
+            message += $" Action: {finding.SuggestedAction}";
+
+        if (finding.FilePath is { } path && finding.Line is { } line)
+        {
+            return new
+            {
+                ruleId = finding.RuleId,
+                message = new { text = message },
+                level,
+                locations = new[]
+                {
+                    new
+                    {
+                        physicalLocation = new
+                        {
+                            artifactLocation = new
+                            {
+                                uri = path.Replace('\\', '/'),
+                                uriBaseId = "%SRCROOT%",
+                            },
+                            region = new { startLine = line },
+                        }
+                    }
+                },
+            };
+        }
+
+        return new
+        {
+            ruleId = finding.RuleId,
+            message = new { text = message },
+            level,
+        };
+    }
+
+    private static string SanitizeName(string name) =>
+        new string(name.Where(c => char.IsLetterOrDigit(c)).ToArray());
+}

--- a/src/GauntletCI.Core/Analysis/AnalysisContext.cs
+++ b/src/GauntletCI.Core/Analysis/AnalysisContext.cs
@@ -30,4 +30,11 @@ public sealed class AnalysisContext
 
     /// <summary>Optional static analysis results for the diff.</summary>
     public AnalyzerResult? StaticAnalysis { get; init; }
+
+    /// <summary>
+    /// Primary target framework moniker detected from the repo's .csproj files
+    /// (e.g. <c>net8.0</c>, <c>net9.0</c>). Null when detection was not possible.
+    /// Rules use this to tailor suggested actions to the target platform.
+    /// </summary>
+    public string? TargetFramework { get; init; }
 }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0048_InsecureRandomInSecurityContext.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0048_InsecureRandomInSecurityContext.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using GauntletCI.Core.Analysis;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
+using GauntletCI.Core.StaticAnalysis;
 
 namespace GauntletCI.Core.Rules.Implementations;
 
@@ -32,6 +33,12 @@ public class GCI0048_InsecureRandomInSecurityContext : RuleBase
         AnalysisContext context, CancellationToken ct = default)
     {
         var findings = new List<Finding>();
+        var isNet8Plus = TargetFrameworkDetector.IsNet8OrLater(context.TargetFramework);
+        var suggestedAction = isNet8Plus
+            ? "Replace with RandomNumberGenerator.GetBytes() or RandomNumberGenerator.GetHexString() " +
+              "(.NET 8+) for security-sensitive values."
+            : "Replace with RandomNumberGenerator.GetBytes() (System.Security.Cryptography) " +
+              "for security-sensitive values.";
 
         foreach (var file in context.Diff.Files)
         {
@@ -66,8 +73,7 @@ public class GCI0048_InsecureRandomInSecurityContext : RuleBase
                     whyItMatters: "System.Random is a pseudo-random number generator seeded from the system clock. " +
                                   "Its output is predictable and must never be used for cryptographic purposes " +
                                   "such as generating tokens, keys, salts, nonces, or passwords.",
-                    suggestedAction: "Replace with RandomNumberGenerator.GetBytes() (System.Security.Cryptography) " +
-                                     "or RandomNumberGenerator.GetHexString() (.NET 8+) for security-sensitive values.",
+                    suggestedAction: suggestedAction,
                     confidence: Confidence.High,
                     line: line));
             }

--- a/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
+++ b/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
@@ -131,6 +131,7 @@ public class RuleOrchestrator
             FileStatistics = fileStatistics,
             Diff           = filteredDiff,
             StaticAnalysis = staticAnalysis,
+            TargetFramework = staticAnalysis?.TargetFramework,
         };
 
         var allFindings = new List<Finding>();

--- a/src/GauntletCI.Core/StaticAnalysis/AnalyzerResult.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/AnalyzerResult.cs
@@ -11,6 +11,11 @@ public class AnalyzerResult
     public string AnalyzedFile { get; init; } = string.Empty;
     public bool Success { get; init; }
     public string? ErrorMessage { get; init; }
+    /// <summary>
+    /// Primary target framework moniker detected from the repo's .csproj files
+    /// (e.g. <c>net8.0</c>, <c>net6.0</c>). Null when detection was not possible.
+    /// </summary>
+    public string? TargetFramework { get; init; }
 }
 
 public class AnalyzerDiagnostic

--- a/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
@@ -32,13 +32,15 @@ public static class StaticAnalysisRunner
         if (string.IsNullOrEmpty(repoPath))
             return null;
 
+        var tfm = TargetFrameworkDetector.Detect(repoPath);
+
         var csFiles = diff.Files
             .Where(f => !f.IsDeleted &&
                         f.NewPath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
             .ToList();
 
         if (csFiles.Count == 0)
-            return null;
+            return tfm is null ? null : new AnalyzerResult { TargetFramework = tfm, Success = true };
 
         var allDiagnostics = new List<AnalyzerDiagnostic>();
         var anySuccess = false;
@@ -82,7 +84,8 @@ public static class StaticAnalysisRunner
         {
             AnalyzedFile = $"[{csFiles.Count} file(s)]",
             Success = anySuccess,
-            Diagnostics = allDiagnostics
+            Diagnostics = allDiagnostics,
+            TargetFramework = tfm,
         };
     }
 }

--- a/src/GauntletCI.Core/StaticAnalysis/TargetFrameworkDetector.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/TargetFrameworkDetector.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.RegularExpressions;
+
+namespace GauntletCI.Core.StaticAnalysis;
+
+/// <summary>
+/// Reads the first <c>&lt;TargetFramework&gt;</c> or <c>&lt;TargetFrameworks&gt;</c> value
+/// found in any <c>.csproj</c> file under the repository root.
+/// Used to tailor rule messages to the actual target TFM rather than always assuming net8.
+/// </summary>
+public static class TargetFrameworkDetector
+{
+    private static readonly Regex TfmPattern =
+        new(@"<TargetFrameworks?>([^<]+)</TargetFrameworks?>", RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Scans <paramref name="repoPath"/> for the first <c>.csproj</c> that declares a target
+    /// framework and returns the primary TFM (the first entry when multiple are listed).
+    /// Returns <c>null</c> when no project file is found or no TFM can be parsed.
+    /// </summary>
+    public static string? Detect(string repoPath)
+    {
+        if (string.IsNullOrEmpty(repoPath) || !Directory.Exists(repoPath))
+            return null;
+
+        try
+        {
+            foreach (var csproj in Directory.EnumerateFiles(repoPath, "*.csproj", SearchOption.AllDirectories))
+            {
+                string xml;
+                try { xml = File.ReadAllText(csproj); }
+                catch (IOException) { continue; }
+
+                var match = TfmPattern.Match(xml);
+                if (!match.Success) continue;
+
+                // <TargetFrameworks> may contain semicolon-separated values; take the first
+                var primary = match.Groups[1].Value.Trim().Split(';')[0].Trim();
+                if (!string.IsNullOrEmpty(primary))
+                    return primary;
+            }
+        }
+        catch (Exception)
+        {
+            // File system errors are non-fatal — TFM detection is best-effort
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="tfm"/> targets .NET 8 or later
+    /// (e.g. <c>net8.0</c>, <c>net9.0</c>).
+    /// Framework monikers like <c>netstandard</c>, <c>netcoreapp</c>, and <c>net4x</c> return false.
+    /// </summary>
+    public static bool IsNet8OrLater(string? tfm)
+    {
+        if (string.IsNullOrEmpty(tfm)) return false;
+
+        // net8.0, net9.0, net10.0, …  — match netN.M where N >= 8
+        var m = Regex.Match(tfm, @"^net(\d+)\.\d+$", RegexOptions.IgnoreCase);
+        return m.Success && int.TryParse(m.Groups[1].Value, out var major) && major >= 8;
+    }
+}

--- a/src/GauntletCI.Tests/RuleTestExtensions.cs
+++ b/src/GauntletCI.Tests/RuleTestExtensions.cs
@@ -23,7 +23,8 @@ internal static class RuleTestExtensions
         this IRule rule,
         DiffContext diff,
         AnalyzerResult? staticAnalysis = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? targetFramework = null)
     {
         var allRecords      = diff.Files.Select(f => FileAnalyzer.Analyze(f)).ToList();
         var eligibleRecords = allRecords.Where(r => r.IsEligible).ToList();
@@ -43,11 +44,12 @@ internal static class RuleTestExtensions
 
         var context = new AnalysisContext
         {
-            EligibleFiles  = eligibleRecords,
-            SkippedFiles   = skippedRecords,
-            FileStatistics = FileEligibilityStatistics.From(allRecords),
-            Diff           = filteredDiff,
-            StaticAnalysis = staticAnalysis,
+            EligibleFiles   = eligibleRecords,
+            SkippedFiles    = skippedRecords,
+            FileStatistics  = FileEligibilityStatistics.From(allRecords),
+            Diff            = filteredDiff,
+            StaticAnalysis  = staticAnalysis,
+            TargetFramework = targetFramework ?? staticAnalysis?.TargetFramework,
         };
 
         return rule.EvaluateAsync(context, ct);

--- a/src/GauntletCI.Tests/SarifWriterTests.cs
+++ b/src/GauntletCI.Tests/SarifWriterTests.cs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.Json;
+using GauntletCI.Cli.Output;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+using GauntletCI.Core.StaticAnalysis;
+
+namespace GauntletCI.Tests;
+
+public class TargetFrameworkDetectorTests
+{
+    [Theory]
+    [InlineData("net8.0",  true)]
+    [InlineData("net9.0",  true)]
+    [InlineData("net10.0", true)]
+    [InlineData("net6.0",  false)]
+    [InlineData("net7.0",  false)]
+    [InlineData("netstandard2.0", false)]
+    [InlineData("netcoreapp3.1", false)]
+    [InlineData("net48",  false)]
+    [InlineData(null,     false)]
+    [InlineData("",       false)]
+    public void IsNet8OrLater_ReturnsExpected(string? tfm, bool expected)
+        => Assert.Equal(expected, TargetFrameworkDetector.IsNet8OrLater(tfm));
+
+    [Fact]
+    public void Detect_NullOrEmptyPath_ReturnsNull()
+    {
+        Assert.Null(TargetFrameworkDetector.Detect(null!));
+        Assert.Null(TargetFrameworkDetector.Detect(""));
+    }
+
+    [Fact]
+    public void Detect_MissingDirectory_ReturnsNull()
+        => Assert.Null(TargetFrameworkDetector.Detect(@"C:\this\path\does\not\exist"));
+
+    [Fact]
+    public void Detect_CsprojWithTargetFramework_ReturnsValue()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "App.csproj"),
+                "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>");
+
+            Assert.Equal("net8.0", TargetFrameworkDetector.Detect(dir));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Detect_CsprojWithTargetFrameworks_ReturnsPrimary()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Lib.csproj"),
+                "<Project><PropertyGroup><TargetFrameworks>net8.0;net6.0</TargetFrameworks></PropertyGroup></Project>");
+
+            Assert.Equal("net8.0", TargetFrameworkDetector.Detect(dir));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Detect_NoCsproj_ReturnsNull()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "README.md"), "# hello");
+            Assert.Null(TargetFrameworkDetector.Detect(dir));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}
+
+public class SarifWriterTests
+{
+    private static EvaluationResult BuildResult(params Finding[] findings) =>
+        new()
+        {
+            CommitSha = "abc1234",
+            Findings = [.. findings],
+            RulesEvaluated = 1,
+        };
+
+    [Fact]
+    public void Serialize_EmptyFindings_ValidSarifSchema()
+    {
+        var result = BuildResult();
+        var json = SarifWriter.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.Equal("2.1.0", doc.RootElement.GetProperty("version").GetString());
+        Assert.True(doc.RootElement.TryGetProperty("$schema", out _));
+        var runs = doc.RootElement.GetProperty("runs");
+        Assert.Equal(JsonValueKind.Array, runs.ValueKind);
+        Assert.Equal(0, runs[0].GetProperty("results").GetArrayLength());
+    }
+
+    [Fact]
+    public void Serialize_BlockFinding_LevelIsError()
+    {
+        var finding = new Finding
+        {
+            RuleId = "GCI0048",
+            RuleName = "Insecure Random in Security Context",
+            Summary = "System.Random used near token",
+            Evidence = "Line 5: var r = new Random();",
+            WhyItMatters = "Predictable output",
+            SuggestedAction = "Use RandomNumberGenerator",
+            Confidence = Confidence.High,
+            Severity = RuleSeverity.Block,
+            FilePath = "src/Auth.cs",
+            Line = 5,
+        };
+
+        var json = SarifWriter.Serialize(BuildResult(finding));
+        var doc = JsonDocument.Parse(json);
+        var result = doc.RootElement.GetProperty("runs")[0].GetProperty("results")[0];
+
+        Assert.Equal("GCI0048", result.GetProperty("ruleId").GetString());
+        Assert.Equal("error", result.GetProperty("level").GetString());
+
+        var loc = result.GetProperty("locations")[0]
+            .GetProperty("physicalLocation");
+        Assert.Equal("src/Auth.cs", loc.GetProperty("artifactLocation").GetProperty("uri").GetString());
+        Assert.Equal(5, loc.GetProperty("region").GetProperty("startLine").GetInt32());
+    }
+
+    [Fact]
+    public void Serialize_WarnFinding_LevelIsWarning()
+    {
+        var finding = new Finding
+        {
+            RuleId = "GCI0001",
+            RuleName = "Diff Integrity",
+            Summary = "Test",
+            Evidence = "Line 1: foo",
+            WhyItMatters = "Why",
+            SuggestedAction = "Action",
+            Confidence = Confidence.Medium,
+            Severity = RuleSeverity.Warn,
+        };
+
+        var json = SarifWriter.Serialize(BuildResult(finding));
+        var doc = JsonDocument.Parse(json);
+        var result = doc.RootElement.GetProperty("runs")[0].GetProperty("results")[0];
+
+        Assert.Equal("warning", result.GetProperty("level").GetString());
+    }
+
+    [Fact]
+    public void Serialize_RulesDeduplicatedInDriver()
+    {
+        var f1 = new Finding
+        {
+            RuleId = "GCI0001", RuleName = "Rule One", Summary = "s", Evidence = "e",
+            WhyItMatters = "w", SuggestedAction = "a", Confidence = Confidence.Low, Severity = RuleSeverity.Info,
+        };
+        var f2 = new Finding
+        {
+            RuleId = "GCI0001", RuleName = "Rule One", Summary = "s2", Evidence = "e2",
+            WhyItMatters = "w2", SuggestedAction = "a2", Confidence = Confidence.Low, Severity = RuleSeverity.Info,
+        };
+
+        var json = SarifWriter.Serialize(BuildResult(f1, f2));
+        var doc = JsonDocument.Parse(json);
+        var rules = doc.RootElement.GetProperty("runs")[0]
+            .GetProperty("tool").GetProperty("driver").GetProperty("rules");
+
+        Assert.Equal(1, rules.GetArrayLength());
+    }
+}


### PR DESCRIPTION
## What changed

Two independent improvements shipped together as quick-win items from the backlog.

### 1. TFM-aware rule messages (`tfm-aware-rule-messages`)

GCI0048 (Insecure Random in Security Context) previously hard-coded a `.NET 8+` API suggestion (`GetHexString`) regardless of the target project's actual framework. It now tailors its suggested action based on the detected TFM:

- **net8.0+** → suggests `RandomNumberGenerator.GetHexString()` (the idiomatic .NET 8 API)
- **net7.0 and earlier / unknown** → suggests the universally available `RandomNumberGenerator.GetBytes()` pattern

**New utility: `TargetFrameworkDetector`**
- Scans the repo for `.csproj` files and extracts `<TargetFramework>` / `<TargetFrameworks>`
- `IsNet8OrLater(tfm)` parses `netX.Y` version strings
- TFM is detected once in `StaticAnalysisRunner` and threaded through `AnalyzerResult` → `AnalysisContext` → rules
- Detection is best-effort and wrapped in try/catch; rules degrade gracefully when TFM is unknown

### 2. SARIF 2.1.0 output (`audit-sarif-output`)

New `--output sarif` mode for `gauntletci analyze`:

- Emits a valid [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) document to stdout
- Includes tool driver metadata, deduplicated rules array, results with file/line locations
- Severity → level mapping: `Block` → `error`, `Warn` → `warning`, `Info`/`Advisory` → `note`
- Banner and spinner are suppressed when `--output sarif` is used (stdout stays clean for piping)
- `--pr-comment-suggest` now rejects both `json` and `sarif` output modes

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- `TargetFrameworkDetectorTests` — 9 tests covering `IsNet8OrLater` theory cases, null/empty/missing path, csproj detection, multi-TFM primary extraction, no-csproj fallback
- `SarifWriterTests` — 4 tests covering empty findings, `Block`→`error` level mapping, `Warn`→`warning` level mapping, rule deduplication in the driver

All 861 tests pass (up from 842 before this branch).

## Checklist

- [x] Self-reviewed
- [x] Tests added and passing (861 total, 0 failures)
- [x] No new warnings
- [x] Backward-compatible — existing `--output json` and default text output unchanged