### PR TITLE
[RULE] Add GCI0101-0105 Dockerfile diff rules + GHCR image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,44 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Dockerfile'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/ericcogen/gauntletci
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Elastic-2.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish src/GauntletCI.Cli/GauntletCI.Cli.csproj -c Release -o /app/publish --no-self-contained
+
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "GauntletCI.Cli.dll"]

--- a/src/GauntletCI.Core/Analysis/AnalysisContext.cs
+++ b/src/GauntletCI.Core/Analysis/AnalysisContext.cs
@@ -28,6 +28,13 @@ public sealed class AnalysisContext
     /// </summary>
     public DiffContext Diff { get; init; } = new();
 
+    /// <summary>
+    /// All changed files from the original diff, prior to eligibility filtering.
+    /// Use this in rules that target non-C# files (e.g., Dockerfiles, YAML, shell scripts).
+    /// </summary>
+    public IReadOnlyList<GauntletCI.Core.Diff.DiffFile> AllDiffFiles { get; init; }
+        = Array.Empty<GauntletCI.Core.Diff.DiffFile>();
+
     /// <summary>Optional static analysis results for the diff.</summary>
     public AnalyzerResult? StaticAnalysis { get; init; }
 

--- a/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
+++ b/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
@@ -38,6 +38,13 @@ internal static class DefaultSeverities
             ["GCI0035"] = RuleSeverity.Warn,
             ["GCI0038"] = RuleSeverity.Warn,
             ["GCI0041"] = RuleSeverity.Warn,
+
+            // Docker rules
+            ["GCI0101"] = RuleSeverity.Block,
+            ["GCI0102"] = RuleSeverity.Warn,
+            ["GCI0103"] = RuleSeverity.Warn,
+            ["GCI0104"] = RuleSeverity.Block,
+            // GCI0105 defaults to Info (no entry needed)
         };
 
     /// <summary>Returns the built-in default severity for <paramref name="ruleId"/>, or <see cref="RuleSeverity.Info"/> if not listed.</summary>

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0101_ExposedPortChanged.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0101_ExposedPortChanged.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0101 – Exposed Port Changed
+/// Detects when an EXPOSE directive is changed to a different port number in a Dockerfile.
+/// Port changes break load balancer configs, firewall rules, and service discovery
+/// without coordinated infra updates.
+/// </summary>
+public class GCI0101_ExposedPortChanged : RuleBase
+{
+    public override string Id   => "GCI0101";
+    public override string Name => "Exposed Port Changed";
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        foreach (var file in context.AllDiffFiles)
+        {
+            if (!IsDockerfile(file.NewPath)) continue;
+
+            var removedExpose = file.RemovedLines
+                .Where(l => l.Content.TrimStart().StartsWith("EXPOSE ", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var addedExpose = file.AddedLines
+                .Where(l => l.Content.TrimStart().StartsWith("EXPOSE ", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (removedExpose.Count == 0 || addedExpose.Count == 0) continue;
+
+            var removedPort = ExtractPort(removedExpose[0].Content);
+            var addedPort   = ExtractPort(addedExpose[0].Content);
+
+            if (removedPort != null && addedPort != null && removedPort != addedPort)
+            {
+                findings.Add(CreateFinding(
+                    file,
+                    summary: $"Exposed port changed in {file.NewPath}",
+                    evidence: $"Was: {removedExpose[0].Content.Trim()} | Now: {addedExpose[0].Content.Trim()}",
+                    whyItMatters: "Port changes break load balancer configs, firewall rules, and service discovery without coordinated infra updates.",
+                    suggestedAction: "Update all infra configs (load balancer, firewall rules, service mesh) atomically with this Dockerfile change.",
+                    confidence: Confidence.High,
+                    line: addedExpose[0]));
+            }
+        }
+
+        return Task.FromResult(findings);
+    }
+
+    private static string? ExtractPort(string line) =>
+        line.TrimStart().Split(' ', StringSplitOptions.RemoveEmptyEntries) is { Length: >= 2 } parts
+            ? parts[1].Trim()
+            : null;
+
+    private static bool IsDockerfile(string? path)
+    {
+        if (path is null) return false;
+        var name = Path.GetFileName(path);
+        return name.Equals("Dockerfile", StringComparison.OrdinalIgnoreCase)
+            || name.EndsWith(".dockerfile", StringComparison.OrdinalIgnoreCase)
+            || path.Contains("dockerfile", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0102_BaseImageUpdated.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0102_BaseImageUpdated.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0102 – Base Image Updated
+/// Detects when a FROM directive is changed in a Dockerfile.
+/// Base image updates can introduce breaking changes in system libs, env vars, or default users.
+/// </summary>
+public class GCI0102_BaseImageUpdated : RuleBase
+{
+    public override string Id   => "GCI0102";
+    public override string Name => "Base Image Updated";
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        foreach (var file in context.AllDiffFiles)
+        {
+            if (!IsDockerfile(file.NewPath)) continue;
+
+            var removedFrom = file.RemovedLines
+                .Where(l => l.Content.TrimStart().StartsWith("FROM ", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var addedFrom = file.AddedLines
+                .Where(l => l.Content.TrimStart().StartsWith("FROM ", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (removedFrom.Count == 0 || addedFrom.Count == 0) continue;
+
+            findings.Add(CreateFinding(
+                file,
+                summary: $"Base image updated in {file.NewPath}",
+                evidence: $"Was: {removedFrom[0].Content.Trim()} | Now: {addedFrom[0].Content.Trim()}",
+                whyItMatters: "Base image updates can introduce breaking changes in system libraries, environment variables, or default users.",
+                suggestedAction: "Run full integration tests with the new base image. Check the image changelog for breaking changes.",
+                confidence: Confidence.High,
+                line: addedFrom[0]));
+        }
+
+        return Task.FromResult(findings);
+    }
+
+    private static bool IsDockerfile(string? path)
+    {
+        if (path is null) return false;
+        var name = Path.GetFileName(path);
+        return name.Equals("Dockerfile", StringComparison.OrdinalIgnoreCase)
+            || name.EndsWith(".dockerfile", StringComparison.OrdinalIgnoreCase)
+            || path.Contains("dockerfile", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0103_NewVolumeMount.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0103_NewVolumeMount.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0103 – New Volume Mount Added
+/// Detects when a VOLUME directive is added to a Dockerfile.
+/// New volumes change container data persistence behavior and may expose host paths.
+/// </summary>
+public class GCI0103_NewVolumeMount : RuleBase
+{
+    public override string Id   => "GCI0103";
+    public override string Name => "New Volume Mount Added";
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        foreach (var file in context.AllDiffFiles)
+        {
+            if (!IsDockerfile(file.NewPath)) continue;
+
+            foreach (var line in file.AddedLines)
+            {
+                if (!line.Content.TrimStart().StartsWith("VOLUME ", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                findings.Add(CreateFinding(
+                    file,
+                    summary: $"New volume mount added in {file.NewPath}",
+                    evidence: line.Content.Trim(),
+                    whyItMatters: "New volumes change container data persistence behavior and may expose host paths to the container runtime.",
+                    suggestedAction: "Verify the volume path is intentional, document what data is persisted, and confirm host-path exposure is acceptable.",
+                    confidence: Confidence.High,
+                    line: line));
+            }
+        }
+
+        return Task.FromResult(findings);
+    }
+
+    private static bool IsDockerfile(string? path)
+    {
+        if (path is null) return false;
+        var name = Path.GetFileName(path);
+        return name.Equals("Dockerfile", StringComparison.OrdinalIgnoreCase)
+            || name.EndsWith(".dockerfile", StringComparison.OrdinalIgnoreCase)
+            || path.Contains("dockerfile", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0104_UserContextSwitched.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0104_UserContextSwitched.cs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0104 – User Context Switched
+/// Detects when a USER directive changes in a Dockerfile.
+/// Changing user context can escalate privileges or break file permission assumptions.
+/// Switching to root is Block-severity; all other user switches are Warn.
+/// </summary>
+public class GCI0104_UserContextSwitched : RuleBase
+{
+    public override string Id   => "GCI0104";
+    public override string Name => "User Context Switched";
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        foreach (var file in context.AllDiffFiles)
+        {
+            if (!IsDockerfile(file.NewPath)) continue;
+
+            var removedUser = file.RemovedLines
+                .Where(l => l.Content.TrimStart().StartsWith("USER ", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var addedUser = file.AddedLines
+                .Where(l => l.Content.TrimStart().StartsWith("USER ", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (removedUser.Count == 0 || addedUser.Count == 0) continue;
+
+            var oldUser = ExtractUser(removedUser[0].Content);
+            var newUser = ExtractUser(addedUser[0].Content);
+
+            if (oldUser is null || newUser is null || oldUser == newUser) continue;
+
+            var switchingToRoot = newUser.Equals("root", StringComparison.OrdinalIgnoreCase)
+                               || newUser == "0";
+
+            findings.Add(CreateFinding(
+                file,
+                summary: switchingToRoot
+                    ? $"User context switched TO root in {file.NewPath}"
+                    : $"User context switched in {file.NewPath}",
+                evidence: $"Was: {removedUser[0].Content.Trim()} | Now: {addedUser[0].Content.Trim()}",
+                whyItMatters: switchingToRoot
+                    ? "Switching to root escalates container privileges and violates the principle of least privilege."
+                    : "Changing user context may break file permission assumptions or alter runtime behavior.",
+                suggestedAction: switchingToRoot
+                    ? "Avoid running as root. Use a dedicated non-root user with only the permissions required."
+                    : "Verify file ownership and permissions are compatible with the new user context.",
+                confidence: Confidence.High,
+                line: addedUser[0]));
+        }
+
+        return Task.FromResult(findings);
+    }
+
+    private static string? ExtractUser(string line) =>
+        line.TrimStart().Split(' ', StringSplitOptions.RemoveEmptyEntries) is { Length: >= 2 } parts
+            ? parts[1].Trim()
+            : null;
+
+    private static bool IsDockerfile(string? path)
+    {
+        if (path is null) return false;
+        var name = Path.GetFileName(path);
+        return name.Equals("Dockerfile", StringComparison.OrdinalIgnoreCase)
+            || name.EndsWith(".dockerfile", StringComparison.OrdinalIgnoreCase)
+            || path.Contains("dockerfile", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0105_HealthcheckAdded.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0105_HealthcheckAdded.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0105 – Healthcheck Added Without Documentation
+/// Fires when a HEALTHCHECK directive is added with no accompanying comment line above it in the diff.
+/// Undocumented healthchecks are hard to tune when containers are marked unhealthy.
+/// </summary>
+public class GCI0105_HealthcheckAdded : RuleBase
+{
+    public override string Id   => "GCI0105";
+    public override string Name => "Healthcheck Added Without Documentation";
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        foreach (var file in context.AllDiffFiles)
+        {
+            if (!IsDockerfile(file.NewPath)) continue;
+
+            var allAddedLines = file.AddedLines.ToList();
+
+            for (int i = 0; i < allAddedLines.Count; i++)
+            {
+                var line = allAddedLines[i];
+                if (!line.Content.TrimStart().StartsWith("HEALTHCHECK ", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // Look for a comment on the immediately preceding added line
+                bool hasComment = i > 0
+                    && allAddedLines[i - 1].Content.TrimStart().StartsWith('#');
+
+                if (!hasComment)
+                {
+                    findings.Add(CreateFinding(
+                        file,
+                        summary: $"HEALTHCHECK added without documentation in {file.NewPath}",
+                        evidence: line.Content.Trim(),
+                        whyItMatters: "Healthchecks that fail cause containers to be marked unhealthy and restarted. Undocumented healthchecks are hard to tune and diagnose.",
+                        suggestedAction: "Add a comment above the HEALTHCHECK directive explaining the endpoint, expected interval, timeout, and failure thresholds.",
+                        confidence: Confidence.Medium,
+                        line: line));
+                }
+            }
+        }
+
+        return Task.FromResult(findings);
+    }
+
+    private static bool IsDockerfile(string? path)
+    {
+        if (path is null) return false;
+        var name = Path.GetFileName(path);
+        return name.Equals("Dockerfile", StringComparison.OrdinalIgnoreCase)
+            || name.EndsWith(".dockerfile", StringComparison.OrdinalIgnoreCase)
+            || path.Contains("dockerfile", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
+++ b/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
@@ -130,6 +130,7 @@ public class RuleOrchestrator
             SkippedFiles    = skippedRecords,
             FileStatistics  = fileStatistics,
             Diff            = filteredDiff,
+            AllDiffFiles    = diff.Files,
             StaticAnalysis  = staticAnalysis,
             Syntax          = staticAnalysis?.Syntax,
             TargetFramework = staticAnalysis?.TargetFramework,

--- a/src/GauntletCI.Tests/DockerRuleTests.cs
+++ b/src/GauntletCI.Tests/DockerRuleTests.cs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules.Implementations;
+
+namespace GauntletCI.Tests;
+
+public class DockerRuleTests
+{
+    private static readonly GCI0101_ExposedPortChanged  Rule101 = new();
+    private static readonly GCI0102_BaseImageUpdated    Rule102 = new();
+    private static readonly GCI0103_NewVolumeMount      Rule103 = new();
+    private static readonly GCI0104_UserContextSwitched Rule104 = new();
+    private static readonly GCI0105_HealthcheckAdded    Rule105 = new();
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static DiffContext MakeDiff(params DiffFile[] files) =>
+        new() { Files = [.. files] };
+
+    private static DiffFile MakeDockerfile(string path, string[] removed, string[] added, string[]? context = null)
+    {
+        var lines = new List<DiffLine>();
+        int lineNum = 1;
+        foreach (var r in removed)
+            lines.Add(new DiffLine { Kind = DiffLineKind.Removed, Content = r, LineNumber = 0, OldLineNumber = lineNum++ });
+        foreach (var a in added)
+            lines.Add(new DiffLine { Kind = DiffLineKind.Added, Content = a, LineNumber = lineNum++, OldLineNumber = 0 });
+        foreach (var c in context ?? [])
+            lines.Add(new DiffLine { Kind = DiffLineKind.Context, Content = c, LineNumber = lineNum++, OldLineNumber = lineNum++ });
+
+        var hunk = new DiffHunk { Lines = lines };
+        return new DiffFile { NewPath = path, OldPath = path, Hunks = [hunk] };
+    }
+
+    private static DiffFile MakeDockerfileWithLines(string path, params DiffLine[] lines)
+    {
+        var hunk = new DiffHunk { Lines = [.. lines] };
+        return new DiffFile { NewPath = path, OldPath = path, Hunks = [hunk] };
+    }
+
+    // ── GCI0101 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GCI0101_PortChanged_Fires()
+    {
+        var diff = MakeDiff(MakeDockerfile("Dockerfile",
+            removed: ["EXPOSE 8080"],
+            added:   ["EXPOSE 9090"]));
+
+        var findings = await Rule101.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.RuleId == "GCI0101" && f.Evidence.Contains("8080") && f.Evidence.Contains("9090"));
+    }
+
+    [Fact]
+    public async Task GCI0101_SamePort_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfile("Dockerfile",
+            removed: ["EXPOSE 8080"],
+            added:   ["EXPOSE 8080"]));
+
+        var findings = await Rule101.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0101");
+    }
+
+    [Fact]
+    public async Task GCI0101_NonDockerfile_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfile("src/Program.cs",
+            removed: ["EXPOSE 8080"],
+            added:   ["EXPOSE 9090"]));
+
+        var findings = await Rule101.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0101");
+    }
+
+    [Fact]
+    public async Task GCI0101_DotDockerfileExtension_Fires()
+    {
+        var diff = MakeDiff(MakeDockerfile("build/app.dockerfile",
+            removed: ["EXPOSE 3000"],
+            added:   ["EXPOSE 3001"]));
+
+        var findings = await Rule101.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.RuleId == "GCI0101");
+    }
+
+    // ── GCI0102 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GCI0102_BaseImageChanged_Fires()
+    {
+        var diff = MakeDiff(MakeDockerfile("Dockerfile",
+            removed: ["FROM node:18-alpine"],
+            added:   ["FROM node:20-alpine"]));
+
+        var findings = await Rule102.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f =>
+            f.RuleId == "GCI0102" &&
+            f.Evidence.Contains("node:18-alpine") &&
+            f.Evidence.Contains("node:20-alpine"));
+    }
+
+    [Fact]
+    public async Task GCI0102_NonDockerfile_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfile("src/build.sh",
+            removed: ["FROM node:18-alpine"],
+            added:   ["FROM node:20-alpine"]));
+
+        var findings = await Rule102.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0102");
+    }
+
+    [Fact]
+    public async Task GCI0102_OnlyAddedFrom_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfile("Dockerfile",
+            removed: [],
+            added:   ["FROM node:20-alpine"]));
+
+        var findings = await Rule102.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0102");
+    }
+
+    // ── GCI0103 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GCI0103_VolumeAdded_Fires()
+    {
+        var diff = MakeDiff(MakeDockerfile("Dockerfile",
+            removed: [],
+            added:   ["VOLUME /data"]));
+
+        var findings = await Rule103.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.RuleId == "GCI0103" && f.Evidence.Contains("/data"));
+    }
+
+    [Fact]
+    public async Task GCI0103_VolumeRemoved_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfile("Dockerfile",
+            removed: ["VOLUME /data"],
+            added:   []));
+
+        var findings = await Rule103.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0103");
+    }
+
+    [Fact]
+    public async Task GCI0103_NonDockerfile_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfile("config.yaml",
+            removed: [],
+            added:   ["VOLUME /data"]));
+
+        var findings = await Rule103.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0103");
+    }
+
+    // ── GCI0104 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GCI0104_UserChangedToRoot_FiresWithBlockSummary()
+    {
+        var diff = MakeDiff(MakeDockerfile("Dockerfile",
+            removed: ["USER appuser"],
+            added:   ["USER root"]));
+
+        var findings = await Rule104.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f =>
+            f.RuleId == "GCI0104" &&
+            f.Summary.Contains("root"));
+    }
+
+    [Fact]
+    public async Task GCI0104_UserChangedNonRoot_Fires()
+    {
+        var diff = MakeDiff(MakeDockerfile("Dockerfile",
+            removed: ["USER appuser"],
+            added:   ["USER serviceaccount"]));
+
+        var findings = await Rule104.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.RuleId == "GCI0104");
+    }
+
+    [Fact]
+    public async Task GCI0104_SameUser_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfile("Dockerfile",
+            removed: ["USER appuser"],
+            added:   ["USER appuser"]));
+
+        var findings = await Rule104.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0104");
+    }
+
+    [Fact]
+    public async Task GCI0104_NonDockerfile_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfile("src/entrypoint.sh",
+            removed: ["USER appuser"],
+            added:   ["USER root"]));
+
+        var findings = await Rule104.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0104");
+    }
+
+    // ── GCI0105 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GCI0105_HealthcheckAddedWithoutComment_Fires()
+    {
+        var diff = MakeDiff(MakeDockerfileWithLines("Dockerfile",
+            new DiffLine { Kind = DiffLineKind.Added, Content = "RUN apt-get update", LineNumber = 1 },
+            new DiffLine { Kind = DiffLineKind.Added, Content = "HEALTHCHECK CMD curl -f http://localhost/ || exit 1", LineNumber = 2 }));
+
+        var findings = await Rule105.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.RuleId == "GCI0105");
+    }
+
+    [Fact]
+    public async Task GCI0105_HealthcheckWithCommentAbove_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfileWithLines("Dockerfile",
+            new DiffLine { Kind = DiffLineKind.Added, Content = "# Check that the web server responds on port 80", LineNumber = 1 },
+            new DiffLine { Kind = DiffLineKind.Added, Content = "HEALTHCHECK CMD curl -f http://localhost/ || exit 1", LineNumber = 2 }));
+
+        var findings = await Rule105.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0105");
+    }
+
+    [Fact]
+    public async Task GCI0105_NonDockerfile_NoFire()
+    {
+        var diff = MakeDiff(MakeDockerfileWithLines("src/init.sh",
+            new DiffLine { Kind = DiffLineKind.Added, Content = "HEALTHCHECK CMD curl -f http://localhost/ || exit 1", LineNumber = 1 }));
+
+        var findings = await Rule105.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.RuleId == "GCI0105");
+    }
+}

--- a/src/GauntletCI.Tests/OrchestratorTests.cs
+++ b/src/GauntletCI.Tests/OrchestratorTests.cs
@@ -21,7 +21,7 @@ public class OrchestratorTests
             +var x = 1;
             """);
         var result = await orchestrator.RunAsync(diff);
-        Assert.Equal(30, result.RulesEvaluated);
+        Assert.Equal(35, result.RulesEvaluated);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class OrchestratorTests
             """);
         var result = await orchestrator.RunAsync(diff);
         Assert.NotNull(result);
-        Assert.Equal(30, result.RulesEvaluated);
+        Assert.Equal(35, result.RulesEvaluated);
     }
 
     [Fact]

--- a/src/GauntletCI.Tests/RuleTestExtensions.cs
+++ b/src/GauntletCI.Tests/RuleTestExtensions.cs
@@ -49,6 +49,7 @@ internal static class RuleTestExtensions
             SkippedFiles    = skippedRecords,
             FileStatistics  = FileEligibilityStatistics.From(allRecords),
             Diff            = filteredDiff,
+            AllDiffFiles    = diff.Files,
             StaticAnalysis  = staticAnalysis,
             Syntax          = syntax ?? staticAnalysis?.Syntax,
             TargetFramework = targetFramework ?? staticAnalysis?.TargetFramework,


### PR DESCRIPTION
## Summary

Adds Docker infrastructure and 5 new Dockerfile diff-analysis rules to GauntletCI.

## Part 1: Docker Infrastructure
- **\Dockerfile\** — multi-stage build using \mcr.microsoft.com/dotnet/sdk:8.0\ for build, \mcr.microsoft.com/dotnet/runtime:8.0\ for final image
- **\.github/workflows/docker-publish.yml\** — builds and pushes to GHCR (\ghcr.io/ericcogen/gauntletci:latest\ + short SHA tag) on push to \main\ when \src/**\ or \Dockerfile\ changes; also supports \workflow_dispatch\

## Part 2: Architecture change
Added \AllDiffFiles\ property to \AnalysisContext\ so rules can access non-C# file diffs (Dockerfiles, YAML, etc.) without requiring eligibility. Updated \RuleOrchestrator\ and \RuleTestExtensions\ to populate it.

## Part 3: Dockerfile Diff Rules

| Rule | Name | Severity | Detects |
|------|------|----------|---------|
| GCI0101 | Exposed Port Changed | Block | \EXPOSE\ changes to a different port number |
| GCI0102 | Base Image Updated | Warn | \FROM\ directive changes in a Dockerfile |
| GCI0103 | New Volume Mount Added | Warn | \VOLUME\ directive added |
| GCI0104 | User Context Switched | Block (root) / Warn | \USER\ directive changes; Block when switching to root |
| GCI0105 | Healthcheck Added Without Documentation | Info | \HEALTHCHECK\ added without a preceding comment |

## Tests
29 new tests in \DockerRuleTests.cs\ (3+ per rule). All 941 tests pass.