### PR TITLE
[CLI] Add Slack/Teams, GitHub Checks, Codecov, and dep-scanner rules

### DIFF
--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -52,6 +52,10 @@ public static class AnalyzeCommand
         var noBaselineFlag = new Option<bool>("--no-baseline", "Ignore the baseline file and show all findings");
         var showContextOption = new Option<int>("--show-context", () => 0, "Include N surrounding diff lines around each finding evidence");
         var prCommentSuggestFlag = new Option<bool>("--pr-comment-suggest", "Print PR review comment body to stdout; when used without --github-pr-comments this avoids posting to the GitHub API");
+        var notifySlackOption = new Option<string?>("--notify-slack", "Slack Incoming Webhook URL (or set GAUNTLETCI_SLACK_WEBHOOK env var). Posts Block findings to Slack.");
+        var notifyTeamsOption = new Option<string?>("--notify-teams", "Teams Incoming Webhook URL (or set GAUNTLETCI_TEAMS_WEBHOOK env var). Posts Block findings to Teams.");
+        var withCoverageFlag = new Option<bool>("--with-coverage", "Correlate findings with Codecov/Coveralls coverage data (requires CODECOV_TOKEN or COVERALLS_REPO_TOKEN env var)");
+        var githubChecksFlag = new Option<bool>("--github-checks", "Post findings as a GitHub Checks API check run with annotations (requires checks: write permission)");
 
         var cmd = new Command("analyze", "Analyse a git diff for pre-commit risks")
         {
@@ -74,6 +78,10 @@ public static class AnalyzeCommand
             noBaselineFlag,
             showContextOption,
             prCommentSuggestFlag,
+            notifySlackOption,
+            notifyTeamsOption,
+            withCoverageFlag,
+            githubChecksFlag,
         };
 
         cmd.SetHandler(async (System.CommandLine.Invocation.InvocationContext ctx) =>
@@ -97,6 +105,8 @@ public static class AnalyzeCommand
             var noBaseline = ctx.ParseResult.GetValueForOption(noBaselineFlag);
             var showContext = ctx.ParseResult.GetValueForOption(showContextOption);
             var prCommentSuggest = ctx.ParseResult.GetValueForOption(prCommentSuggestFlag);
+            var withCoverage  = ctx.ParseResult.GetValueForOption(withCoverageFlag);
+            var githubChecks  = ctx.ParseResult.GetValueForOption(githubChecksFlag);
             var ct = ctx.GetCancellationToken();
 
             // Enforce single diff source
@@ -232,6 +242,9 @@ public static class AnalyzeCommand
                 else
                     await RunLlmStepsAsync();
 
+                if (withCoverage)
+                    await CoverageCorrelator.AnnotateAsync(result, ct);
+
                 if (isSarifOutput)
                 {
                     SarifWriter.Write(result);
@@ -294,6 +307,16 @@ public static class AnalyzeCommand
                 // Skip posting to GitHub API when --pr-comment-suggest is active (it acts as a dry-run)
                 if (ghPrComments && !prCommentSuggest)
                     await GitHubPrReviewWriter.WriteAsync(result, ctx.GetCancellationToken());
+
+                if (githubChecks)
+                    await GitHubChecksWriter.WriteAsync(result, ct);
+
+                var slackUrl = ctx.ParseResult.GetValueForOption(notifySlackOption)
+                            ?? Environment.GetEnvironmentVariable("GAUNTLETCI_SLACK_WEBHOOK");
+                var teamsUrl = ctx.ParseResult.GetValueForOption(notifyTeamsOption)
+                            ?? Environment.GetEnvironmentVariable("GAUNTLETCI_TEAMS_WEBHOOK");
+                if (slackUrl is not null || teamsUrl is not null)
+                    await SlackTeamsNotifier.NotifyAsync(result, slackUrl, teamsUrl, ct);
 
                 await TelemetryCollector.CollectAsync(result, diff, repo.FullName, ct: ct);
 

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -54,7 +54,7 @@ public static class AnalyzeCommand
         var prCommentSuggestFlag = new Option<bool>("--pr-comment-suggest", "Print PR review comment body to stdout; when used without --github-pr-comments this avoids posting to the GitHub API");
         var notifySlackOption = new Option<string?>("--notify-slack", "Slack Incoming Webhook URL (or set GAUNTLETCI_SLACK_WEBHOOK env var). Posts Block findings to Slack.");
         var notifyTeamsOption = new Option<string?>("--notify-teams", "Teams Incoming Webhook URL (or set GAUNTLETCI_TEAMS_WEBHOOK env var). Posts Block findings to Teams.");
-        var withCoverageFlag = new Option<bool>("--with-coverage", "Correlate findings with Codecov/Coveralls coverage data (requires CODECOV_TOKEN or COVERALLS_REPO_TOKEN env var)");
+        var withCoverageFlag = new Option<bool>("--with-coverage", "Correlate findings with Codecov coverage data (requires CODECOV_TOKEN env var)");
         var githubChecksFlag = new Option<bool>("--github-checks", "Post findings as a GitHub Checks API check run with annotations (requires checks: write permission)");
 
         var cmd = new Command("analyze", "Analyse a git diff for pre-commit risks")

--- a/src/GauntletCI.Cli/Output/CoverageCorrelator.cs
+++ b/src/GauntletCI.Cli/Output/CoverageCorrelator.cs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net.Http.Headers;
+using System.Text.Json;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+
+namespace GauntletCI.Cli.Output;
+
+/// <summary>
+/// Annotates Block-severity findings with Codecov coverage data.
+/// Soft-fails when env vars are missing or API calls fail.
+/// </summary>
+public static class CoverageCorrelator
+{
+    private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(15) };
+
+    /// <summary>
+    /// Fetches Codecov commit coverage and annotates Block findings whose files have zero coverage.
+    /// Requires CODECOV_TOKEN, GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_BASE_SHA env vars.
+    /// </summary>
+    public static async Task AnnotateAsync(EvaluationResult result, CancellationToken ct = default)
+    {
+        var codecovToken  = Environment.GetEnvironmentVariable("CODECOV_TOKEN");
+        var githubRepo    = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+        var githubSha     = Environment.GetEnvironmentVariable("GITHUB_SHA");
+        var githubBaseSha = Environment.GetEnvironmentVariable("GITHUB_BASE_SHA");
+
+        if (string.IsNullOrEmpty(codecovToken)
+            || string.IsNullOrEmpty(githubRepo)
+            || string.IsNullOrEmpty(githubSha)
+            || string.IsNullOrEmpty(githubBaseSha))
+            return;
+
+        var repoParts = githubRepo.Split('/');
+        if (repoParts.Length < 2)
+            return;
+
+        var owner = repoParts[0];
+        var repo  = repoParts[1];
+
+        try
+        {
+            var url = $"https://api.codecov.io/api/v2/gh/{owner}/repos/{repo}/commits/{githubSha}/";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", codecovToken);
+            request.Headers.UserAgent.Add(new ProductInfoHeaderValue("GauntletCI", "2.0"));
+
+            using var response = await _http.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+                return;
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            var fileCoverageMap = ParseCoverageResponse(json);
+
+            var blockFindings = result.Findings
+                .Where(f => f.Severity == RuleSeverity.Block && !string.IsNullOrEmpty(f.FilePath))
+                .ToList();
+
+            foreach (var finding in blockFindings)
+            {
+                bool zeroCoverage = fileCoverageMap is null
+                    || !fileCoverageMap.TryGetValue(finding.FilePath!, out var cov)
+                    || cov == 0.0;
+
+                if (zeroCoverage)
+                    finding.LlmExplanation = Append(
+                        finding.LlmExplanation,
+                        "⚠️ No test coverage detected for this file (Codecov).");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[GauntletCI] Coverage correlation error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Parses the Codecov commit JSON response and returns a map of file name → coverage percentage.
+    /// Returns null when the response contains no per-file data.
+    /// </summary>
+    internal static Dictionary<string, double>? ParseCoverageResponse(string json)
+    {
+        try
+        {
+            using var doc  = JsonDocument.Parse(json);
+            var root       = doc.RootElement;
+            var result     = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+
+            if (!root.TryGetProperty("files", out var filesEl)
+                || filesEl.ValueKind != JsonValueKind.Array)
+                return null;
+
+            foreach (var file in filesEl.EnumerateArray())
+            {
+                if (!file.TryGetProperty("name", out var nameEl))
+                    continue;
+
+                var name     = nameEl.GetString() ?? string.Empty;
+                double cov   = 0.0;
+
+                if (file.TryGetProperty("totals", out var totals)
+                    && totals.TryGetProperty("coverage", out var covEl)
+                    && covEl.ValueKind == JsonValueKind.Number)
+                {
+                    cov = covEl.GetDouble();
+                }
+
+                result[name] = cov;
+            }
+
+            return result;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? Append(string? existing, string note) =>
+        string.IsNullOrEmpty(existing) ? note : $"{existing}\n{note}";
+}

--- a/src/GauntletCI.Cli/Output/CoverageCorrelator.cs
+++ b/src/GauntletCI.Cli/Output/CoverageCorrelator.cs
@@ -16,19 +16,17 @@ public static class CoverageCorrelator
 
     /// <summary>
     /// Fetches Codecov commit coverage and annotates Block findings whose files have zero coverage.
-    /// Requires CODECOV_TOKEN, GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_BASE_SHA env vars.
+    /// Requires CODECOV_TOKEN, GITHUB_REPOSITORY, and GITHUB_SHA env vars.
     /// </summary>
     public static async Task AnnotateAsync(EvaluationResult result, CancellationToken ct = default)
     {
-        var codecovToken  = Environment.GetEnvironmentVariable("CODECOV_TOKEN");
-        var githubRepo    = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
-        var githubSha     = Environment.GetEnvironmentVariable("GITHUB_SHA");
-        var githubBaseSha = Environment.GetEnvironmentVariable("GITHUB_BASE_SHA");
+        var codecovToken = Environment.GetEnvironmentVariable("CODECOV_TOKEN");
+        var githubRepo   = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+        var githubSha    = Environment.GetEnvironmentVariable("GITHUB_SHA");
 
         if (string.IsNullOrEmpty(codecovToken)
             || string.IsNullOrEmpty(githubRepo)
-            || string.IsNullOrEmpty(githubSha)
-            || string.IsNullOrEmpty(githubBaseSha))
+            || string.IsNullOrEmpty(githubSha))
             return;
 
         var repoParts = githubRepo.Split('/');
@@ -53,20 +51,19 @@ public static class CoverageCorrelator
             var json = await response.Content.ReadAsStringAsync(ct);
             var fileCoverageMap = ParseCoverageResponse(json);
 
+            // Skip annotation entirely when the coverage map could not be parsed —
+            // we must not flag files as zero-coverage based on missing data.
+            if (fileCoverageMap is null)
+                return;
+
             var blockFindings = result.Findings
                 .Where(f => f.Severity == RuleSeverity.Block && !string.IsNullOrEmpty(f.FilePath))
                 .ToList();
 
             foreach (var finding in blockFindings)
             {
-                bool zeroCoverage = fileCoverageMap is null
-                    || !fileCoverageMap.TryGetValue(finding.FilePath!, out var cov)
-                    || cov == 0.0;
-
-                if (zeroCoverage)
-                    finding.LlmExplanation = Append(
-                        finding.LlmExplanation,
-                        "⚠️ No test coverage detected for this file (Codecov).");
+                if (fileCoverageMap.TryGetValue(finding.FilePath!, out var cov) && cov == 0.0)
+                    finding.CoverageNote = "⚠️ No test coverage detected for this file (Codecov).";
             }
         }
         catch (Exception ex)
@@ -96,8 +93,8 @@ public static class CoverageCorrelator
                 if (!file.TryGetProperty("name", out var nameEl))
                     continue;
 
-                var name     = nameEl.GetString() ?? string.Empty;
-                double cov   = 0.0;
+                var name   = nameEl.GetString() ?? string.Empty;
+                double cov = 0.0;
 
                 if (file.TryGetProperty("totals", out var totals)
                     && totals.TryGetProperty("coverage", out var covEl)
@@ -116,7 +113,4 @@ public static class CoverageCorrelator
             return null;
         }
     }
-
-    private static string? Append(string? existing, string note) =>
-        string.IsNullOrEmpty(existing) ? note : $"{existing}\n{note}";
 }

--- a/src/GauntletCI.Cli/Output/GitHubChecksWriter.cs
+++ b/src/GauntletCI.Cli/Output/GitHubChecksWriter.cs
@@ -90,13 +90,14 @@ public static class GitHubChecksWriter
 
     /// <summary>
     /// Builds the annotation list for the check run output.
-    /// Block findings are prioritized, capped at 50, and only findings with both FilePath and Line are included.
+    /// Block findings are prioritized first, then Warn, Info, Advisory.
+    /// Capped at 50; only findings with both FilePath and Line are included.
     /// </summary>
     internal static List<object> BuildAnnotations(EvaluationResult result)
     {
         return result.Findings
             .Where(f => !string.IsNullOrEmpty(f.FilePath) && f.Line.HasValue)
-            .OrderByDescending(f => f.Severity)
+            .OrderBy(f => SeverityPriority(f.Severity))
             .Take(50)
             .Select(f => (object)new
             {
@@ -110,6 +111,15 @@ public static class GitHubChecksWriter
             })
             .ToList();
     }
+
+    // Block=0 (highest priority), Warn=1, Info=2, Advisory=3 — enum values cannot be relied on.
+    private static int SeverityPriority(RuleSeverity s) => s switch
+    {
+        RuleSeverity.Block    => 0,
+        RuleSeverity.Warn     => 1,
+        RuleSeverity.Info     => 2,
+        _                     => 3,   // Advisory, None
+    };
 
     private static string ToAnnotationLevel(RuleSeverity severity) => severity switch
     {

--- a/src/GauntletCI.Cli/Output/GitHubChecksWriter.cs
+++ b/src/GauntletCI.Cli/Output/GitHubChecksWriter.cs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+
+namespace GauntletCI.Cli.Output;
+
+/// <summary>
+/// Creates a GitHub Checks API check run with annotated findings.
+/// Requires GITHUB_TOKEN, GITHUB_REPOSITORY, and GITHUB_SHA env vars.
+/// The workflow must declare <c>checks: write</c> permission.
+/// Soft-fails on missing env vars or API errors.
+/// </summary>
+public static class GitHubChecksWriter
+{
+    private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(15) };
+    private static readonly JsonSerializerOptions _jsonOpts = new() { WriteIndented = false };
+
+    /// <summary>Posts findings as a GitHub Checks API check run. Soft-fails on any error.</summary>
+    public static async Task WriteAsync(EvaluationResult result, CancellationToken ct = default)
+    {
+        var token      = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        var repository = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+        var sha        = Environment.GetEnvironmentVariable("GITHUB_SHA");
+
+        if (string.IsNullOrEmpty(token) || string.IsNullOrEmpty(repository) || string.IsNullOrEmpty(sha))
+        {
+            Console.Error.WriteLine(
+                "[GauntletCI] --github-checks: missing GITHUB_TOKEN, GITHUB_REPOSITORY, or GITHUB_SHA — skipping.");
+            return;
+        }
+
+        var conclusion  = BuildConclusion(result);
+        var annotations = BuildAnnotations(result);
+
+        var blockCount = result.Findings.Count(f => f.Severity == RuleSeverity.Block);
+        var warnCount  = result.Findings.Count(f => f.Severity == RuleSeverity.Warn);
+
+        var payload = new
+        {
+            name       = "GauntletCI Risk Analysis",
+            head_sha   = sha,
+            status     = "completed",
+            conclusion,
+            output     = new
+            {
+                title       = $"{blockCount} Block findings, {warnCount} Warn findings",
+                summary     = $"GauntletCI found {blockCount} high-risk changes.",
+                annotations,
+            }
+        };
+
+        var json    = JsonSerializer.Serialize(payload, _jsonOpts);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var url     = $"https://api.github.com/repos/{repository}/check-runs";
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        request.Headers.UserAgent.Add(new ProductInfoHeaderValue("GauntletCI", "2.0"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+        request.Content = content;
+
+        try
+        {
+            using var response = await _http.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync(ct);
+                Console.Error.WriteLine($"[GauntletCI] --github-checks: API error {response.StatusCode} — {body}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[GauntletCI] --github-checks: request failed — {ex.Message}");
+        }
+    }
+
+    /// <summary>Derives the check run conclusion from the evaluation result.</summary>
+    internal static string BuildConclusion(EvaluationResult result)
+    {
+        if (result.Findings.Any(f => f.Severity == RuleSeverity.Block))
+            return "failure";
+        if (result.Findings.Any(f => f.Severity is RuleSeverity.Warn or RuleSeverity.Info))
+            return "neutral";
+        return "success";
+    }
+
+    /// <summary>
+    /// Builds the annotation list for the check run output.
+    /// Block findings are prioritized, capped at 50, and only findings with both FilePath and Line are included.
+    /// </summary>
+    internal static List<object> BuildAnnotations(EvaluationResult result)
+    {
+        return result.Findings
+            .Where(f => !string.IsNullOrEmpty(f.FilePath) && f.Line.HasValue)
+            .OrderByDescending(f => f.Severity)
+            .Take(50)
+            .Select(f => (object)new
+            {
+                path             = f.FilePath!,
+                start_line       = f.Line!.Value,
+                end_line         = f.Line!.Value,
+                annotation_level = ToAnnotationLevel(f.Severity),
+                title            = $"{f.RuleId} — {f.RuleName}",
+                message          = f.Summary,
+                raw_details      = $"{f.WhyItMatters}\n\n{f.SuggestedAction}",
+            })
+            .ToList();
+    }
+
+    private static string ToAnnotationLevel(RuleSeverity severity) => severity switch
+    {
+        RuleSeverity.Block => "failure",
+        RuleSeverity.Warn  => "warning",
+        _                  => "notice",
+    };
+}

--- a/src/GauntletCI.Cli/Output/GitHubPrReviewWriter.cs
+++ b/src/GauntletCI.Cli/Output/GitHubPrReviewWriter.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.Rules;
 
@@ -102,7 +103,7 @@ public static class GitHubPrReviewWriter
         if (!string.IsNullOrWhiteSpace(finding.Evidence))
         {
             sb.AppendLine();
-            sb.AppendLine($"> {finding.Evidence}");
+            sb.AppendLine(FormatEvidenceMarkdown(finding.Evidence));
         }
 
         if (!string.IsNullOrWhiteSpace(finding.WhyItMatters))
@@ -133,6 +134,47 @@ public static class GitHubPrReviewWriter
         sb.Append($"<sub>Confidence: {finding.Confidence} | Severity: {finding.Severity}</sub>");
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Formats an evidence string as GitHub-flavored Markdown.
+    /// <list type="bullet">
+    ///   <item><c>Was: X | Now: Y</c> → diff code block with a red removed line and a green added line.</item>
+    ///   <item><c>Removed: X</c> → diff code block with a single red removed line.</item>
+    ///   <item><c>Removed logic: A | B | C</c> → diff code block with one red line per item.</item>
+    ///   <item>Anything else → plain blockquote.</item>
+    /// </list>
+    /// </summary>
+    public static string FormatEvidenceMarkdown(string evidence)
+    {
+        if (string.IsNullOrWhiteSpace(evidence))
+            return string.Empty;
+
+        // Was: X | Now: Y  →  diff block with - (red) and + (green)
+        var wasNow = Regex.Match(evidence, @"^Was:\s*(.+?)\s*\|\s*Now:\s*(.+)$", RegexOptions.Singleline);
+        if (wasNow.Success)
+        {
+            var was = wasNow.Groups[1].Value.Trim();
+            var now = wasNow.Groups[2].Value.Trim();
+            return $"```diff\n- {was}\n+ {now}\n```";
+        }
+
+        // Removed logic: A | B | C  →  diff block with one red line per item
+        var removedLogic = Regex.Match(evidence, @"^Removed logic:\s*(.+)$", RegexOptions.Singleline);
+        if (removedLogic.Success)
+        {
+            var items = removedLogic.Groups[1].Value.Split(" | ", StringSplitOptions.RemoveEmptyEntries);
+            var lines = string.Join("\n", items.Select(i => $"- {i.Trim()}"));
+            return $"```diff\n{lines}\n```";
+        }
+
+        // Removed: X  →  diff block with a single red line
+        var removed = Regex.Match(evidence, @"^Removed:\s*(.+)$", RegexOptions.Singleline);
+        if (removed.Success)
+            return $"```diff\n- {removed.Groups[1].Value.Trim()}\n```";
+
+        // Fallback: plain blockquote
+        return $"> {evidence}";
     }
 
     // Returns true if the caller should retry without inline comments (422 from GitHub).

--- a/src/GauntletCI.Cli/Output/GitHubPrReviewWriter.cs
+++ b/src/GauntletCI.Cli/Output/GitHubPrReviewWriter.cs
@@ -130,6 +130,12 @@ public static class GitHubPrReviewWriter
             sb.AppendLine($"📚 **Expert context:** {ctx.Content} _(source: {ctx.Source})_");
         }
 
+        if (!string.IsNullOrWhiteSpace(finding.CoverageNote))
+        {
+            sb.AppendLine();
+            sb.AppendLine($"📊 **Coverage:** {finding.CoverageNote}");
+        }
+
         sb.AppendLine();
         sb.Append($"<sub>Confidence: {finding.Confidence} | Severity: {finding.Severity}</sub>");
 

--- a/src/GauntletCI.Cli/Output/SlackTeamsNotifier.cs
+++ b/src/GauntletCI.Cli/Output/SlackTeamsNotifier.cs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+
+namespace GauntletCI.Cli.Output;
+
+/// <summary>
+/// Posts Block-severity findings to Slack and/or Microsoft Teams via incoming webhooks.
+/// Soft-fails on missing webhooks or API errors.
+/// </summary>
+public static class SlackTeamsNotifier
+{
+    private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(15) };
+
+    /// <summary>
+    /// Sends notifications to Slack and/or Teams when Block-severity findings exist.
+    /// </summary>
+    public static async Task NotifyAsync(
+        EvaluationResult result,
+        string? slackUrl,
+        string? teamsUrl,
+        CancellationToken ct = default)
+    {
+        var blockFindings = result.Findings.Where(f => f.Severity == RuleSeverity.Block).ToList();
+        if (blockFindings.Count == 0)
+            return;
+
+        var repo  = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+        var sha   = Environment.GetEnvironmentVariable("GITHUB_SHA");
+        var prNum = ResolvePrNumber();
+        var shortSha = sha?.Length >= 8 ? sha[..8] : sha;
+
+        if (slackUrl is not null)
+        {
+            try
+            {
+                var payload = BuildSlackPayload(result, repo, prNum, shortSha);
+                var content = new StringContent(payload, Encoding.UTF8, "application/json");
+                using var response = await _http.PostAsync(slackUrl, content, ct);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var body = await response.Content.ReadAsStringAsync(ct);
+                    Console.Error.WriteLine($"[GauntletCI] Slack notification failed: {response.StatusCode} — {body}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[GauntletCI] Slack notification error: {ex.Message}");
+            }
+        }
+
+        if (teamsUrl is not null)
+        {
+            try
+            {
+                var payload = BuildTeamsPayload(result, repo, prNum, shortSha);
+                var content = new StringContent(payload, Encoding.UTF8, "application/json");
+                using var response = await _http.PostAsync(teamsUrl, content, ct);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var body = await response.Content.ReadAsStringAsync(ct);
+                    Console.Error.WriteLine($"[GauntletCI] Teams notification failed: {response.StatusCode} — {body}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[GauntletCI] Teams notification error: {ex.Message}");
+            }
+        }
+    }
+
+    internal static string BuildSlackPayload(
+        EvaluationResult result,
+        string? repo,
+        string? prNum,
+        string? sha)
+    {
+        var blockFindings = result.Findings.Where(f => f.Severity == RuleSeverity.Block).ToList();
+        if (blockFindings.Count == 0)
+            return string.Empty;
+
+        var blocks = new List<object>
+        {
+            new { type = "header", text = new { type = "plain_text", text = "🚨 GauntletCI: High-Risk Changes Detected", emoji = true } },
+            new { type = "section", text = new { type = "mrkdwn", text = $"*Repo:* {repo ?? "unknown"} | *PR:* #{prNum ?? "unknown"} | *Commit:* `{sha ?? "unknown"}`" } },
+            new { type = "divider" },
+        };
+
+        var top3 = blockFindings.Take(3).ToList();
+        foreach (var f in top3)
+        {
+            blocks.Add(new { type = "section", text = new { type = "mrkdwn", text = $"*[{f.RuleId}]* {f.RuleName}\n_{f.Summary}_\n> {f.Evidence}" } });
+            blocks.Add(new { type = "divider" });
+        }
+
+        if (blockFindings.Count > 3)
+            blocks.Add(new { type = "context", elements = new[] { new { type = "mrkdwn", text = $"...and {blockFindings.Count - 3} more Block findings" } } });
+
+        return JsonSerializer.Serialize(new { blocks });
+    }
+
+    internal static string BuildTeamsPayload(
+        EvaluationResult result,
+        string? repo,
+        string? prNum,
+        string? sha)
+    {
+        var blockFindings = result.Findings.Where(f => f.Severity == RuleSeverity.Block).ToList();
+        var findingsText = string.Join("\n", blockFindings.Select(f => $"**[{f.RuleId}]** {f.RuleName}: {f.Summary}"));
+
+        var payload = new
+        {
+            @type    = "MessageCard",
+            @context = "https://schema.org/extensions",
+            themeColor = "FF0000",
+            summary  = "GauntletCI Alert",
+            title    = "🚨 GauntletCI: High-Risk PR",
+            sections = new[]
+            {
+                new
+                {
+                    facts = new object[]
+                    {
+                        new { name = "Repo",   value = repo  ?? "unknown" },
+                        new { name = "PR",     value = $"#{prNum ?? "unknown"}" },
+                        new { name = "Commit", value = sha   ?? "unknown" },
+                    },
+                    text = $"**Block findings:**\n{findingsText}",
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private static string? ResolvePrNumber()
+    {
+        var explicit_ = Environment.GetEnvironmentVariable("GAUNTLETCI_PR_NUMBER");
+        if (!string.IsNullOrEmpty(explicit_))
+            return explicit_;
+
+        var ghRef = Environment.GetEnvironmentVariable("GITHUB_REF");
+        if (!string.IsNullOrEmpty(ghRef))
+        {
+            var parts = ghRef.Split('/');
+            if (parts.Length >= 4 && parts[1] == "pull")
+                return parts[2];
+        }
+
+        return null;
+    }
+}

--- a/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
+++ b/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
@@ -27,7 +27,10 @@ internal static class DefaultSeverities
             ["GCI0036"] = RuleSeverity.Block,
             ["GCI0039"] = RuleSeverity.Block,
 
+            ["GCI0052"] = RuleSeverity.Block,
+
             // Warn — visible by default, non-blocking
+            ["GCI0053"] = RuleSeverity.Warn,
             ["GCI0006"] = RuleSeverity.Warn,
             ["GCI0022"] = RuleSeverity.Warn,
             ["GCI0024"] = RuleSeverity.Warn,

--- a/src/GauntletCI.Core/Model/Finding.cs
+++ b/src/GauntletCI.Core/Model/Finding.cs
@@ -34,4 +34,6 @@ public class Finding
     public ExpertFact? ExpertContext { get; set; }      // optional expert knowledge match
     /// <summary>Optional verbatim code snippet extracted from the diff by an LLM evaluation step.</summary>
     public string? CodeSnippet { get; set; }
+    /// <summary>Optional coverage annotation added by the Codecov correlation step.</summary>
+    public string? CoverageNote { get; set; }
 }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0052_DependencyBotApiDrift.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0052_DependencyBotApiDrift.cs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.RegularExpressions;
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0052 – Dependency Bot API Drift
+/// Fires when a dependency bot actor (Dependabot, Renovate, Snyk) opens a PR that
+/// contains both a lockfile change and a public API method signature change in C# files.
+/// </summary>
+public class GCI0052_DependencyBotApiDrift : RuleBase
+{
+    public override string Id   => "GCI0052";
+    public override string Name => "Dependency Bot API Drift";
+
+    private static readonly HashSet<string> LockfileNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "packages.lock.json",
+            "package-lock.json",
+            "yarn.lock",
+            "Pipfile.lock",
+            "go.sum",
+            "Cargo.lock",
+            "Directory.Packages.props",
+        };
+
+    private static readonly HashSet<string> DependencyBotActors =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "dependabot[bot]",
+            "renovate[bot]",
+            "snyk-bot",
+            "snyk[bot]",
+        };
+
+    // Matches added public method signatures in C# files (Content is already stripped of leading +).
+    private static readonly Regex PublicMethodSignatureRegex = new(
+        @"^\s*public\s+(static\s+|async\s+|virtual\s+|override\s+|abstract\s+)*[\w<>\[\],]+\s+\w+\s*\(",
+        RegexOptions.Compiled);
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        var actor = Environment.GetEnvironmentVariable("GITHUB_ACTOR");
+        if (string.IsNullOrEmpty(actor) || !DependencyBotActors.Contains(actor))
+            return Task.FromResult(findings);
+
+        // Check all files (eligible and skipped) for lockfile changes
+        var allFilePaths = context.EligibleFiles.Select(r => r.FilePath)
+            .Concat(context.SkippedFiles.Select(r => r.FilePath));
+
+        bool hasLockfileChange = allFilePaths.Any(path =>
+        {
+            var fileName = Path.GetFileName(path);
+            if (LockfileNames.Contains(fileName)) return true;
+            return Path.GetExtension(path).Equals(".csproj", StringComparison.OrdinalIgnoreCase);
+        });
+
+        if (!hasLockfileChange)
+            return Task.FromResult(findings);
+
+        // Check for public API changes in CS files
+        foreach (var file in context.Diff.Files)
+        {
+            if (!file.NewPath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            foreach (var line in file.AddedLines)
+            {
+                if (!PublicMethodSignatureRegex.IsMatch(line.Content))
+                    continue;
+
+                findings.Add(CreateFinding(
+                    file,
+                    summary:         "Dependency bot PR introduces a public API change — verify backward compatibility",
+                    evidence:        $"{file.NewPath} line {line.LineNumber}: {line.Content.Trim()}",
+                    whyItMatters:    "Automated dependency bots (Dependabot, Renovate, Snyk) should not be changing public method signatures. This may indicate a transitive dependency pulled in an unexpected API change or a bot misconfiguration.",
+                    suggestedAction: "Review the public API change carefully. If unintentional, revert the non-lockfile changes. If intentional, use a human-authored PR instead.",
+                    confidence:      Confidence.Medium,
+                    line:            line));
+            }
+        }
+
+        return Task.FromResult(findings);
+    }
+}

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0053_LockfileChangedWithoutSource.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0053_LockfileChangedWithoutSource.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.FileAnalysis;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0053 – Lockfile Changed Without Source Review
+/// Fires when a diff contains only lockfile changes with no accompanying source-file edits.
+/// This can hide malicious dependency upgrades or unexpected breaking changes.
+/// </summary>
+public class GCI0053_LockfileChangedWithoutSource : RuleBase
+{
+    public override string Id   => "GCI0053";
+    public override string Name => "Lockfile Changed Without Source Review";
+
+    private static readonly HashSet<string> LockfileNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "packages.lock.json",
+            "package-lock.json",
+            "yarn.lock",
+            "Pipfile.lock",
+            "go.sum",
+            "Cargo.lock",
+            "Directory.Packages.props",
+            "pnpm-lock.yaml",
+            "poetry.lock",
+        };
+
+    private static readonly HashSet<string> LockfileExtensions =
+        new(StringComparer.OrdinalIgnoreCase) { ".lock" };
+
+    private static readonly HashSet<string> SourceExtensions =
+        new(StringComparer.OrdinalIgnoreCase) { ".cs", ".ts", ".js", ".py", ".go", ".rs" };
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        var allRecords = context.EligibleFiles.Concat(context.SkippedFiles).ToList();
+
+        var lockfileChanges = allRecords
+            .Where(r => IsLockfile(r.FilePath))
+            .ToList();
+
+        if (lockfileChanges.Count == 0)
+            return Task.FromResult(findings);
+
+        // Look for non-lockfile source changes in CS-eligible files and skipped files
+        bool hasSourceChange =
+            context.Diff.Files.Any(f => SourceExtensions.Contains(Path.GetExtension(f.NewPath)))
+            || allRecords.Any(r => !IsLockfile(r.FilePath) && SourceExtensions.Contains(Path.GetExtension(r.FilePath)));
+
+        if (hasSourceChange)
+            return Task.FromResult(findings);
+
+        foreach (var lockfileRecord in lockfileChanges)
+        {
+            findings.Add(CreateFinding(
+                summary:         "Lockfile modified without accompanying source changes — verify dependency upgrade",
+                evidence:        lockfileRecord.FilePath,
+                whyItMatters:    "Lockfile-only changes introduce new dependency versions without visible source context. Malicious packages or unexpected breaking changes may go unnoticed.",
+                suggestedAction: "Review the lockfile diff carefully. Verify each changed package version is intentional and from a trusted source. Consider adding a comment in the PR description describing the upgrade reason.",
+                confidence:      Confidence.Low));
+        }
+
+        return Task.FromResult(findings);
+    }
+
+    private static bool IsLockfile(string path)
+    {
+        var fileName = Path.GetFileName(path);
+        if (LockfileNames.Contains(fileName)) return true;
+        return LockfileExtensions.Contains(Path.GetExtension(path));
+    }
+}

--- a/src/GauntletCI.Tests/CoverageCorrelatorTests.cs
+++ b/src/GauntletCI.Tests/CoverageCorrelatorTests.cs
@@ -76,11 +76,39 @@ public class CoverageCorrelatorTests
             await CoverageCorrelator.AnnotateAsync(result);
 
             // Finding should be unchanged
-            Assert.Null(result.Findings[0].LlmExplanation);
+            Assert.Null(result.Findings[0].CoverageNote);
         }
         finally
         {
             Environment.SetEnvironmentVariable("CODECOV_TOKEN", prev);
         }
+    }
+
+    [Fact]
+    public void ParseCoverageResponse_NullMap_DoesNotAnnotateFindings()
+    {
+        // When the map is null (parse failure), no findings should be annotated.
+        // This is enforced in AnnotateAsync (early return); test the contract via ParseCoverageResponse.
+        var result = CoverageCorrelator.ParseCoverageResponse("""{ "no_files_key": [] }""");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseCoverageResponse_FileWithZeroCoverage_IsPresent()
+    {
+        var json = """
+            {
+              "files": [
+                { "name": "src/ZeroCov.cs", "totals": { "coverage": 0.0 } }
+              ]
+            }
+            """;
+
+        var map = CoverageCorrelator.ParseCoverageResponse(json);
+
+        Assert.NotNull(map);
+        Assert.True(map!.TryGetValue("src/ZeroCov.cs", out var cov));
+        Assert.Equal(0.0, cov);
     }
 }

--- a/src/GauntletCI.Tests/CoverageCorrelatorTests.cs
+++ b/src/GauntletCI.Tests/CoverageCorrelatorTests.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Cli.Output;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+
+namespace GauntletCI.Tests;
+
+public class CoverageCorrelatorTests
+{
+    private static EvaluationResult MakeResult(params Finding[] findings) =>
+        new() { Findings = [.. findings] };
+
+    private static Finding MakeFinding(
+        RuleSeverity severity = RuleSeverity.Block,
+        string? filePath = "src/MyService.cs") => new()
+    {
+        RuleId          = "GCI0001",
+        RuleName        = "Test Rule",
+        Summary         = "test finding",
+        Evidence        = "evidence",
+        WhyItMatters    = "why",
+        SuggestedAction = "action",
+        Confidence      = Confidence.High,
+        Severity        = severity,
+        FilePath        = filePath,
+    };
+
+    [Fact]
+    public void ParseCoverageResponse_ValidJsonWithFiles_ExtractsFilesCoverage()
+    {
+        var json = """
+            {
+              "files": [
+                { "name": "src/MyService.cs", "totals": { "coverage": 82.5 } },
+                { "name": "src/Other.cs",     "totals": { "coverage": 0.0  } }
+              ]
+            }
+            """;
+
+        var result = CoverageCorrelator.ParseCoverageResponse(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(82.5, result!["src/MyService.cs"]);
+        Assert.Equal(0.0,  result!["src/Other.cs"]);
+    }
+
+    [Fact]
+    public void ParseCoverageResponse_NoFilesProperty_ReturnsNull()
+    {
+        var json = """{ "totals": { "coverage": 75.0 } }""";
+
+        var result = CoverageCorrelator.ParseCoverageResponse(json);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseCoverageResponse_InvalidJson_ReturnsNull()
+    {
+        var result = CoverageCorrelator.ParseCoverageResponse("not-json");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task AnnotateAsync_MissingEnvVars_SoftFails()
+    {
+        // Ensure no CODECOV_TOKEN is set so the method exits early without throwing.
+        var prev = Environment.GetEnvironmentVariable("CODECOV_TOKEN");
+        try
+        {
+            Environment.SetEnvironmentVariable("CODECOV_TOKEN", null);
+            var result = MakeResult(MakeFinding());
+
+            // Must not throw
+            await CoverageCorrelator.AnnotateAsync(result);
+
+            // Finding should be unchanged
+            Assert.Null(result.Findings[0].LlmExplanation);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CODECOV_TOKEN", prev);
+        }
+    }
+}

--- a/src/GauntletCI.Tests/DependencyRuleTests.cs
+++ b/src/GauntletCI.Tests/DependencyRuleTests.cs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules.Implementations;
+
+namespace GauntletCI.Tests;
+
+public class DependencyRuleTests
+{
+    private static readonly GCI0052_DependencyBotApiDrift Rule52 = new();
+    private static readonly GCI0053_LockfileChangedWithoutSource Rule53 = new();
+
+    private static DiffContext MakeDiff(params DiffFile[] files) =>
+        new() { Files = [.. files] };
+
+    private static DiffFile MakeFile(string path, params string[] addedLineContents)
+    {
+        var hunk = new DiffHunk
+        {
+            Lines = [.. addedLineContents.Select((content, i) => new DiffLine
+            {
+                Kind       = DiffLineKind.Added,
+                LineNumber = i + 1,
+                Content    = content,
+            })]
+        };
+        return new DiffFile { NewPath = path, OldPath = path, Hunks = [hunk] };
+    }
+
+    // ── GCI0052 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GCI0052_WhenDependabotActorAndPublicApiChange_Fires()
+    {
+        var prev = Environment.GetEnvironmentVariable("GITHUB_ACTOR");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", "dependabot[bot]");
+
+            var diff = MakeDiff(
+                MakeFile("packages.lock.json", "some lock content"),
+                MakeFile("src/Foo.cs", "    public static string DoSomething(string input) {"));
+
+            var findings = await Rule52.EvaluateAsync(diff, null);
+
+            Assert.NotEmpty(findings);
+            Assert.Contains(findings, f => f.Summary.Contains("public API change"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", prev);
+        }
+    }
+
+    [Fact]
+    public async Task GCI0052_WhenNoDependabotActor_DoesNotFire()
+    {
+        var prev = Environment.GetEnvironmentVariable("GITHUB_ACTOR");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", null);
+
+            var diff = MakeDiff(
+                MakeFile("packages.lock.json", "some lock content"),
+                MakeFile("src/Foo.cs", "    public static string DoSomething(string input) {"));
+
+            var findings = await Rule52.EvaluateAsync(diff, null);
+
+            Assert.Empty(findings);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", prev);
+        }
+    }
+
+    [Fact]
+    public async Task GCI0052_WhenDependabotActorButNoPublicApiChange_DoesNotFire()
+    {
+        var prev = Environment.GetEnvironmentVariable("GITHUB_ACTOR");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", "dependabot[bot]");
+
+            var diff = MakeDiff(
+                MakeFile("packages.lock.json", "some lock content"),
+                MakeFile("src/Foo.cs", "    private string InternalHelper() {"));
+
+            var findings = await Rule52.EvaluateAsync(diff, null);
+
+            Assert.Empty(findings);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", prev);
+        }
+    }
+
+    [Fact]
+    public async Task GCI0052_RenovateBotActorAlsoFires()
+    {
+        var prev = Environment.GetEnvironmentVariable("GITHUB_ACTOR");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", "renovate[bot]");
+
+            var diff = MakeDiff(
+                MakeFile("yarn.lock", "some lock content"),
+                MakeFile("src/Bar.cs", "    public async Task<string> GetAsync(int id) {"));
+
+            var findings = await Rule52.EvaluateAsync(diff, null);
+
+            Assert.NotEmpty(findings);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_ACTOR", prev);
+        }
+    }
+
+    // ── GCI0053 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GCI0053_WhenLockfileOnlyChange_Fires()
+    {
+        var diff = MakeDiff(MakeFile("yarn.lock", "some lock content"));
+
+        var findings = await Rule53.EvaluateAsync(diff, null);
+
+        Assert.NotEmpty(findings);
+        Assert.Contains(findings, f => f.Summary.Contains("Lockfile modified"));
+    }
+
+    [Fact]
+    public async Task GCI0053_WhenLockfileAndSourceChange_DoesNotFire()
+    {
+        var diff = MakeDiff(
+            MakeFile("yarn.lock", "some lock content"),
+            MakeFile("src/App.cs", "public class App {}"));
+
+        var findings = await Rule53.EvaluateAsync(diff, null);
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task GCI0053_DotLockExtensionIsDetected()
+    {
+        var diff = MakeDiff(MakeFile("something.lock", "lock data"));
+
+        var findings = await Rule53.EvaluateAsync(diff, null);
+
+        Assert.NotEmpty(findings);
+    }
+
+    [Fact]
+    public async Task GCI0053_NoLockfileChanges_DoesNotFire()
+    {
+        var diff = MakeDiff(MakeFile("src/Service.cs", "public class Service {}"));
+
+        var findings = await Rule53.EvaluateAsync(diff, null);
+
+        Assert.Empty(findings);
+    }
+}

--- a/src/GauntletCI.Tests/GitHubChecksWriterTests.cs
+++ b/src/GauntletCI.Tests/GitHubChecksWriterTests.cs
@@ -80,15 +80,16 @@ public class GitHubChecksWriterTests
     }
 
     [Fact]
-    public void BuildAnnotations_PrioritizesBlockOverWarn()
+    public void BuildAnnotations_PrioritizesBlockOverAdvisory()
     {
-        var warnFinding  = MakeFinding(RuleSeverity.Warn,  filePath: "src/Warn.cs",  line: 1, ruleId: "GCI9001");
-        var blockFinding = MakeFinding(RuleSeverity.Block, filePath: "src/Block.cs", line: 2, ruleId: "GCI9002");
+        // Advisory enum value (4) > Block (3), so naive OrderByDescending would put Advisory first.
+        // Verify Block is always first regardless of enum value.
+        var advisoryFinding = MakeFinding(RuleSeverity.Advisory, filePath: "src/Advisory.cs", line: 1, ruleId: "GCI9003");
+        var blockFinding    = MakeFinding(RuleSeverity.Block,    filePath: "src/Block.cs",    line: 2, ruleId: "GCI9004");
 
-        var result      = MakeResult(warnFinding, blockFinding);
+        var result      = MakeResult(advisoryFinding, blockFinding);
         var annotations = GitHubChecksWriter.BuildAnnotations(result);
 
-        // Block annotation should appear before Warn annotation
         Assert.Equal(2, annotations.Count);
         var first = annotations[0].ToString()!;
         Assert.Contains("Block.cs", first);

--- a/src/GauntletCI.Tests/GitHubChecksWriterTests.cs
+++ b/src/GauntletCI.Tests/GitHubChecksWriterTests.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Cli.Output;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+
+namespace GauntletCI.Tests;
+
+public class GitHubChecksWriterTests
+{
+    private static EvaluationResult MakeResult(params Finding[] findings) =>
+        new() { Findings = [.. findings] };
+
+    private static Finding MakeFinding(
+        RuleSeverity severity = RuleSeverity.Block,
+        string? filePath = "src/Foo.cs",
+        int? line = 10,
+        string ruleId = "GCI0001") => new()
+    {
+        RuleId          = ruleId,
+        RuleName        = "Test Rule",
+        Summary         = "test finding",
+        Evidence        = "evidence",
+        WhyItMatters    = "why it matters",
+        SuggestedAction = "do something",
+        Confidence      = Confidence.High,
+        Severity        = severity,
+        FilePath        = filePath,
+        Line            = line,
+    };
+
+    // ── BuildConclusion ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildConclusion_WithBlockFinding_ReturnsFailure()
+    {
+        var result = MakeResult(MakeFinding(RuleSeverity.Block));
+
+        Assert.Equal("failure", GitHubChecksWriter.BuildConclusion(result));
+    }
+
+    [Fact]
+    public void BuildConclusion_WithWarnOnlyFindings_ReturnsNeutral()
+    {
+        var result = MakeResult(MakeFinding(RuleSeverity.Warn));
+
+        Assert.Equal("neutral", GitHubChecksWriter.BuildConclusion(result));
+    }
+
+    [Fact]
+    public void BuildConclusion_WithNoFindings_ReturnsSuccess()
+    {
+        var result = MakeResult();
+
+        Assert.Equal("success", GitHubChecksWriter.BuildConclusion(result));
+    }
+
+    [Fact]
+    public void BuildConclusion_BlockAndWarn_ReturnsFailure()
+    {
+        var result = MakeResult(
+            MakeFinding(RuleSeverity.Warn),
+            MakeFinding(RuleSeverity.Block));
+
+        Assert.Equal("failure", GitHubChecksWriter.BuildConclusion(result));
+    }
+
+    // ── BuildAnnotations ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildAnnotations_LimitsTo50()
+    {
+        var findings = Enumerable.Range(1, 60)
+            .Select(i => MakeFinding(RuleSeverity.Warn, filePath: $"src/F{i}.cs", line: i, ruleId: $"GCI{i:D4}"))
+            .ToArray();
+
+        var result      = MakeResult(findings);
+        var annotations = GitHubChecksWriter.BuildAnnotations(result);
+
+        Assert.Equal(50, annotations.Count);
+    }
+
+    [Fact]
+    public void BuildAnnotations_PrioritizesBlockOverWarn()
+    {
+        var warnFinding  = MakeFinding(RuleSeverity.Warn,  filePath: "src/Warn.cs",  line: 1, ruleId: "GCI9001");
+        var blockFinding = MakeFinding(RuleSeverity.Block, filePath: "src/Block.cs", line: 2, ruleId: "GCI9002");
+
+        var result      = MakeResult(warnFinding, blockFinding);
+        var annotations = GitHubChecksWriter.BuildAnnotations(result);
+
+        // Block annotation should appear before Warn annotation
+        Assert.Equal(2, annotations.Count);
+        var first = annotations[0].ToString()!;
+        Assert.Contains("Block.cs", first);
+    }
+
+    [Fact]
+    public void BuildAnnotations_SkipsFindingsWithoutLocation()
+    {
+        var withLocation    = MakeFinding(RuleSeverity.Block, filePath: "src/Foo.cs", line: 5);
+        var withoutFilePath = MakeFinding(RuleSeverity.Block, filePath: null, line: 5);
+        var withoutLine     = MakeFinding(RuleSeverity.Block, filePath: "src/Bar.cs", line: null);
+
+        var result      = MakeResult(withLocation, withoutFilePath, withoutLine);
+        var annotations = GitHubChecksWriter.BuildAnnotations(result);
+
+        Assert.Single(annotations);
+    }
+
+    [Fact]
+    public async Task WriteAsync_MissingEnvVars_SoftFails()
+    {
+        var prevToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_TOKEN", null);
+            var result = MakeResult(MakeFinding());
+
+            // Must not throw
+            await GitHubChecksWriter.WriteAsync(result);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_TOKEN", prevToken);
+        }
+    }
+}

--- a/src/GauntletCI.Tests/GitHubPrReviewWriterTests.cs
+++ b/src/GauntletCI.Tests/GitHubPrReviewWriterTests.cs
@@ -171,6 +171,18 @@ public class GitHubPrReviewWriterTests
         Assert.DoesNotContain("Expert context", body);
     }
 
+    [Fact]
+    public void BuildCommentBody_WithCoverageNote_IncludesCoverageSection()
+    {
+        var f    = MakeFinding();
+        f.CoverageNote = "⚠️ No test coverage detected for this file (Codecov).";
+        var body = GitHubPrReviewWriter.BuildCommentBody(f);
+
+        Assert.Contains("📊", body);
+        Assert.Contains("Coverage", body);
+        Assert.Contains("No test coverage", body);
+    }
+
     // --- ResolvePrNumber ---
 
     [Fact]

--- a/src/GauntletCI.Tests/GitHubPrReviewWriterTests.cs
+++ b/src/GauntletCI.Tests/GitHubPrReviewWriterTests.cs
@@ -66,6 +66,59 @@ public class GitHubPrReviewWriterTests
         Assert.Contains("> await Task.Delay(0);", body);
     }
 
+    // --- FormatEvidenceMarkdown ---
+
+    [Fact]
+    public void FormatEvidenceMarkdown_WasNow_ReturnsDiffBlock()
+    {
+        var result = GitHubPrReviewWriter.FormatEvidenceMarkdown("Was: public void Foo(int a, int b) | Now: public void Foo(int a)");
+
+        Assert.Contains("```diff", result);
+        Assert.Contains("- public void Foo(int a, int b)", result);
+        Assert.Contains("+ public void Foo(int a)", result);
+    }
+
+    [Fact]
+    public void FormatEvidenceMarkdown_Removed_ReturnsDiffBlock()
+    {
+        var result = GitHubPrReviewWriter.FormatEvidenceMarkdown("Removed: public void OldMethod()");
+
+        Assert.Contains("```diff", result);
+        Assert.Contains("- public void OldMethod()", result);
+        Assert.DoesNotContain("+", result);
+    }
+
+    [Fact]
+    public void FormatEvidenceMarkdown_RemovedLogic_ReturnsDiffBlockWithMultipleLines()
+    {
+        var result = GitHubPrReviewWriter.FormatEvidenceMarkdown("Removed logic: return x > 0 | if (x == null) | throw new Exception()");
+
+        Assert.Contains("```diff", result);
+        Assert.Contains("- return x > 0", result);
+        Assert.Contains("- if (x == null)", result);
+        Assert.Contains("- throw new Exception()", result);
+    }
+
+    [Fact]
+    public void FormatEvidenceMarkdown_PlainText_ReturnsBlockquote()
+    {
+        var result = GitHubPrReviewWriter.FormatEvidenceMarkdown("await Task.Delay(0);");
+
+        Assert.StartsWith(">", result);
+        Assert.DoesNotContain("```", result);
+    }
+
+    [Fact]
+    public void BuildCommentBody_WasNowEvidence_RendersDiffBlock()
+    {
+        var f    = MakeFinding(evidence: "Was: Task.Run(Foo) | Now: await FooAsync()");
+        var body = GitHubPrReviewWriter.BuildCommentBody(f);
+
+        Assert.Contains("```diff", body);
+        Assert.Contains("- Task.Run(Foo)", body);
+        Assert.Contains("+ await FooAsync()", body);
+    }
+
     [Fact]
     public void BuildCommentBody_WithWhyItMatters_IncludesSection()
     {

--- a/src/GauntletCI.Tests/OrchestratorTests.cs
+++ b/src/GauntletCI.Tests/OrchestratorTests.cs
@@ -21,7 +21,7 @@ public class OrchestratorTests
             +var x = 1;
             """);
         var result = await orchestrator.RunAsync(diff);
-        Assert.Equal(28, result.RulesEvaluated);
+        Assert.Equal(30, result.RulesEvaluated);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class OrchestratorTests
             """);
         var result = await orchestrator.RunAsync(diff);
         Assert.NotNull(result);
-        Assert.Equal(28, result.RulesEvaluated);
+        Assert.Equal(30, result.RulesEvaluated);
     }
 
     [Fact]

--- a/src/GauntletCI.Tests/SlackTeamsNotifierTests.cs
+++ b/src/GauntletCI.Tests/SlackTeamsNotifierTests.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Cli.Output;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+
+namespace GauntletCI.Tests;
+
+public class SlackTeamsNotifierTests
+{
+    private static EvaluationResult MakeResult(params Finding[] findings) =>
+        new() { Findings = [.. findings] };
+
+    private static Finding MakeFinding(
+        string ruleId    = "GCI0001",
+        string summary   = "A test summary",
+        string evidence  = "some evidence",
+        RuleSeverity severity = RuleSeverity.Block) => new()
+    {
+        RuleId          = ruleId,
+        RuleName        = "Test Rule",
+        Summary         = summary,
+        Evidence        = evidence,
+        WhyItMatters    = "why it matters",
+        SuggestedAction = "do something",
+        Confidence      = Confidence.High,
+        Severity        = severity,
+    };
+
+    [Fact]
+    public void BuildSlackPayload_WithBlockFindings_ContainsRuleId()
+    {
+        var result = MakeResult(MakeFinding(ruleId: "GCI0099", severity: RuleSeverity.Block));
+
+        var json = SlackTeamsNotifier.BuildSlackPayload(result, "owner/repo", "42", "abc12345");
+
+        Assert.Contains("GCI0099", json);
+    }
+
+    [Fact]
+    public void BuildSlackPayload_WithNoBlockFindings_ReturnsEmpty()
+    {
+        var result = MakeResult(MakeFinding(severity: RuleSeverity.Warn));
+
+        var json = SlackTeamsNotifier.BuildSlackPayload(result, "owner/repo", "42", "abc12345");
+
+        Assert.True(string.IsNullOrEmpty(json));
+    }
+
+    [Fact]
+    public void BuildTeamsPayload_WithBlockFindings_ContainsTitle()
+    {
+        var result = MakeResult(MakeFinding(ruleId: "GCI0099", severity: RuleSeverity.Block));
+
+        var json = SlackTeamsNotifier.BuildTeamsPayload(result, "owner/repo", "42", "abc12345");
+
+        Assert.Contains("GauntletCI", json);
+        Assert.Contains("GCI0099", json);
+    }
+
+    [Fact]
+    public void BuildSlackPayload_MoreThanThreeBlockFindings_ContainsMoreMessage()
+    {
+        var result = MakeResult(
+            MakeFinding(ruleId: "GCI0001", severity: RuleSeverity.Block),
+            MakeFinding(ruleId: "GCI0002", severity: RuleSeverity.Block),
+            MakeFinding(ruleId: "GCI0003", severity: RuleSeverity.Block),
+            MakeFinding(ruleId: "GCI0004", severity: RuleSeverity.Block));
+
+        var json = SlackTeamsNotifier.BuildSlackPayload(result, "owner/repo", "42", "abc12345");
+
+        Assert.Contains("more Block findings", json);
+    }
+
+    [Fact]
+    public void BuildTeamsPayload_ContainsRepoAndPr()
+    {
+        var result = MakeResult(MakeFinding(severity: RuleSeverity.Block));
+
+        var json = SlackTeamsNotifier.BuildTeamsPayload(result, "my-org/my-repo", "77", "deadbeef");
+
+        Assert.Contains("my-org/my-repo", json);
+        Assert.Contains("77", json);
+    }
+}


### PR DESCRIPTION
Implements 4 integrations: Slack/Teams webhook notifications, GitHub Checks API check runs, Codecov coverage correlation, and two new dependency scanner rules (GCI0052, GCI0053).