### PR TITLE
[RULE] Add Roslyn syntax guards for GCI0048/GCI0049 FP reduction

### DIFF
--- a/src/GauntletCI.Core/Analysis/AnalysisContext.cs
+++ b/src/GauntletCI.Core/Analysis/AnalysisContext.cs
@@ -32,6 +32,13 @@ public sealed class AnalysisContext
     public AnalyzerResult? StaticAnalysis { get; init; }
 
     /// <summary>
+    /// Roslyn syntax trees for files analyzed in this run.
+    /// Used by rules to perform syntax-level false-positive guards.
+    /// Null when no C# files were analyzed or static analysis was skipped.
+    /// </summary>
+    public SyntaxContext? Syntax { get; init; }
+
+    /// <summary>
     /// Primary target framework moniker detected from the repo's .csproj files
     /// (e.g. <c>net8.0</c>, <c>net9.0</c>). Null when detection was not possible.
     /// Rules use this to tailor suggested actions to the target platform.

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0048_InsecureRandomInSecurityContext.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0048_InsecureRandomInSecurityContext.cs
@@ -48,11 +48,11 @@ public class GCI0048_InsecureRandomInSecurityContext : RuleBase
             for (int i = 0; i < addedLines.Count; i++)
             {
                 var line = addedLines[i];
-                if (!NewRandomRegex.IsMatch(line.Content)) continue;
+                var match = NewRandomRegex.Match(line.Content);
+                if (!match.Success) continue;
 
-                // Syntax guard: suppress if Roslyn confirms the match is inside a comment
-                // or string literal (e.g. quoted code samples, end-of-line comments).
-                if (context.Syntax?.IsInCommentOrStringLiteral(file.NewPath, line.LineNumber) == true)
+                // Syntax guard: suppress if the match position is inside a comment or string literal.
+                if (context.Syntax?.IsInCommentOrStringLiteral(file.NewPath, line.LineNumber, match.Index) == true)
                     continue;
 
                 // Check ±5 surrounding added lines for security-sensitive identifiers

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0048_InsecureRandomInSecurityContext.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0048_InsecureRandomInSecurityContext.cs
@@ -50,6 +50,11 @@ public class GCI0048_InsecureRandomInSecurityContext : RuleBase
                 var line = addedLines[i];
                 if (!NewRandomRegex.IsMatch(line.Content)) continue;
 
+                // Syntax guard: suppress if Roslyn confirms the match is inside a comment
+                // or string literal (e.g. quoted code samples, end-of-line comments).
+                if (context.Syntax?.IsInCommentOrStringLiteral(file.NewPath, line.LineNumber) == true)
+                    continue;
+
                 // Check ±5 surrounding added lines for security-sensitive identifiers
                 int start = Math.Max(0, i - 5);
                 int end   = Math.Min(addedLines.Count - 1, i + 5);

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0049_FloatDoubleEqualityComparison.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0049_FloatDoubleEqualityComparison.cs
@@ -62,9 +62,9 @@ public class GCI0049_FloatDoubleEqualityComparison : RuleBase
                 // Skip string literals — crude but effective: skip if inside a quoted region
                 if (IsLikelyStringComparison(content)) continue;
 
-                // Syntax guard: suppress if Roslyn confirms this line is inside a comment
-                // or string literal (covers end-of-line comments the StartsWith check misses).
-                if (context.Syntax?.IsInCommentOrStringLiteral(file.NewPath, line.LineNumber) == true)
+                // Syntax guard: suppress if the match position is inside a comment or string literal.
+                if (context.Syntax?.IsInCommentOrStringLiteral(
+                        file.NewPath, line.LineNumber, GetFirstMatchIndex(content)) == true)
                     continue;
 
                 bool matches = FloatLiteralOnRightRegex.IsMatch(content)
@@ -89,6 +89,22 @@ public class GCI0049_FloatDoubleEqualityComparison : RuleBase
         }
 
         return Task.FromResult(findings);
+    }
+
+    private static int GetFirstMatchIndex(string content)
+    {
+        int min = int.MaxValue;
+        UpdateMin(FloatLiteralOnRightRegex,   content, ref min);
+        UpdateMin(FloatLiteralOnLeftRegex,    content, ref min);
+        UpdateMin(FloatCastWithEqualityRegex, content, ref min);
+        UpdateMin(FloatTypeWithEqualityRegex, content, ref min);
+        return min == int.MaxValue ? 0 : min;
+    }
+
+    private static void UpdateMin(Regex regex, string content, ref int min)
+    {
+        var m = regex.Match(content);
+        if (m.Success && m.Index < min) min = m.Index;
     }
 
     /// <summary>

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0049_FloatDoubleEqualityComparison.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0049_FloatDoubleEqualityComparison.cs
@@ -54,13 +54,18 @@ public class GCI0049_FloatDoubleEqualityComparison : RuleBase
             {
                 var content = line.Content;
 
-                // Skip comment lines
+                // Skip comment lines (simple prefix check)
                 var trimmed = content.TrimStart();
                 if (trimmed.StartsWith("//") || trimmed.StartsWith("*") || trimmed.StartsWith("/*"))
                     continue;
 
                 // Skip string literals — crude but effective: skip if inside a quoted region
                 if (IsLikelyStringComparison(content)) continue;
+
+                // Syntax guard: suppress if Roslyn confirms this line is inside a comment
+                // or string literal (covers end-of-line comments the StartsWith check misses).
+                if (context.Syntax?.IsInCommentOrStringLiteral(file.NewPath, line.LineNumber) == true)
+                    continue;
 
                 bool matches = FloatLiteralOnRightRegex.IsMatch(content)
                             || FloatLiteralOnLeftRegex.IsMatch(content)

--- a/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
+++ b/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
@@ -126,11 +126,12 @@ public class RuleOrchestrator
 
         var context = new AnalysisContext
         {
-            EligibleFiles  = eligibleRecords,
-            SkippedFiles   = skippedRecords,
-            FileStatistics = fileStatistics,
-            Diff           = filteredDiff,
-            StaticAnalysis = staticAnalysis,
+            EligibleFiles   = eligibleRecords,
+            SkippedFiles    = skippedRecords,
+            FileStatistics  = fileStatistics,
+            Diff            = filteredDiff,
+            StaticAnalysis  = staticAnalysis,
+            Syntax          = staticAnalysis?.Syntax,
             TargetFramework = staticAnalysis?.TargetFramework,
         };
 

--- a/src/GauntletCI.Core/StaticAnalysis/AnalyzerResult.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/AnalyzerResult.cs
@@ -16,6 +16,14 @@ public class AnalyzerResult
     /// (e.g. <c>net8.0</c>, <c>net6.0</c>). Null when detection was not possible.
     /// </summary>
     public string? TargetFramework { get; init; }
+
+    /// <summary>
+    /// Per-file Roslyn syntax trees built during analysis.
+    /// Not serialized — used at runtime only by <see cref="SyntaxContext"/> guards.
+    /// Null when analysis was not run or all files failed to parse.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public SyntaxContext? Syntax { get; init; }
 }
 
 public class AnalyzerDiagnostic

--- a/src/GauntletCI.Core/StaticAnalysis/RoslynAnalyzer.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/RoslynAnalyzer.cs
@@ -14,7 +14,12 @@ public class RoslynAnalyzer
     private static readonly CSharpCompilationOptions DefaultOptions =
         new(OutputKind.DynamicallyLinkedLibrary, reportSuppressedDiagnostics: false);
 
-    public async Task<AnalyzerResult> AnalyzeFileAsync(
+    /// <summary>
+    /// Analyzes a single file and returns both the diagnostics result and the parsed
+    /// <see cref="SyntaxTree"/>. The tree is used by <see cref="SyntaxContext"/> to
+    /// provide Roslyn-backed false-positive guards in downstream rules.
+    /// </summary>
+    public async Task<(AnalyzerResult Result, SyntaxTree? Tree)> AnalyzeFileAsync(
         string filePath,
         string sourceCode,
         IEnumerable<int>? changedLineNumbers = null,
@@ -55,21 +60,21 @@ public class RoslynAnalyzer
                 })
                 .ToList();
 
-            return new AnalyzerResult
+            return (new AnalyzerResult
             {
                 AnalyzedFile = filePath,
                 Diagnostics = filtered,
                 Success = true
-            };
+            }, syntaxTree);
         }
         catch (Exception ex)
         {
-            return new AnalyzerResult
+            return (new AnalyzerResult
             {
                 AnalyzedFile = filePath,
                 Success = false,
                 ErrorMessage = ex.Message
-            };
+            }, null);
         }
     }
 

--- a/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
@@ -43,6 +43,7 @@ public static class StaticAnalysisRunner
             return tfm is null ? null : new AnalyzerResult { TargetFramework = tfm, Success = true };
 
         var allDiagnostics = new List<AnalyzerDiagnostic>();
+        var syntaxTrees    = new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>();
         var anySuccess = false;
 
         foreach (var file in csFiles)
@@ -67,13 +68,15 @@ public static class StaticAnalysisRunner
             }
 
             var changedLines = file.AddedLines.Select(l => l.LineNumber).ToList();
-            var result = await Analyzer.AnalyzeFileAsync(
+            var (result, tree) = await Analyzer.AnalyzeFileAsync(
                 absolutePath, sourceCode, changedLines.Count > 0 ? changedLines : null, ct);
 
             if (result.Success)
             {
                 anySuccess = true;
                 allDiagnostics.AddRange(result.Diagnostics);
+                if (tree is not null)
+                    syntaxTrees[absolutePath] = tree;
             }
         }
 
@@ -82,10 +85,11 @@ public static class StaticAnalysisRunner
 
         return new AnalyzerResult
         {
-            AnalyzedFile = $"[{csFiles.Count} file(s)]",
-            Success = anySuccess,
-            Diagnostics = allDiagnostics,
+            AnalyzedFile  = $"[{csFiles.Count} file(s)]",
+            Success       = anySuccess,
+            Diagnostics   = allDiagnostics,
             TargetFramework = tfm,
+            Syntax        = syntaxTrees.Count > 0 ? new SyntaxContext(syntaxTrees) : null,
         };
     }
 }

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
@@ -42,11 +42,11 @@ public sealed class SyntaxContext
     /// Returns <c>true</c> when the line falls inside a comment or string literal.
     /// Returns <c>false</c> (don't suppress) when no syntax tree is available.
     /// </summary>
-    public bool IsInCommentOrStringLiteral(string filePath, int lineNumber)
+    public bool IsInCommentOrStringLiteral(string filePath, int lineNumber, int columnOffset = 0)
     {
         ArgumentNullException.ThrowIfNull(filePath);
         if (!TryGetTree(filePath, out var tree)) return false;
-        return SyntaxGuard.IsInCommentOrStringLiteral(tree!, lineNumber);
+        return SyntaxGuard.IsInCommentOrStringLiteral(tree!, lineNumber, columnOffset);
     }
 
     private bool TryGetTree(string filePath, out SyntaxTree? tree)

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Elastic-2.0
+using Microsoft.CodeAnalysis;
+
+namespace GauntletCI.Core.StaticAnalysis;
+
+/// <summary>
+/// Holds pre-parsed Roslyn <see cref="SyntaxTree"/> instances for each C# file
+/// that was analyzed in this run. Exposes guard helpers used by rules to reduce
+/// false positives without requiring a full semantic model.
+/// <para>
+/// Pass-through semantics when no tree is available for a file:
+/// <list type="bullet">
+///   <item><description><see cref="IsConfirmedObjectCreation"/> returns <c>true</c> (don't suppress — no evidence to filter).</description></item>
+///   <item><description><see cref="IsInCommentOrStringLiteral"/> returns <c>false</c> (don't suppress — no evidence to suppress).</description></item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class SyntaxContext
+{
+    private readonly Dictionary<string, SyntaxTree> _trees;
+
+    public SyntaxContext(Dictionary<string, SyntaxTree> trees) =>
+        _trees = trees ?? throw new ArgumentNullException(nameof(trees));
+
+    /// <summary>Number of files for which a syntax tree is available.</summary>
+    public int TreeCount => _trees.Count;
+
+    /// <summary>
+    /// Returns <c>true</c> when Roslyn confirms an <c>ObjectCreationExpression</c>
+    /// of type <paramref name="typeName"/> exists on the given line, or when no
+    /// syntax tree is available for the file (pass-through).
+    /// </summary>
+    public bool IsConfirmedObjectCreation(string filePath, int lineNumber, string typeName)
+    {
+        if (!TryGetTree(filePath, out var tree)) return true;
+        return SyntaxGuard.HasObjectCreation(tree!, lineNumber, typeName);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the line falls inside a comment or string literal.
+    /// Returns <c>false</c> (don't suppress) when no syntax tree is available.
+    /// </summary>
+    public bool IsInCommentOrStringLiteral(string filePath, int lineNumber)
+    {
+        if (!TryGetTree(filePath, out var tree)) return false;
+        return SyntaxGuard.IsInCommentOrStringLiteral(tree!, lineNumber);
+    }
+
+    private bool TryGetTree(string filePath, out SyntaxTree? tree)
+    {
+        if (_trees.TryGetValue(filePath, out tree)) return true;
+
+        // Normalize separators for cross-platform path matching
+        var normalized = filePath.Replace('\\', '/');
+        foreach (var kvp in _trees)
+        {
+            if (kvp.Key.Replace('\\', '/').EndsWith(normalized, StringComparison.OrdinalIgnoreCase))
+            {
+                tree = kvp.Value;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
@@ -32,6 +32,8 @@ public sealed class SyntaxContext
     /// </summary>
     public bool IsConfirmedObjectCreation(string filePath, int lineNumber, string typeName)
     {
+        ArgumentNullException.ThrowIfNull(filePath);
+        ArgumentNullException.ThrowIfNull(typeName);
         if (!TryGetTree(filePath, out var tree)) return true;
         return SyntaxGuard.HasObjectCreation(tree!, lineNumber, typeName);
     }
@@ -42,6 +44,7 @@ public sealed class SyntaxContext
     /// </summary>
     public bool IsInCommentOrStringLiteral(string filePath, int lineNumber)
     {
+        ArgumentNullException.ThrowIfNull(filePath);
         if (!TryGetTree(filePath, out var tree)) return false;
         return SyntaxGuard.IsInCommentOrStringLiteral(tree!, lineNumber);
     }

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
@@ -33,62 +33,62 @@ public static class SyntaxGuard
     }
 
     /// <summary>
-    /// Returns <c>true</c> when the given 1-based <paramref name="lineNumber"/> falls
-    /// inside comment trivia or a string/interpolated-string literal token.
-    /// Use to suppress rules when the triggering text is quoted or commented-out code
-    /// rather than live executable code — including end-of-line comments that the
-    /// simple <c>StartsWith("//")</c> check misses.
+    /// Returns <c>true</c> when the character at the given 1-based <paramref name="lineNumber"/>
+    /// and 0-based <paramref name="columnOffset"/> falls inside comment trivia or a
+    /// string/interpolated-string literal token. Checks the specific match position rather
+    /// than the entire line so that code like
+    /// <c>if (x == 0.0) throw new Exception("msg")</c> is never suppressed just because
+    /// a string literal exists elsewhere on the line.
     /// </summary>
-    public static bool IsInCommentOrStringLiteral(SyntaxTree tree, int lineNumber)
+    public static bool IsInCommentOrStringLiteral(SyntaxTree tree, int lineNumber, int columnOffset = 0)
     {
         ArgumentNullException.ThrowIfNull(tree);
         var text = tree.GetText();
         if (lineNumber < 1 || lineNumber > text.Lines.Count) return false;
 
         var line = text.Lines[lineNumber - 1];
-        var root = tree.GetRoot();
+        if (columnOffset < 0) columnOffset = 0;
+        if (line.Span.IsEmpty) return false;
+        var position = line.Start + Math.Min(columnOffset, line.Span.Length - 1);
 
-        // Step 1: check all tokens whose Span overlaps with this line.
-        // Finds string literals anywhere on the line, and trailing-trivia comments.
-        foreach (var token in root.DescendantTokens(line.Span))
+        var root  = tree.GetRoot();
+        var token = root.FindToken(position, findInsideTrivia: true);
+
+        // Direct string literal token at this position
+        if (token.IsKind(SyntaxKind.StringLiteralToken)          ||
+            token.IsKind(SyntaxKind.InterpolatedStringTextToken) ||
+            token.IsKind(SyntaxKind.SingleLineRawStringLiteralToken))
+            return true;
+
+        // Ancestor is a string expression node
+        var node = token.Parent;
+        while (node is not null)
         {
-            // String literal tokens
-            if (token.IsKind(SyntaxKind.StringLiteralToken)          ||
-                token.IsKind(SyntaxKind.InterpolatedStringTextToken) ||
-                token.IsKind(SyntaxKind.SingleLineRawStringLiteralToken))
+            if (node.IsKind(SyntaxKind.StringLiteralExpression)   ||
+                node.IsKind(SyntaxKind.InterpolatedStringExpression))
                 return true;
-
-            // Walk up ancestors to catch content inside string expression nodes
-            var node = token.Parent;
-            while (node is not null)
-            {
-                if (node.IsKind(SyntaxKind.StringLiteralExpression)   ||
-                    node.IsKind(SyntaxKind.InterpolatedStringExpression))
-                    return true;
-                node = node.Parent;
-            }
-
-            // Trailing comment trivia on this line
-            foreach (var trivia in token.TrailingTrivia)
-            {
-                if (IsCommentKind(trivia.Kind()) && trivia.Span.IntersectsWith(line.Span))
-                    return true;
-            }
+            node = node.Parent;
         }
 
-        // Step 2: line-starting comments are stored as leading trivia of the NEXT token.
-        // Use FindToken at the first non-whitespace position on the line to find that token.
-        var lineStr    = line.ToString();
-        var wsLen      = lineStr.Length - lineStr.TrimStart().Length;
-        if (wsLen < lineStr.Length)
+        // Check if position falls inside comment trivia on this token
+        foreach (var trivia in token.LeadingTrivia)
         {
-            var firstNonWs = line.Start + wsLen;
-            var nextToken  = root.FindToken(firstNonWs, findInsideTrivia: true);
-            foreach (var trivia in nextToken.LeadingTrivia)
-            {
-                if (IsCommentKind(trivia.Kind()) && trivia.Span.IntersectsWith(line.Span))
-                    return true;
-            }
+            if (IsCommentKind(trivia.Kind()) && trivia.FullSpan.Contains(position))
+                return true;
+        }
+        foreach (var trivia in token.TrailingTrivia)
+        {
+            if (IsCommentKind(trivia.Kind()) && trivia.FullSpan.Contains(position))
+                return true;
+        }
+
+        // Also check the preceding token's trailing trivia (handles end-of-line comments
+        // where FindToken returns the token AFTER the comment, not the one before it)
+        var prevToken = token.GetPreviousToken();
+        foreach (var trivia in prevToken.TrailingTrivia)
+        {
+            if (IsCommentKind(trivia.Kind()) && trivia.FullSpan.Contains(position))
+                return true;
         }
 
         return false;

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
@@ -55,18 +55,20 @@ public static class SyntaxGuard
         var token = root.FindToken(position, findInsideTrivia: true);
 
         // Direct string literal token at this position
-        if (token.IsKind(SyntaxKind.StringLiteralToken)          ||
-            token.IsKind(SyntaxKind.InterpolatedStringTextToken) ||
-            token.IsKind(SyntaxKind.SingleLineRawStringLiteralToken))
+        if (token.IsKind(SyntaxKind.StringLiteralToken)             ||
+            token.IsKind(SyntaxKind.InterpolatedStringTextToken)    ||
+            token.IsKind(SyntaxKind.SingleLineRawStringLiteralToken)||
+            token.IsKind(SyntaxKind.MultiLineRawStringLiteralToken))
             return true;
 
-        // Ancestor is a string expression node
+        // Ancestor is a plain string literal expression.
+        // Deliberately excludes InterpolatedStringExpression: the {…} holes are
+        // live code, so code that appears inside an interpolated expression should
+        // still be flagged (e.g. $"{new Random().Next()}" is a real finding).
         var node = token.Parent;
         while (node is not null)
         {
-            if (node.IsKind(SyntaxKind.StringLiteralExpression)   ||
-                node.IsKind(SyntaxKind.InterpolatedStringExpression))
-                return true;
+            if (node.IsKind(SyntaxKind.StringLiteralExpression)) return true;
             node = node.Parent;
         }
 
@@ -102,8 +104,9 @@ public static class SyntaxGuard
 
     private static string GetSimpleTypeName(TypeSyntax type) => type switch
     {
-        SimpleNameSyntax simple        => simple.Identifier.ValueText,
-        QualifiedNameSyntax qualified  => qualified.Right.Identifier.ValueText,
-        _                              => string.Empty,
+        SimpleNameSyntax simple              => simple.Identifier.ValueText,
+        QualifiedNameSyntax qualified        => qualified.Right.Identifier.ValueText,
+        AliasQualifiedNameSyntax aliased     => GetSimpleTypeName(aliased.Name),
+        _                                    => string.Empty,
     };
 }

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Elastic-2.0
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace GauntletCI.Core.StaticAnalysis;
+
+/// <summary>
+/// Provides syntax-tree-based guards for reducing false positives in regex-based rules.
+/// All methods operate on a pre-parsed <see cref="SyntaxTree"/> and are intentionally
+/// lightweight — no semantic model, no compilation, no disk I/O.
+/// </summary>
+public static class SyntaxGuard
+{
+    /// <summary>
+    /// Returns <c>true</c> when the given 1-based <paramref name="lineNumber"/> contains
+    /// an <c>ObjectCreationExpression</c> (i.e. <c>new T(...)</c>) whose simple type name
+    /// matches <paramref name="typeName"/>. Useful to confirm a regex hit like
+    /// <c>new Random(</c> is an actual object creation, not text inside a comment or string.
+    /// </summary>
+    public static bool HasObjectCreation(SyntaxTree tree, int lineNumber, string typeName)
+    {
+        var text = tree.GetText();
+        if (lineNumber < 1 || lineNumber > text.Lines.Count) return false;
+
+        var lineSpan = text.Lines[lineNumber - 1].Span;
+        return tree.GetRoot()
+            .DescendantNodes(lineSpan)
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Any(n => GetSimpleTypeName(n.Type).Equals(typeName, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the given 1-based <paramref name="lineNumber"/> falls
+    /// inside comment trivia or a string/interpolated-string literal token.
+    /// Use to suppress rules when the triggering text is quoted or commented-out code
+    /// rather than live executable code — including end-of-line comments that the
+    /// simple <c>StartsWith("//")</c> check misses.
+    /// </summary>
+    public static bool IsInCommentOrStringLiteral(SyntaxTree tree, int lineNumber)
+    {
+        var text = tree.GetText();
+        if (lineNumber < 1 || lineNumber > text.Lines.Count) return false;
+
+        var line = text.Lines[lineNumber - 1];
+        var root = tree.GetRoot();
+
+        // Step 1: check all tokens whose Span overlaps with this line.
+        // Finds string literals anywhere on the line, and trailing-trivia comments.
+        foreach (var token in root.DescendantTokens(line.Span))
+        {
+            // String literal tokens
+            if (token.IsKind(SyntaxKind.StringLiteralToken)          ||
+                token.IsKind(SyntaxKind.InterpolatedStringTextToken) ||
+                token.IsKind(SyntaxKind.SingleLineRawStringLiteralToken))
+                return true;
+
+            // Walk up ancestors to catch content inside string expression nodes
+            var node = token.Parent;
+            while (node is not null)
+            {
+                if (node.IsKind(SyntaxKind.StringLiteralExpression)   ||
+                    node.IsKind(SyntaxKind.InterpolatedStringExpression))
+                    return true;
+                node = node.Parent;
+            }
+
+            // Trailing comment trivia on this line
+            foreach (var trivia in token.TrailingTrivia)
+            {
+                if (IsCommentKind(trivia.Kind()) && trivia.Span.IntersectsWith(line.Span))
+                    return true;
+            }
+        }
+
+        // Step 2: line-starting comments are stored as leading trivia of the NEXT token.
+        // Use FindToken at the first non-whitespace position on the line to find that token.
+        var lineStr    = line.ToString();
+        var wsLen      = lineStr.Length - lineStr.TrimStart().Length;
+        if (wsLen < lineStr.Length)
+        {
+            var firstNonWs = line.Start + wsLen;
+            var nextToken  = root.FindToken(firstNonWs, findInsideTrivia: true);
+            foreach (var trivia in nextToken.LeadingTrivia)
+            {
+                if (IsCommentKind(trivia.Kind()) && trivia.Span.IntersectsWith(line.Span))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCommentKind(SyntaxKind kind) =>
+        kind is SyntaxKind.SingleLineCommentTrivia
+             or SyntaxKind.MultiLineCommentTrivia
+             or SyntaxKind.SingleLineDocumentationCommentTrivia
+             or SyntaxKind.MultiLineDocumentationCommentTrivia;
+
+    private static string GetSimpleTypeName(TypeSyntax type) => type switch
+    {
+        SimpleNameSyntax simple        => simple.Identifier.ValueText,
+        QualifiedNameSyntax qualified  => qualified.Right.Identifier.ValueText,
+        _                              => string.Empty,
+    };
+}

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
@@ -20,6 +20,8 @@ public static class SyntaxGuard
     /// </summary>
     public static bool HasObjectCreation(SyntaxTree tree, int lineNumber, string typeName)
     {
+        ArgumentNullException.ThrowIfNull(tree);
+        ArgumentNullException.ThrowIfNull(typeName);
         var text = tree.GetText();
         if (lineNumber < 1 || lineNumber > text.Lines.Count) return false;
 
@@ -39,6 +41,7 @@ public static class SyntaxGuard
     /// </summary>
     public static bool IsInCommentOrStringLiteral(SyntaxTree tree, int lineNumber)
     {
+        ArgumentNullException.ThrowIfNull(tree);
         var text = tree.GetText();
         if (lineNumber < 1 || lineNumber > text.Lines.Count) return false;
 

--- a/src/GauntletCI.Tests/RuleTestExtensions.cs
+++ b/src/GauntletCI.Tests/RuleTestExtensions.cs
@@ -24,7 +24,8 @@ internal static class RuleTestExtensions
         DiffContext diff,
         AnalyzerResult? staticAnalysis = null,
         CancellationToken ct = default,
-        string? targetFramework = null)
+        string? targetFramework = null,
+        SyntaxContext? syntax = null)
     {
         var allRecords      = diff.Files.Select(f => FileAnalyzer.Analyze(f)).ToList();
         var eligibleRecords = allRecords.Where(r => r.IsEligible).ToList();
@@ -49,6 +50,7 @@ internal static class RuleTestExtensions
             FileStatistics  = FileEligibilityStatistics.From(allRecords),
             Diff            = filteredDiff,
             StaticAnalysis  = staticAnalysis,
+            Syntax          = syntax ?? staticAnalysis?.Syntax,
             TargetFramework = targetFramework ?? staticAnalysis?.TargetFramework,
         };
 

--- a/src/GauntletCI.Tests/StaticAnalysisTests.cs
+++ b/src/GauntletCI.Tests/StaticAnalysisTests.cs
@@ -116,7 +116,7 @@ public class StaticAnalysisTests
             }
             """;
 
-        var result = await analyzer.AnalyzeFileAsync("Foo.cs", source);
+        var (result, _) = await analyzer.AnalyzeFileAsync("Foo.cs", source);
 
         Assert.True(result.Success);
         Assert.Equal("Foo.cs", result.AnalyzedFile);
@@ -128,7 +128,7 @@ public class StaticAnalysisTests
         var analyzer = new RoslynAnalyzer();
         var source = "class Foo { }";
 
-        var result = await analyzer.AnalyzeFileAsync("test.cs", source, [1, 2, 3]);
+        var (result, _) = await analyzer.AnalyzeFileAsync("test.cs", source, [1, 2, 3]);
 
         Assert.True(result.Success);
         Assert.NotNull(result.Diagnostics);
@@ -140,7 +140,7 @@ public class StaticAnalysisTests
         var analyzer = new RoslynAnalyzer();
         var source = "class Bar { }";
 
-        var result = await analyzer.AnalyzeFileAsync("bar.cs", source, null);
+        var (result, _) = await analyzer.AnalyzeFileAsync("bar.cs", source, null);
 
         Assert.True(result.Success);
     }

--- a/src/GauntletCI.Tests/SyntaxGuardTests.cs
+++ b/src/GauntletCI.Tests/SyntaxGuardTests.cs
@@ -86,6 +86,22 @@ public class SyntaxGuardTests
         Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 1, 12));
     }
 
+    [Fact]
+    public void IsInCommentOrString_WhenInsideInterpolatedExpressionHole_ReturnsFalse()
+    {
+        // new Random() inside the {…} hole is live code, not a string literal
+        var tree = Parse("var s = $\"seed={new Random().Next()}\";");
+        int col = "var s = $\"seed={".Length;  // position of 'new'
+        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 1, col));
+    }
+
+    [Fact]
+    public void HasObjectCreation_HandlesGlobalAlias()
+    {
+        var tree = Parse("var r = new global::System.Random();");
+        Assert.True(SyntaxGuard.HasObjectCreation(tree, 1, "Random"));
+    }
+
     // ── SyntaxContext pass-through semantics ──────────────────────────────
 
     [Fact]

--- a/src/GauntletCI.Tests/SyntaxGuardTests.cs
+++ b/src/GauntletCI.Tests/SyntaxGuardTests.cs
@@ -49,29 +49,41 @@ public class SyntaxGuardTests
     {
         var source = "var x = 1;\n// new Random() is insecure\nvar y = 2;";
         var tree = Parse(source);
-        Assert.True(SyntaxGuard.IsInCommentOrStringLiteral(tree, 2));
+        // Column 0 is inside the '//' comment
+        Assert.True(SyntaxGuard.IsInCommentOrStringLiteral(tree, 2, 0));
     }
 
     [Fact]
     public void IsInCommentOrString_WhenLineIsCode_ReturnsFalse()
     {
         var tree = Parse("var r = new Random();");
-        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 1));
+        // Column 8 is at 'new Random(' — live code
+        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 1, 8));
     }
 
     [Fact]
     public void IsInCommentOrString_WhenLineIsStringLiteral_ReturnsTrue()
     {
         var tree = Parse("var s = \"new Random() is bad\";");
-        Assert.True(SyntaxGuard.IsInCommentOrStringLiteral(tree, 1));
+        // Column 8 is inside the string literal
+        Assert.True(SyntaxGuard.IsInCommentOrStringLiteral(tree, 1, 8));
     }
 
     [Fact]
     public void IsInCommentOrString_WhenLineNumberOutOfRange_ReturnsFalse()
     {
         var tree = Parse("var x = 1;");
-        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 0));
-        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 999));
+        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 0, 0));
+        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 999, 0));
+    }
+
+    [Fact]
+    public void IsInCommentOrString_WhenCodeHasAdjacentStringOnSameLine_ReturnsFalse()
+    {
+        // The float literal `0.0` is live code — the adjacent string "bad" must not cause suppression
+        var tree = Parse("if (result == 0.0) throw new Exception(\"bad\");");
+        // Column 12 is at '== 0.0' — live code
+        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 1, 12));
     }
 
     // ── SyntaxContext pass-through semantics ──────────────────────────────
@@ -89,7 +101,7 @@ public class SyntaxGuardTests
     {
         var ctx = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>());
         // No tree — should NOT suppress (return false)
-        Assert.False(ctx.IsInCommentOrStringLiteral("src/Foo.cs", 1));
+        Assert.False(ctx.IsInCommentOrStringLiteral("src/Foo.cs", 1, 0));
     }
 
     [Fact]
@@ -100,7 +112,7 @@ public class SyntaxGuardTests
         {
             [@"C:\repo\src\Foo.cs"] = tree
         });
-        Assert.True(ctx.IsInCommentOrStringLiteral("src/Foo.cs", 1));
+        Assert.True(ctx.IsInCommentOrStringLiteral("src/Foo.cs", 1, 0));
     }
 
     // ── Integration: GCI0048 suppressed by syntax guard ───────────────────

--- a/src/GauntletCI.Tests/SyntaxGuardTests.cs
+++ b/src/GauntletCI.Tests/SyntaxGuardTests.cs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Rules.Implementations;
+using GauntletCI.Core.StaticAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace GauntletCI.Tests;
+
+/// <summary>Tests for <see cref="SyntaxGuard"/> and <see cref="SyntaxContext"/>.</summary>
+public class SyntaxGuardTests
+{
+    // ── SyntaxGuard.HasObjectCreation ──────────────────────────────────────
+
+    [Fact]
+    public void HasObjectCreation_WhenLineHasMatchingNew_ReturnsTrue()
+    {
+        var tree = Parse("var r = new Random();");
+        Assert.True(SyntaxGuard.HasObjectCreation(tree, 1, "Random"));
+    }
+
+    [Fact]
+    public void HasObjectCreation_WhenLineHasDifferentType_ReturnsFalse()
+    {
+        var tree = Parse("var r = new RandomHelper();");
+        Assert.False(SyntaxGuard.HasObjectCreation(tree, 1, "Random"));
+    }
+
+    [Fact]
+    public void HasObjectCreation_WhenNewIsInsideComment_ReturnsFalse()
+    {
+        var source = "// use new Random() for testing\nvar x = 1;";
+        var tree = Parse(source);
+        Assert.False(SyntaxGuard.HasObjectCreation(tree, 1, "Random"));
+    }
+
+    [Fact]
+    public void HasObjectCreation_WhenLineNumberOutOfRange_ReturnsFalse()
+    {
+        var tree = Parse("var x = 1;");
+        Assert.False(SyntaxGuard.HasObjectCreation(tree, 999, "Random"));
+        Assert.False(SyntaxGuard.HasObjectCreation(tree, 0, "Random"));
+    }
+
+    // ── SyntaxGuard.IsInCommentOrStringLiteral ────────────────────────────
+
+    [Fact]
+    public void IsInCommentOrString_WhenLineIsFullSingleLineComment_ReturnsTrue()
+    {
+        var source = "var x = 1;\n// new Random() is insecure\nvar y = 2;";
+        var tree = Parse(source);
+        Assert.True(SyntaxGuard.IsInCommentOrStringLiteral(tree, 2));
+    }
+
+    [Fact]
+    public void IsInCommentOrString_WhenLineIsCode_ReturnsFalse()
+    {
+        var tree = Parse("var r = new Random();");
+        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 1));
+    }
+
+    [Fact]
+    public void IsInCommentOrString_WhenLineIsStringLiteral_ReturnsTrue()
+    {
+        var tree = Parse("var s = \"new Random() is bad\";");
+        Assert.True(SyntaxGuard.IsInCommentOrStringLiteral(tree, 1));
+    }
+
+    [Fact]
+    public void IsInCommentOrString_WhenLineNumberOutOfRange_ReturnsFalse()
+    {
+        var tree = Parse("var x = 1;");
+        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 0));
+        Assert.False(SyntaxGuard.IsInCommentOrStringLiteral(tree, 999));
+    }
+
+    // ── SyntaxContext pass-through semantics ──────────────────────────────
+
+    [Fact]
+    public void SyntaxContext_IsConfirmedObjectCreation_PassesThroughWhenNoTree()
+    {
+        var ctx = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>());
+        // No tree for this file — should pass through (return true, don't suppress)
+        Assert.True(ctx.IsConfirmedObjectCreation("src/Foo.cs", 1, "Random"));
+    }
+
+    [Fact]
+    public void SyntaxContext_IsInCommentOrString_DoesNotSuppressWhenNoTree()
+    {
+        var ctx = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>());
+        // No tree — should NOT suppress (return false)
+        Assert.False(ctx.IsInCommentOrStringLiteral("src/Foo.cs", 1));
+    }
+
+    [Fact]
+    public void SyntaxContext_ResolvesTreeBySuffixPath()
+    {
+        var tree = Parse("// comment line");
+        var ctx = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            [@"C:\repo\src\Foo.cs"] = tree
+        });
+        Assert.True(ctx.IsInCommentOrStringLiteral("src/Foo.cs", 1));
+    }
+
+    // ── Integration: GCI0048 suppressed by syntax guard ───────────────────
+
+    [Fact]
+    public async Task GCI0048_SuppressesNewRandomInSingleLineComment()
+    {
+        const string addedLine = "// var token = new Random(seed).Next(); // old insecure approach";
+        // Parse with the same preceding "// existing" line so line 2 matches the diff's line 2
+        var tree = Parse("// existing\n" + addedLine);
+        var ctx  = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            ["src/Auth.cs"] = tree
+        });
+
+        var diff = MakeDiff("src/Auth.cs", addedLine);
+        var rule = new GCI0048_InsecureRandomInSecurityContext();
+        var findings = await rule.EvaluateAsync(diff, syntax: ctx);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task GCI0048_FiresWhenNewRandomIsLiveCode()
+    {
+        const string addedLine = "    var token = new Random(seed).Next();";
+        var diff = MakeDiff("src/Auth.cs", addedLine);
+        var rule = new GCI0048_InsecureRandomInSecurityContext();
+        var findings = await rule.EvaluateAsync(diff);
+        Assert.NotEmpty(findings);
+    }
+
+    // ── Integration: GCI0049 suppressed by syntax guard ───────────────────
+
+    [Fact]
+    public async Task GCI0049_SuppressesFloatEqualityInsideComment()
+    {
+        const string addedLine = "// if (value == 0.0) return; // legacy check";
+        var tree = Parse("// existing\n" + addedLine);
+        var ctx  = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            ["src/Calc.cs"] = tree
+        });
+
+        var diff = MakeDiff("src/Calc.cs", addedLine);
+        var rule = new GCI0049_FloatDoubleEqualityComparison();
+        var findings = await rule.EvaluateAsync(diff, syntax: ctx);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task GCI0049_FiresWhenFloatEqualityIsLiveCode()
+    {
+        const string addedLine = "    if (result == 0.0) throw new Exception();";
+        var diff = MakeDiff("src/Calc.cs", addedLine);
+        var rule = new GCI0049_FloatDoubleEqualityComparison();
+        var findings = await rule.EvaluateAsync(diff);
+        Assert.NotEmpty(findings);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static Microsoft.CodeAnalysis.SyntaxTree Parse(string source) =>
+        CSharpSyntaxTree.ParseText(SourceText.From(source));
+
+    private static DiffContext MakeDiff(string filePath, string addedLine) =>
+        DiffParser.Parse($"""
+            diff --git a/{filePath} b/{filePath}
+            index abc..def 100644
+            --- a/{filePath}
+            +++ b/{filePath}
+            @@ -1,1 +1,2 @@
+             // existing
+            +{addedLine}
+            """);
+}
+


### PR DESCRIPTION
Adds syntax-tree-based false positive guards that suppress GCI0048 and GCI0049 when the triggering regex appears inside a comment or string literal.

New files: SyntaxGuard.cs, SyntaxContext.cs, SyntaxGuardTests.cs.

Rules updated: GCI0048 and GCI0049 now call IsInCommentOrStringLiteral before reporting.

876 tests passing (up from 861).