### PR TITLE
[CLI] Add gauntletci trace command with PagerDuty/Opsgenie incident correlation

### DIFF
--- a/src/GauntletCI.Cli/Commands/TraceCommand.cs
+++ b/src/GauntletCI.Cli/Commands/TraceCommand.cs
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.CommandLine;
+using System.Text;
+using GauntletCI.Cli.IncidentCorrelation;
+using GauntletCI.Cli.Presentation;
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+using Spectre.Console;
+
+namespace GauntletCI.Cli.Commands;
+
+/// <summary>
+/// Implements <c>gauntletci trace</c> — post-mortem incident correlation.
+/// Gets the diff since a deploy tag, re-runs GauntletCI analysis, optionally fetches
+/// PagerDuty/Opsgenie incidents, and outputs a Change Risk Heatmap.
+/// </summary>
+public static class TraceCommand
+{
+    public static Command Create()
+    {
+        var deployTagOption = new Option<string?>(
+            "--deploy-tag",
+            "Git tag or commit SHA representing the deploy baseline");
+
+        var fromCommitOption = new Option<string?>(
+            "--from-commit",
+            "Explicit base commit SHA (alternative to --deploy-tag)");
+
+        var sinceOption = new Option<string>(
+            "--since",
+            () => "24h",
+            "Time window for incident fetching, e.g. 24h, 7d, 30m (default: 24h)");
+
+        var repoOption = new Option<DirectoryInfo>(
+            "--repo",
+            () => new DirectoryInfo(Directory.GetCurrentDirectory()),
+            "Repository root (default: current directory)");
+
+        var outputOption = new Option<string>(
+            "--output",
+            () => "text",
+            "Output format: text or json");
+
+        var pdTokenOption = new Option<string?>(
+            "--pd-token",
+            "PagerDuty API token (or set PAGERDUTY_TOKEN env var)");
+
+        var ogTokenOption = new Option<string?>(
+            "--og-token",
+            "Opsgenie API key (or set OPSGENIE_TOKEN env var)");
+
+        var postToPdOption = new Option<string?>(
+            "--post-to-pd-incident",
+            "Post the heatmap as a note on this PagerDuty incident ID");
+
+        var noBannerOption = new Option<bool>(
+            "--no-banner",
+            "Disable banner");
+
+        var asciiFlag = new Option<bool>(
+            "--ascii",
+            "ASCII-only output");
+
+        var cmd = new Command("trace", "Post-mortem incident correlation — correlates deploy diff with PagerDuty/Opsgenie incidents")
+        {
+            deployTagOption,
+            fromCommitOption,
+            sinceOption,
+            repoOption,
+            outputOption,
+            pdTokenOption,
+            ogTokenOption,
+            postToPdOption,
+            noBannerOption,
+            asciiFlag,
+        };
+
+        cmd.SetHandler(async (System.CommandLine.Invocation.InvocationContext ctx) =>
+        {
+            var deployTag   = ctx.ParseResult.GetValueForOption(deployTagOption);
+            var fromCommit  = ctx.ParseResult.GetValueForOption(fromCommitOption);
+            var since       = ctx.ParseResult.GetValueForOption(sinceOption)!;
+            var repo        = ctx.ParseResult.GetValueForOption(repoOption)!;
+            var output      = ctx.ParseResult.GetValueForOption(outputOption)!;
+            var pdToken     = ctx.ParseResult.GetValueForOption(pdTokenOption)
+                           ?? Environment.GetEnvironmentVariable("PAGERDUTY_TOKEN");
+            var ogToken     = ctx.ParseResult.GetValueForOption(ogTokenOption)
+                           ?? Environment.GetEnvironmentVariable("OPSGENIE_TOKEN");
+            var postToPd    = ctx.ParseResult.GetValueForOption(postToPdOption);
+            var noBanner    = ctx.ParseResult.GetValueForOption(noBannerOption);
+            var ascii       = ctx.ParseResult.GetValueForOption(asciiFlag);
+            var ct          = ctx.GetCancellationToken();
+
+            var isJson = output.Equals("json", StringComparison.OrdinalIgnoreCase);
+            CliBanner.PrintIfEnabled(new BannerContext { NoBanner = noBanner, OutputFormat = output });
+
+            // Validate: need exactly one of --deploy-tag or --from-commit
+            var baseRef = deployTag ?? fromCommit;
+            if (string.IsNullOrWhiteSpace(baseRef))
+            {
+                Console.Error.WriteLine("[GauntletCI] Error: specify --deploy-tag <tag> or --from-commit <sha>.");
+                ctx.ExitCode = 1;
+                return;
+            }
+
+            if (deployTag is not null && fromCommit is not null)
+            {
+                Console.Error.WriteLine("[GauntletCI] Error: --deploy-tag and --from-commit are mutually exclusive.");
+                ctx.ExitCode = 1;
+                return;
+            }
+
+            try
+            {
+                var now      = DateTimeOffset.UtcNow;
+                var sinceDto = IncidentClient.ParseSince(since, now);
+
+                // Step 1: get diff from base ref to HEAD using three-dot range
+                var rangeRef = $"{baseRef}...HEAD";
+                var diff     = await DiffParser.FromGitAsync(repo.FullName, rangeRef, ct);
+
+                // Step 2: run rule orchestrator
+                var config      = ConfigLoader.Load(repo.FullName);
+                var ignoreList  = IgnoreList.Load(repo.FullName);
+                var orchestrator = RuleOrchestrator.CreateDefault(config, repoPath: repo.FullName);
+                var result       = await orchestrator.RunAsync(diff, ignoreList: ignoreList);
+
+                // Step 3: fetch incidents (soft-fail)
+                var allIncidents = new List<IncidentCorrelation.IncidentSummary>();
+
+                if (!string.IsNullOrWhiteSpace(pdToken))
+                {
+                    var pdIncidents = await IncidentClient.FetchPagerDutyAsync(pdToken, sinceDto, now, ct);
+                    allIncidents.AddRange(pdIncidents);
+                    if (!isJson)
+                        AnsiConsole.MarkupLine($"[dim]  📟  Fetched {pdIncidents.Count} PagerDuty incident(s)[/]");
+                }
+                else
+                {
+                    Console.Error.WriteLine("[GauntletCI] No PagerDuty token — skipping PD incident fetch (set --pd-token or PAGERDUTY_TOKEN).");
+                }
+
+                if (!string.IsNullOrWhiteSpace(ogToken))
+                {
+                    var ogAlerts = await IncidentClient.FetchOpsgenieAsync(ogToken, ct);
+                    allIncidents.AddRange(ogAlerts);
+                    if (!isJson)
+                        AnsiConsole.MarkupLine($"[dim]  📟  Fetched {ogAlerts.Count} Opsgenie alert(s)[/]");
+                }
+                else
+                {
+                    Console.Error.WriteLine("[GauntletCI] No Opsgenie token — skipping OG alert fetch (set --og-token or OPSGENIE_TOKEN).");
+                }
+
+                // Step 4: correlate
+                var correlations = IncidentClient.CorrelateIncidents(result.Findings, allIncidents);
+
+                // Step 5: output
+                if (isJson)
+                {
+                    var json = IncidentClient.BuildHeatmapJson(
+                        baseRef, sinceDto, now, result.Findings, correlations, allIncidents);
+                    Console.WriteLine(json);
+                }
+                else
+                {
+                    PrintHeatmap(baseRef, sinceDto, now, result, correlations, allIncidents, ascii);
+                }
+
+                // Step 6: post to PD incident if requested
+                if (!string.IsNullOrWhiteSpace(postToPd) && !string.IsNullOrWhiteSpace(pdToken))
+                {
+                    var textContent = BuildHeatmapText(baseRef, result, correlations, allIncidents);
+                    await IncidentClient.PostPagerDutyNoteAsync(pdToken, postToPd, $"GauntletCI Change Risk Heatmap:\n{textContent}", ct);
+                    if (!isJson)
+                        AnsiConsole.MarkupLine($"[dim]  ✅  Posted heatmap note to PagerDuty incident {Markup.Escape(postToPd)}[/]");
+                }
+                else if (!string.IsNullOrWhiteSpace(postToPd) && string.IsNullOrWhiteSpace(pdToken))
+                {
+                    Console.Error.WriteLine("[GauntletCI] --post-to-pd-incident requires --pd-token or PAGERDUTY_TOKEN.");
+                }
+
+                ctx.ExitCode = result.HasFindings ? 1 : 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[GauntletCI] Error: {ex.Message}");
+                ctx.ExitCode = 2;
+            }
+        });
+
+        return cmd;
+    }
+
+    // ── Text rendering ────────────────────────────────────────────────────────
+
+    private static void PrintHeatmap(
+        string baseRef,
+        DateTimeOffset since,
+        DateTimeOffset now,
+        GauntletCI.Core.Rules.EvaluationResult result,
+        Dictionary<string, List<IncidentCorrelation.IncidentSummary>> correlations,
+        List<IncidentCorrelation.IncidentSummary> allIncidents,
+        bool ascii)
+    {
+        var hr = ascii
+            ? "======================================================="
+            : "═══════════════════════════════════════════════════════";
+
+        AnsiConsole.MarkupLine($"[cyan]{hr}[/]");
+        AnsiConsole.MarkupLine("[cyan]  GauntletCI Change Risk Heatmap[/]");
+        AnsiConsole.MarkupLine($"[cyan]{hr}[/]");
+        AnsiConsole.MarkupLine($"  Base ref : {Markup.Escape(baseRef)}");
+        AnsiConsole.MarkupLine($"  Window   : {since:u} → {now:u}");
+        AnsiConsole.MarkupLine($"  Findings : {result.Findings.Count}");
+        AnsiConsole.MarkupLine($"  Incidents: {allIncidents.Count}");
+        AnsiConsole.WriteLine();
+
+        var byFile = result.Findings
+            .Where(f => !string.IsNullOrWhiteSpace(f.FilePath))
+            .GroupBy(f => f.FilePath!, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (byFile.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[green]  No file-level findings.[/]");
+            return;
+        }
+
+        var table = new Table()
+            .Border(ascii ? TableBorder.Ascii : TableBorder.Rounded)
+            .AddColumn("[bold]File[/]")
+            .AddColumn("[bold]Severity[/]")
+            .AddColumn("[bold]Findings[/]")
+            .AddColumn("[bold]Correlated Incidents[/]");
+
+        foreach (var grp in byFile.OrderByDescending(g => g.Max(f => f.Severity)))
+        {
+            var filePath = grp.Key;
+            var maxSev   = grp.Max(f => f.Severity);
+            var sevColor = maxSev switch
+            {
+                RuleSeverity.Block => "red",
+                RuleSeverity.Warn  => "yellow",
+                _                  => "grey",
+            };
+
+            var findingsSummary = string.Join(", ", grp.Select(f => f.RuleId).Distinct());
+
+            correlations.TryGetValue(filePath, out var correlated);
+            var incidentText = (correlated is null || correlated.Count == 0)
+                ? "[grey]none[/]"
+                : string.Join(", ", correlated.Select(i => Markup.Escape($"{i.Source}:{i.Id}")));
+
+            table.AddRow(
+                Markup.Escape(filePath),
+                $"[{sevColor}]{maxSev}[/]",
+                Markup.Escape(findingsSummary),
+                incidentText);
+        }
+
+        AnsiConsole.Write(table);
+    }
+
+    private static string BuildHeatmapText(
+        string baseRef,
+        GauntletCI.Core.Rules.EvaluationResult result,
+        Dictionary<string, List<IncidentCorrelation.IncidentSummary>> correlations,
+        List<IncidentCorrelation.IncidentSummary> allIncidents)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Base ref: {baseRef}");
+        sb.AppendLine($"Findings: {result.Findings.Count} | Incidents: {allIncidents.Count}");
+        sb.AppendLine();
+
+        var byFile = result.Findings
+            .Where(f => !string.IsNullOrWhiteSpace(f.FilePath))
+            .GroupBy(f => f.FilePath!, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var grp in byFile.OrderByDescending(g => g.Max(f => f.Severity)))
+        {
+            var filePath = grp.Key;
+            var maxSev   = grp.Max(f => f.Severity);
+            correlations.TryGetValue(filePath, out var correlated);
+
+            sb.AppendLine($"  {filePath} [{maxSev}]");
+            foreach (var f in grp)
+                sb.AppendLine($"    - [{f.RuleId}] {f.Summary}");
+
+            if (correlated is { Count: > 0 })
+                sb.AppendLine($"    Incidents: {string.Join(", ", correlated.Select(i => $"{i.Source}:{i.Id} \"{i.Title}\""))}");
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/GauntletCI.Cli/Commands/TraceCommand.cs
+++ b/src/GauntletCI.Cli/Commands/TraceCommand.cs
@@ -135,7 +135,7 @@ public static class TraceCommand
                     var pdIncidents = await IncidentClient.FetchPagerDutyAsync(pdToken, sinceDto, now, ct);
                     allIncidents.AddRange(pdIncidents);
                     if (!isJson)
-                        AnsiConsole.MarkupLine($"[dim]  📟  Fetched {pdIncidents.Count} PagerDuty incident(s)[/]");
+                        AnsiConsole.MarkupLine($"[dim]  {(ascii ? "[PD]" : "📟")}  Fetched {pdIncidents.Count} PagerDuty incident(s)[/]");
                 }
                 else
                 {
@@ -144,10 +144,10 @@ public static class TraceCommand
 
                 if (!string.IsNullOrWhiteSpace(ogToken))
                 {
-                    var ogAlerts = await IncidentClient.FetchOpsgenieAsync(ogToken, ct);
+                    var ogAlerts = await IncidentClient.FetchOpsgenieAsync(ogToken, sinceDto, now, ct);
                     allIncidents.AddRange(ogAlerts);
                     if (!isJson)
-                        AnsiConsole.MarkupLine($"[dim]  📟  Fetched {ogAlerts.Count} Opsgenie alert(s)[/]");
+                        AnsiConsole.MarkupLine($"[dim]  {(ascii ? "[OG]" : "📟")}  Fetched {ogAlerts.Count} Opsgenie alert(s)[/]");
                 }
                 else
                 {
@@ -173,9 +173,9 @@ public static class TraceCommand
                 if (!string.IsNullOrWhiteSpace(postToPd) && !string.IsNullOrWhiteSpace(pdToken))
                 {
                     var textContent = BuildHeatmapText(baseRef, result, correlations, allIncidents);
-                    await IncidentClient.PostPagerDutyNoteAsync(pdToken, postToPd, $"GauntletCI Change Risk Heatmap:\n{textContent}", ct);
-                    if (!isJson)
-                        AnsiConsole.MarkupLine($"[dim]  ✅  Posted heatmap note to PagerDuty incident {Markup.Escape(postToPd)}[/]");
+                    var posted = await IncidentClient.PostPagerDutyNoteAsync(pdToken, postToPd, $"GauntletCI Change Risk Heatmap:\n{textContent}", ct);
+                    if (!isJson && posted)
+                        AnsiConsole.MarkupLine($"[dim]  {(ascii ? "[OK]" : "✅")}  Posted heatmap note to PagerDuty incident {Markup.Escape(postToPd)}[/]");
                 }
                 else if (!string.IsNullOrWhiteSpace(postToPd) && string.IsNullOrWhiteSpace(pdToken))
                 {
@@ -213,7 +213,7 @@ public static class TraceCommand
         AnsiConsole.MarkupLine("[cyan]  GauntletCI Change Risk Heatmap[/]");
         AnsiConsole.MarkupLine($"[cyan]{hr}[/]");
         AnsiConsole.MarkupLine($"  Base ref : {Markup.Escape(baseRef)}");
-        AnsiConsole.MarkupLine($"  Window   : {since:u} → {now:u}");
+        AnsiConsole.MarkupLine($"  Window   : {since:u} {(ascii ? "->" : "→")} {now:u}");
         AnsiConsole.MarkupLine($"  Findings : {result.Findings.Count}");
         AnsiConsole.MarkupLine($"  Incidents: {allIncidents.Count}");
         AnsiConsole.WriteLine();

--- a/src/GauntletCI.Cli/IncidentCorrelation/IncidentClient.cs
+++ b/src/GauntletCI.Cli/IncidentCorrelation/IncidentClient.cs
@@ -102,8 +102,8 @@ public static class IncidentClient
         }
     }
 
-    /// <summary>Posts a note to a PagerDuty incident.</summary>
-    public static async Task PostPagerDutyNoteAsync(
+    /// <summary>Posts a note to a PagerDuty incident. Returns true if the post succeeded.</summary>
+    public static async Task<bool> PostPagerDutyNoteAsync(
         string token,
         string incidentId,
         string content,
@@ -124,24 +124,34 @@ public static class IncidentClient
             {
                 var err = await response.Content.ReadAsStringAsync(ct);
                 Console.Error.WriteLine($"[GauntletCI] PagerDuty note post failed: {(int)response.StatusCode} — {err}");
+                return false;
             }
+
+            return true;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             Console.Error.WriteLine($"[GauntletCI] PagerDuty note error: {ex.Message}");
+            return false;
         }
     }
 
     // ── Opsgenie ─────────────────────────────────────────────────────────────
 
-    /// <summary>Fetches open Opsgenie alerts.</summary>
+    /// <summary>Fetches Opsgenie alerts within the given time window.</summary>
     public static async Task<List<IncidentSummary>> FetchOpsgenieAsync(
         string token,
+        DateTimeOffset since,
+        DateTimeOffset until,
         CancellationToken ct = default)
     {
         try
         {
-            const string url = "https://api.opsgenie.com/v2/alerts?query=status%3Aopen&limit=100";
+            // Opsgenie query language: createdAt > {epoch_ms} AND createdAt < {epoch_ms}
+            var sinceMs = since.ToUnixTimeMilliseconds();
+            var untilMs = until.ToUnixTimeMilliseconds();
+            var query = Uri.EscapeDataString($"createdAt > {sinceMs} AND createdAt < {untilMs}");
+            var url = $"https://api.opsgenie.com/v2/alerts?query={query}&limit=100&order=desc";
 
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Authorization = new AuthenticationHeaderValue("GenieKey", token);
@@ -276,6 +286,10 @@ public static class IncidentClient
             allIncidents = allIncidents.Select(i => new { i.Id, i.Title, i.Description, i.Source }).ToList(),
         };
 
-        return JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
+        return JsonSerializer.Serialize(obj, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        });
     }
 }

--- a/src/GauntletCI.Cli/IncidentCorrelation/IncidentClient.cs
+++ b/src/GauntletCI.Cli/IncidentCorrelation/IncidentClient.cs
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Cli.IncidentCorrelation;
+
+/// <summary>Represents a normalised incident or alert from PagerDuty or Opsgenie.</summary>
+public record IncidentSummary(string Id, string Title, string? Description, string Source);
+
+/// <summary>
+/// Fetches incidents from PagerDuty and Opsgenie, and correlates them with GauntletCI findings.
+/// All HTTP calls soft-fail — network errors log to stderr and return empty lists.
+/// </summary>
+public static class IncidentClient
+{
+    private static readonly HttpClient _http = new(new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(5) })
+    {
+        Timeout = TimeSpan.FromSeconds(15),
+    };
+
+    static IncidentClient()
+    {
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd("GauntletCI/2.0");
+    }
+
+    // ── Duration parsing ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Parses a duration string like "24h", "7d", "30m" and returns the point in time
+    /// that far before <paramref name="now"/>. Falls back to 24 hours on invalid input.
+    /// </summary>
+    internal static DateTimeOffset ParseSince(string since, DateTimeOffset now)
+    {
+        if (string.IsNullOrWhiteSpace(since) || since.Length < 2)
+            return now.AddHours(-24);
+
+        var unit = char.ToLowerInvariant(since[^1]);
+        if (!int.TryParse(since[..^1], out var value) || value <= 0)
+            return now.AddHours(-24);
+
+        return unit switch
+        {
+            'h' => now.AddHours(-value),
+            'd' => now.AddDays(-value),
+            'm' => now.AddMinutes(-value),
+            'w' => now.AddDays(-value * 7),
+            _   => now.AddHours(-24),
+        };
+    }
+
+    // ── PagerDuty ─────────────────────────────────────────────────────────────
+
+    /// <summary>Fetches PagerDuty incidents in the given time window.</summary>
+    public static async Task<List<IncidentSummary>> FetchPagerDutyAsync(
+        string token,
+        DateTimeOffset since,
+        DateTimeOffset until,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var sinceStr = since.UtcDateTime.ToString("o");
+            var untilStr = until.UtcDateTime.ToString("o");
+            var url = $"https://api.pagerduty.com/incidents?since={Uri.EscapeDataString(sinceStr)}&until={Uri.EscapeDataString(untilStr)}&statuses[]=triggered&statuses[]=acknowledged&statuses[]=resolved&limit=100";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Token", $"token={token}");
+            request.Headers.Accept.ParseAdd("application/vnd.pagerduty+json;version=2");
+
+            using var response = await _http.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.Error.WriteLine($"[GauntletCI] PagerDuty fetch failed: {(int)response.StatusCode} {response.ReasonPhrase}");
+                return [];
+            }
+
+            using var stream = await response.Content.ReadAsStreamAsync(ct);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+
+            var incidents = new List<IncidentSummary>();
+            if (doc.RootElement.TryGetProperty("incidents", out var arr))
+            {
+                foreach (var item in arr.EnumerateArray())
+                {
+                    var id    = item.TryGetProperty("id",    out var p) ? p.GetString() ?? "" : "";
+                    var title = item.TryGetProperty("title", out var t) ? t.GetString() ?? "" : "";
+                    string? desc = null;
+                    if (item.TryGetProperty("description", out var d))
+                        desc = d.GetString();
+                    incidents.Add(new IncidentSummary(id, title, desc, "PagerDuty"));
+                }
+            }
+
+            return incidents;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Console.Error.WriteLine($"[GauntletCI] PagerDuty fetch error: {ex.Message}");
+            return [];
+        }
+    }
+
+    /// <summary>Posts a note to a PagerDuty incident.</summary>
+    public static async Task PostPagerDutyNoteAsync(
+        string token,
+        string incidentId,
+        string content,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var url = $"https://api.pagerduty.com/incidents/{Uri.EscapeDataString(incidentId)}/notes";
+            var body = JsonSerializer.Serialize(new { note = new { content } });
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Token", $"token={token}");
+            request.Headers.Accept.ParseAdd("application/vnd.pagerduty+json;version=2");
+            request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+            using var response = await _http.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                var err = await response.Content.ReadAsStringAsync(ct);
+                Console.Error.WriteLine($"[GauntletCI] PagerDuty note post failed: {(int)response.StatusCode} — {err}");
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Console.Error.WriteLine($"[GauntletCI] PagerDuty note error: {ex.Message}");
+        }
+    }
+
+    // ── Opsgenie ─────────────────────────────────────────────────────────────
+
+    /// <summary>Fetches open Opsgenie alerts.</summary>
+    public static async Task<List<IncidentSummary>> FetchOpsgenieAsync(
+        string token,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            const string url = "https://api.opsgenie.com/v2/alerts?query=status%3Aopen&limit=100";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("GenieKey", token);
+
+            using var response = await _http.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.Error.WriteLine($"[GauntletCI] Opsgenie fetch failed: {(int)response.StatusCode} {response.ReasonPhrase}");
+                return [];
+            }
+
+            using var stream = await response.Content.ReadAsStreamAsync(ct);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+
+            var alerts = new List<IncidentSummary>();
+            if (doc.RootElement.TryGetProperty("data", out var arr))
+            {
+                foreach (var item in arr.EnumerateArray())
+                {
+                    var id      = item.TryGetProperty("id",      out var p) ? p.GetString() ?? "" : "";
+                    var message = item.TryGetProperty("message", out var m) ? m.GetString() ?? "" : "";
+                    string? desc = null;
+                    if (item.TryGetProperty("description", out var d))
+                        desc = d.GetString();
+                    alerts.Add(new IncidentSummary(id, message, desc, "Opsgenie"));
+                }
+            }
+
+            return alerts;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Console.Error.WriteLine($"[GauntletCI] Opsgenie fetch error: {ex.Message}");
+            return [];
+        }
+    }
+
+    // ── Correlation ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// For each finding that has a file path, checks whether any incident's title or
+    /// description contains the file name (simple substring match). Returns a map from
+    /// file path to matching incidents.
+    /// </summary>
+    internal static Dictionary<string, List<IncidentSummary>> CorrelateIncidents(
+        IReadOnlyList<Finding> findings,
+        IReadOnlyList<IncidentSummary> incidents)
+    {
+        var result = new Dictionary<string, List<IncidentSummary>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var finding in findings)
+        {
+            if (string.IsNullOrWhiteSpace(finding.FilePath))
+                continue;
+
+            var fileName = Path.GetFileName(finding.FilePath);
+            if (string.IsNullOrWhiteSpace(fileName))
+                continue;
+
+            if (result.ContainsKey(finding.FilePath))
+                continue;
+
+            var matches = incidents.Where(inc =>
+                Contains(inc.Title, fileName) ||
+                Contains(inc.Title, finding.FilePath) ||
+                Contains(inc.Description, fileName) ||
+                Contains(inc.Description, finding.FilePath))
+                .ToList();
+
+            result[finding.FilePath] = matches;
+        }
+
+        return result;
+    }
+
+    private static bool Contains(string? haystack, string needle) =>
+        haystack is not null &&
+        haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+
+    // ── Heatmap builder ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds the JSON representation of the change-risk heatmap.
+    /// </summary>
+    internal static string BuildHeatmapJson(
+        string baseRef,
+        DateTimeOffset since,
+        DateTimeOffset until,
+        IReadOnlyList<Finding> findings,
+        Dictionary<string, List<IncidentSummary>> correlations,
+        IReadOnlyList<IncidentSummary> allIncidents)
+    {
+        // Group findings by file path
+        var byFile = findings
+            .Where(f => !string.IsNullOrWhiteSpace(f.FilePath))
+            .GroupBy(f => f.FilePath!, StringComparer.OrdinalIgnoreCase)
+            .Select(g =>
+            {
+                var filePath   = g.Key;
+                var maxSev     = g.Max(f => f.Severity);
+                var correlated = correlations.TryGetValue(filePath, out var incs) ? incs : [];
+                return new
+                {
+                    file = filePath,
+                    maxSeverity = maxSev.ToString(),
+                    findings = g.Select(f => new
+                    {
+                        f.RuleId,
+                        f.RuleName,
+                        f.Summary,
+                        severity = f.Severity.ToString(),
+                        confidence = f.Confidence.ToString(),
+                        f.Line,
+                    }).ToList(),
+                    correlatedIncidents = correlated.Select(i => new
+                    {
+                        i.Id,
+                        i.Title,
+                        i.Description,
+                        i.Source,
+                    }).ToList(),
+                };
+            })
+            .ToList();
+
+        var obj = new
+        {
+            baseRef,
+            since = since.UtcDateTime.ToString("o"),
+            until = until.UtcDateTime.ToString("o"),
+            files = byFile,
+            allIncidents = allIncidents.Select(i => new { i.Id, i.Title, i.Description, i.Source }).ToList(),
+        };
+
+        return JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
+    }
+}

--- a/src/GauntletCI.Cli/Program.cs
+++ b/src/GauntletCI.Cli/Program.cs
@@ -33,6 +33,7 @@ rootCommand.AddCommand(McpCommand.Create());
 rootCommand.AddCommand(ModelCommand.Create());
 rootCommand.AddCommand(LlmCommand.Create());
 rootCommand.AddCommand(PostmortemCommand.Create());
+rootCommand.AddCommand(TraceCommand.Create());
 rootCommand.AddCommand(FeedbackCommand.Create());
 rootCommand.AddCommand(TelemetryCommand.Create());
 

--- a/src/GauntletCI.Tests/TraceCommandTests.cs
+++ b/src/GauntletCI.Tests/TraceCommandTests.cs
@@ -183,11 +183,11 @@ public class TraceCommandTests
 
         var findings = firstFile.GetProperty("findings");
         Assert.Equal(1, findings.GetArrayLength());
-        Assert.Equal("GCI0010", findings[0].GetProperty("RuleId").GetString());
+        Assert.Equal("GCI0010", findings[0].GetProperty("ruleId").GetString());
 
         var correlatedInc = firstFile.GetProperty("correlatedIncidents");
         Assert.Equal(1, correlatedInc.GetArrayLength());
-        Assert.Equal("INC010", correlatedInc[0].GetProperty("Id").GetString());
+        Assert.Equal("INC010", correlatedInc[0].GetProperty("id").GetString());
 
         var allInc = root.GetProperty("allIncidents");
         Assert.Equal(1, allInc.GetArrayLength());

--- a/src/GauntletCI.Tests/TraceCommandTests.cs
+++ b/src/GauntletCI.Tests/TraceCommandTests.cs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.Json;
+using GauntletCI.Cli.IncidentCorrelation;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Tests;
+
+public class TraceCommandTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static Finding MakeFinding(
+        string ruleId    = "GCI0001",
+        string summary   = "A test finding",
+        string? filePath = "src/Auth.cs",
+        RuleSeverity severity = RuleSeverity.Warn) => new()
+    {
+        RuleId          = ruleId,
+        RuleName        = "Test Rule",
+        Summary         = summary,
+        Evidence        = "Line 10: some code",
+        WhyItMatters    = "risk reason",
+        SuggestedAction = "fix it",
+        Confidence      = Confidence.High,
+        Severity        = severity,
+        FilePath        = filePath,
+        Line            = 10,
+    };
+
+    private static IncidentSummary MakeIncident(
+        string id,
+        string title,
+        string? description = null,
+        string source = "PagerDuty") =>
+        new(id, title, description, source);
+
+    // ── ParseSince ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseSince_24h_Returns24HoursAgo()
+    {
+        var now    = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var result = IncidentClient.ParseSince("24h", now);
+
+        Assert.Equal(now.AddHours(-24), result);
+    }
+
+    [Fact]
+    public void ParseSince_7d_Returns7DaysAgo()
+    {
+        var now    = new DateTimeOffset(2024, 6, 10, 0, 0, 0, TimeSpan.Zero);
+        var result = IncidentClient.ParseSince("7d", now);
+
+        Assert.Equal(now.AddDays(-7), result);
+    }
+
+    [Fact]
+    public void ParseSince_30m_Returns30MinutesAgo()
+    {
+        var now    = new DateTimeOffset(2024, 1, 1, 6, 0, 0, TimeSpan.Zero);
+        var result = IncidentClient.ParseSince("30m", now);
+
+        Assert.Equal(now.AddMinutes(-30), result);
+    }
+
+    [Fact]
+    public void ParseSince_Invalid_FallsBackTo24h()
+    {
+        var now = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+        Assert.Equal(now.AddHours(-24), IncidentClient.ParseSince("xyz", now));
+        Assert.Equal(now.AddHours(-24), IncidentClient.ParseSince("",    now));
+        Assert.Equal(now.AddHours(-24), IncidentClient.ParseSince("-5h", now));
+        Assert.Equal(now.AddHours(-24), IncidentClient.ParseSince("h",   now));
+    }
+
+    [Fact]
+    public void ParseSince_1w_Returns7DaysAgo()
+    {
+        var now    = new DateTimeOffset(2024, 3, 15, 0, 0, 0, TimeSpan.Zero);
+        var result = IncidentClient.ParseSince("1w", now);
+
+        Assert.Equal(now.AddDays(-7), result);
+    }
+
+    // ── CorrelateIncidents ────────────────────────────────────────────────────
+
+    [Fact]
+    public void CorrelateIncidents_FileMatchesTitle_ReturnsCorrelated()
+    {
+        var finding  = MakeFinding(filePath: "src/Auth.cs");
+        var incident = MakeIncident("INC001", "Outage in Auth.cs module — users cannot log in");
+
+        var result = IncidentClient.CorrelateIncidents([finding], [incident]);
+
+        Assert.True(result.ContainsKey("src/Auth.cs"));
+        var correlated = result["src/Auth.cs"];
+        Assert.Single(correlated);
+        Assert.Equal("INC001", correlated[0].Id);
+    }
+
+    [Fact]
+    public void CorrelateIncidents_FileMatchesDescription_ReturnsCorrelated()
+    {
+        var finding  = MakeFinding(filePath: "src/PaymentService.cs");
+        var incident = MakeIncident("INC002", "Payment failures", "Errors in PaymentService.cs at line 42");
+
+        var result = IncidentClient.CorrelateIncidents([finding], [incident]);
+
+        Assert.True(result.ContainsKey("src/PaymentService.cs"));
+        Assert.Single(result["src/PaymentService.cs"]);
+    }
+
+    [Fact]
+    public void CorrelateIncidents_NoMatch_ReturnsEmpty()
+    {
+        var finding  = MakeFinding(filePath: "src/Auth.cs");
+        var incident = MakeIncident("INC003", "Database connection pool exhausted");
+
+        var result = IncidentClient.CorrelateIncidents([finding], [incident]);
+
+        Assert.True(result.ContainsKey("src/Auth.cs"));
+        Assert.Empty(result["src/Auth.cs"]);
+    }
+
+    [Fact]
+    public void CorrelateIncidents_NoFilePath_IsSkipped()
+    {
+        var finding = MakeFinding(filePath: null);
+        var incident = MakeIncident("INC004", "Some incident");
+
+        var result = IncidentClient.CorrelateIncidents([finding], [incident]);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void CorrelateIncidents_MultipleFindings_GroupsByFile()
+    {
+        var finding1 = MakeFinding(ruleId: "GCI0001", filePath: "src/Auth.cs");
+        var finding2 = MakeFinding(ruleId: "GCI0002", filePath: "src/Auth.cs");
+        var finding3 = MakeFinding(ruleId: "GCI0003", filePath: "src/Other.cs");
+        var incident = MakeIncident("INC005", "Auth.cs regression");
+
+        var result = IncidentClient.CorrelateIncidents([finding1, finding2, finding3], [incident]);
+
+        Assert.Equal(2, result.Count);
+        Assert.Single(result["src/Auth.cs"]);
+        Assert.Empty(result["src/Other.cs"]);
+    }
+
+    // ── BuildHeatmapJson ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildHeatmapJson_WithFindings_ContainsExpectedFields()
+    {
+        var finding  = MakeFinding(ruleId: "GCI0010", filePath: "src/Auth.cs", severity: RuleSeverity.Block);
+        var incident = MakeIncident("INC010", "Auth.cs is broken");
+        var correlations = IncidentClient.CorrelateIncidents([finding], [incident]);
+
+        var now   = DateTimeOffset.UtcNow;
+        var since = now.AddHours(-24);
+
+        var json = IncidentClient.BuildHeatmapJson(
+            "v1.2.3", since, now,
+            [finding],
+            correlations,
+            [incident]);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("v1.2.3", root.GetProperty("baseRef").GetString());
+        Assert.True(root.TryGetProperty("since", out _));
+        Assert.True(root.TryGetProperty("until", out _));
+
+        var files = root.GetProperty("files");
+        Assert.Equal(1, files.GetArrayLength());
+
+        var firstFile = files[0];
+        Assert.Equal("src/Auth.cs", firstFile.GetProperty("file").GetString());
+        Assert.Equal("Block", firstFile.GetProperty("maxSeverity").GetString());
+
+        var findings = firstFile.GetProperty("findings");
+        Assert.Equal(1, findings.GetArrayLength());
+        Assert.Equal("GCI0010", findings[0].GetProperty("RuleId").GetString());
+
+        var correlatedInc = firstFile.GetProperty("correlatedIncidents");
+        Assert.Equal(1, correlatedInc.GetArrayLength());
+        Assert.Equal("INC010", correlatedInc[0].GetProperty("Id").GetString());
+
+        var allInc = root.GetProperty("allIncidents");
+        Assert.Equal(1, allInc.GetArrayLength());
+    }
+
+    [Fact]
+    public void BuildHeatmapJson_NoIncidents_EmptyArrays()
+    {
+        var finding = MakeFinding(filePath: "src/Foo.cs");
+        var correlations = IncidentClient.CorrelateIncidents([finding], []);
+
+        var now   = DateTimeOffset.UtcNow;
+        var since = now.AddDays(-7);
+
+        var json = IncidentClient.BuildHeatmapJson(
+            "abc1234", since, now,
+            [finding],
+            correlations,
+            []);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal(0, doc.RootElement.GetProperty("allIncidents").GetArrayLength());
+        Assert.Equal(0, doc.RootElement.GetProperty("files")[0]
+            .GetProperty("correlatedIncidents").GetArrayLength());
+    }
+}


### PR DESCRIPTION
Implements gauntletci trace: post-mortem incident correlation. Diffs since a deploy tag, runs rule analysis, fetches PagerDuty/Opsgenie incidents, and outputs a Change Risk Heatmap.

New files: TraceCommand.cs, IncidentClient.cs (HttpClient, 15s timeout, UserAgent GauntletCI/2.0), 12 unit tests (all passing).