### PR TITLE
[CLI] Add --with-ticket-context: Jira / Linear / GitHub Issues integration

### DIFF
--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -8,6 +8,7 @@ using GauntletCI.Cli.LlmDaemon;
 using GauntletCI.Cli.Output;
 using GauntletCI.Cli.Presentation;
 using GauntletCI.Cli.Telemetry;
+using GauntletCI.Cli.TicketProviders;
 using GauntletCI.Core.Configuration;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
@@ -56,6 +57,8 @@ public static class AnalyzeCommand
         var notifyTeamsOption = new Option<string?>("--notify-teams", "Teams Incoming Webhook URL (or set GAUNTLETCI_TEAMS_WEBHOOK env var). Posts Block findings to Teams.");
         var withCoverageFlag = new Option<bool>("--with-coverage", "Correlate findings with Codecov coverage data (requires CODECOV_TOKEN env var)");
         var githubChecksFlag = new Option<bool>("--github-checks", "Post findings as a GitHub Checks API check run with annotations (requires checks: write permission)");
+        var withTicketCtxFlag = new Option<bool>("--with-ticket-context",
+            "Fetch ticket info from Jira/Linear/GitHub Issues and attach to findings (reads branch name and JIRA_*, LINEAR_API_KEY, or GITHUB_TOKEN)");
 
         var cmd = new Command("analyze", "Analyse a git diff for pre-commit risks")
         {
@@ -82,6 +85,7 @@ public static class AnalyzeCommand
             notifyTeamsOption,
             withCoverageFlag,
             githubChecksFlag,
+            withTicketCtxFlag,
         };
 
         cmd.SetHandler(async (System.CommandLine.Invocation.InvocationContext ctx) =>
@@ -107,6 +111,7 @@ public static class AnalyzeCommand
             var prCommentSuggest = ctx.ParseResult.GetValueForOption(prCommentSuggestFlag);
             var withCoverage  = ctx.ParseResult.GetValueForOption(withCoverageFlag);
             var githubChecks  = ctx.ParseResult.GetValueForOption(githubChecksFlag);
+            var withTicketCtx = ctx.ParseResult.GetValueForOption(withTicketCtxFlag);
             var ct = ctx.GetCancellationToken();
 
             // Enforce single diff source
@@ -178,6 +183,30 @@ public static class AnalyzeCommand
                     }
                 }
 
+                // Ticket context enrichment
+                if (withTicketCtx && result.Findings.Count > 0)
+                {
+                    string? branchName = null;
+                    try
+                    {
+                        var gitProc = new System.Diagnostics.Process
+                        {
+                            StartInfo = new System.Diagnostics.ProcessStartInfo("git", "rev-parse --abbrev-ref HEAD")
+                            {
+                                WorkingDirectory = repo.FullName,
+                                RedirectStandardOutput = true,
+                                UseShellExecute = false,
+                            }
+                        };
+                        gitProc.Start();
+                        branchName = (await gitProc.StandardOutput.ReadToEndAsync(ct)).Trim();
+                        await gitProc.WaitForExitAsync(ct);
+                    }
+                    catch { /* soft fail */ }
+
+                    await TicketResolver.AnnotateFindingsAsync(branchName, result.Findings, ct);
+                }
+
                 using ILlmEngine llm = await LlmEngineSelector.ResolveAsync(config, withLlm && !noLlm);
 
                 var isJsonOutput  = (output ?? "text").Equals("json", StringComparison.OrdinalIgnoreCase);
@@ -195,6 +224,13 @@ public static class AnalyzeCommand
                         {
                             setStatus($"Annotating [{finding.RuleId}]...");
                             finding.LlmExplanation = await llm.EnrichFindingAsync(finding);
+                            // When ticket context is attached, also adjudicate intent alignment
+                            if (withTicketCtx && finding.TicketContext is not null)
+                            {
+                                var ticketNote = await EnrichWithTicketContextAsync(llm, finding, ct);
+                                if (!string.IsNullOrWhiteSpace(ticketNote))
+                                    finding.LlmExplanation = $"{finding.LlmExplanation} | Ticket: {ticketNote}";
+                            }
                         }
                     }
 
@@ -367,4 +403,23 @@ public static class AnalyzeCommand
             "info"  => GauntletCI.Core.Model.RuleSeverity.Info,
             _       => GauntletCI.Core.Model.RuleSeverity.Warn,
         };
+
+    private static async Task<string?> EnrichWithTicketContextAsync(ILlmEngine llm, Finding finding, CancellationToken ct)
+    {
+        var ticket = finding.TicketContext!;
+        var prompt =
+            $"Ticket {ticket.Id}: \"{ticket.Title}\". {ticket.Description}\n\n" +
+            $"Finding: {finding.Summary}. {finding.WhyItMatters}\n\n" +
+            $"Does this change align with the stated ticket intent? " +
+            $"If yes, state 'Change aligns with ticket intent: {ticket.Id}' and suggest a downgrade rationale. " +
+            $"If no, explain briefly. Maximum 30 words.";
+        try
+        {
+            return await llm.CompleteAsync(prompt, ct);
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -189,7 +189,7 @@ public static class AnalyzeCommand
                     string? branchName = null;
                     try
                     {
-                        var gitProc = new System.Diagnostics.Process
+                        using var gitProc = new System.Diagnostics.Process
                         {
                             StartInfo = new System.Diagnostics.ProcessStartInfo("git", "rev-parse --abbrev-ref HEAD")
                             {

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -202,7 +202,7 @@ public static class AnalyzeCommand
                         branchName = (await gitProc.StandardOutput.ReadToEndAsync(ct)).Trim();
                         await gitProc.WaitForExitAsync(ct);
                     }
-                    catch { /* soft fail */ }
+                    catch (Exception ex) { Console.Error.WriteLine($"[ticket] Branch detection failed: {ex.Message}"); }
 
                     await TicketResolver.AnnotateFindingsAsync(branchName, result.Findings, ct);
                 }

--- a/src/GauntletCI.Cli/Output/ConsoleReporter.cs
+++ b/src/GauntletCI.Cli/Output/ConsoleReporter.cs
@@ -169,7 +169,7 @@ public static class ConsoleReporter
         if (finding.TicketContext is { } ticket)
         {
             var ticketRef = ticket.Url is not null ? $"{ticket.Id} ({ticket.Url})" : ticket.Id;
-            AnsiConsole.MarkupLine($"[cyan]  Ticket   : [{ticket.Provider}] {Markup.Escape(ticketRef)} — {Markup.Escape(ticket.Title)}[/]");
+            AnsiConsole.MarkupLine($"[cyan]  Ticket   : [[{Markup.Escape(ticket.Provider)}]] {Markup.Escape(ticketRef)} — {Markup.Escape(ticket.Title)}[/]");
             if (!string.IsNullOrWhiteSpace(ticket.Description))
                 AnsiConsole.MarkupLine($"[grey]             {Markup.Escape(ticket.Description)}[/]");
         }

--- a/src/GauntletCI.Cli/Output/ConsoleReporter.cs
+++ b/src/GauntletCI.Cli/Output/ConsoleReporter.cs
@@ -166,6 +166,14 @@ public static class ConsoleReporter
             AnsiConsole.MarkupLine($"[grey]             Score {expert.Score:F2} · {Markup.Escape(expert.Source)}[/]");
         }
 
+        if (finding.TicketContext is { } ticket)
+        {
+            var ticketRef = ticket.Url is not null ? $"{ticket.Id} ({ticket.Url})" : ticket.Id;
+            AnsiConsole.MarkupLine($"[cyan]  Ticket   : [{ticket.Provider}] {Markup.Escape(ticketRef)} — {Markup.Escape(ticket.Title)}[/]");
+            if (!string.IsNullOrWhiteSpace(ticket.Description))
+                AnsiConsole.MarkupLine($"[grey]             {Markup.Escape(ticket.Description)}[/]");
+        }
+
         AnsiConsole.WriteLine();
     }
 

--- a/src/GauntletCI.Cli/Output/GitHubPrReviewWriter.cs
+++ b/src/GauntletCI.Cli/Output/GitHubPrReviewWriter.cs
@@ -136,6 +136,17 @@ public static class GitHubPrReviewWriter
             sb.AppendLine($"📊 **Coverage:** {finding.CoverageNote}");
         }
 
+        if (finding.TicketContext is not null)
+        {
+            var t = finding.TicketContext;
+            var link = t.Url is not null ? $"[{t.Id}]({t.Url})" : t.Id;
+            sb.AppendLine();
+            sb.AppendLine($"🎫 **Ticket ({t.Provider}):** {link} — {t.Title}");
+            if (!string.IsNullOrWhiteSpace(t.Description))
+                sb.AppendLine($"> {t.Description}");
+            sb.AppendLine();
+        }
+
         sb.AppendLine();
         sb.Append($"<sub>Confidence: {finding.Confidence} | Severity: {finding.Severity}</sub>");
 

--- a/src/GauntletCI.Cli/TicketProviders/GitHubIssueProvider.cs
+++ b/src/GauntletCI.Cli/TicketProviders/GitHubIssueProvider.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net.Http.Headers;
+using System.Text.Json;
+using GauntletCI.Core.Model;
+namespace GauntletCI.Cli.TicketProviders;
+
+public sealed class GitHubIssueProvider : ITicketProvider
+{
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(15) };
+    static GitHubIssueProvider() => Http.DefaultRequestHeaders.UserAgent.ParseAdd("GauntletCI/2.0");
+
+    public string ProviderName => "GitHub";
+    public bool IsAvailable =>
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_TOKEN")) &&
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_REPOSITORY"));
+
+    public async Task<TicketInfo?> FetchAsync(string issueKey, CancellationToken ct = default)
+    {
+        var token      = Environment.GetEnvironmentVariable("GITHUB_TOKEN")!;
+        var repository = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY")!; // owner/repo
+        // issueKey may be "#42" or "42"
+        var number = issueKey.TrimStart('#');
+
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"https://api.github.com/repos/{repository}/issues/{number}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Accept.ParseAdd("application/vnd.github+json");
+
+        var resp = await Http.SendAsync(req, ct);
+        if (!resp.IsSuccessStatusCode) return null;
+
+        var json = await resp.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        var title = doc.RootElement.TryGetProperty("title", out var t) ? t.GetString() : null;
+        var body  = doc.RootElement.TryGetProperty("body",  out var b) ? b.GetString() : null;
+        var url   = doc.RootElement.TryGetProperty("html_url", out var u) ? u.GetString() : null;
+
+        return new TicketInfo
+        {
+            Id          = $"#{number}",
+            Title       = title ?? $"#{number}",
+            Description = body?.Length > 500 ? body[..500] : body,
+            Url         = url,
+            Provider    = "GitHub",
+        };
+    }
+}

--- a/src/GauntletCI.Cli/TicketProviders/GitHubIssueProvider.cs
+++ b/src/GauntletCI.Cli/TicketProviders/GitHubIssueProvider.cs
@@ -21,12 +21,12 @@ public sealed class GitHubIssueProvider : ITicketProvider
         // issueKey may be "#42" or "42"
         var number = issueKey.TrimStart('#');
 
-        var req = new HttpRequestMessage(HttpMethod.Get,
+        using var req = new HttpRequestMessage(HttpMethod.Get,
             $"https://api.github.com/repos/{repository}/issues/{number}");
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         req.Headers.Accept.ParseAdd("application/vnd.github+json");
 
-        var resp = await Http.SendAsync(req, ct);
+        using var resp = await Http.SendAsync(req, ct);
         if (!resp.IsSuccessStatusCode) return null;
 
         var json = await resp.Content.ReadAsStringAsync(ct);

--- a/src/GauntletCI.Cli/TicketProviders/ITicketProvider.cs
+++ b/src/GauntletCI.Cli/TicketProviders/ITicketProvider.cs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Model;
+namespace GauntletCI.Cli.TicketProviders;
+
+public interface ITicketProvider
+{
+    string ProviderName { get; }
+    /// <summary>Returns true if required env vars/tokens are present.</summary>
+    bool IsAvailable { get; }
+    /// <summary>Fetches ticket info by key; returns null if not found or on error.</summary>
+    Task<TicketInfo?> FetchAsync(string issueKey, CancellationToken ct = default);
+}

--- a/src/GauntletCI.Cli/TicketProviders/JiraTicketProvider.cs
+++ b/src/GauntletCI.Cli/TicketProviders/JiraTicketProvider.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using GauntletCI.Core.Model;
+namespace GauntletCI.Cli.TicketProviders;
+
+public sealed class JiraTicketProvider : ITicketProvider
+{
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(15) };
+    static JiraTicketProvider() => Http.DefaultRequestHeaders.UserAgent.ParseAdd("GauntletCI/2.0");
+
+    public string ProviderName => "Jira";
+
+    public bool IsAvailable =>
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JIRA_BASE_URL")) &&
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JIRA_API_TOKEN")) &&
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JIRA_USER_EMAIL"));
+
+    public async Task<TicketInfo?> FetchAsync(string issueKey, CancellationToken ct = default)
+    {
+        var baseUrl = Environment.GetEnvironmentVariable("JIRA_BASE_URL")!.TrimEnd('/');
+        var token   = Environment.GetEnvironmentVariable("JIRA_API_TOKEN")!;
+        var email   = Environment.GetEnvironmentVariable("JIRA_USER_EMAIL")!;
+        var creds   = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{email}:{token}"));
+
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"{baseUrl}/rest/api/3/issue/{issueKey}?fields=summary,description");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Basic", creds);
+        req.Headers.Accept.ParseAdd("application/json");
+
+        var resp = await Http.SendAsync(req, ct);
+        if (!resp.IsSuccessStatusCode) return null;
+
+        var json = await resp.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        var fields = doc.RootElement.GetProperty("fields");
+        var summary = fields.TryGetProperty("summary", out var s) ? s.GetString() : null;
+        var desc    = ExtractDescription(fields);
+
+        return new TicketInfo
+        {
+            Id          = issueKey,
+            Title       = summary ?? issueKey,
+            Description = desc,
+            Url         = $"{baseUrl}/browse/{issueKey}",
+            Provider    = "Jira",
+        };
+    }
+
+    private static string? ExtractDescription(JsonElement fields)
+    {
+        if (!fields.TryGetProperty("description", out var d) || d.ValueKind == JsonValueKind.Null)
+            return null;
+        // Jira v3 uses Atlassian Document Format; extract plain text from paragraphs
+        if (d.ValueKind == JsonValueKind.Object &&
+            d.TryGetProperty("content", out var content))
+        {
+            var sb = new StringBuilder();
+            foreach (var block in content.EnumerateArray())
+            {
+                if (!block.TryGetProperty("content", out var inner)) continue;
+                foreach (var node in inner.EnumerateArray())
+                {
+                    if (node.TryGetProperty("text", out var t)) sb.Append(t.GetString()).Append(' ');
+                }
+            }
+            var text = sb.ToString().Trim();
+            return text.Length > 500 ? text[..500] : text;
+        }
+        // Fallback: treat as plain string
+        var raw = d.GetString();
+        return raw?.Length > 500 ? raw[..500] : raw;
+    }
+}

--- a/src/GauntletCI.Cli/TicketProviders/JiraTicketProvider.cs
+++ b/src/GauntletCI.Cli/TicketProviders/JiraTicketProvider.cs
@@ -24,12 +24,12 @@ public sealed class JiraTicketProvider : ITicketProvider
         var email   = Environment.GetEnvironmentVariable("JIRA_USER_EMAIL")!;
         var creds   = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{email}:{token}"));
 
-        var req = new HttpRequestMessage(HttpMethod.Get,
+        using var req = new HttpRequestMessage(HttpMethod.Get,
             $"{baseUrl}/rest/api/3/issue/{issueKey}?fields=summary,description");
         req.Headers.Authorization = new AuthenticationHeaderValue("Basic", creds);
         req.Headers.Accept.ParseAdd("application/json");
 
-        var resp = await Http.SendAsync(req, ct);
+        using var resp = await Http.SendAsync(req, ct);
         if (!resp.IsSuccessStatusCode) return null;
 
         var json = await resp.Content.ReadAsStringAsync(ct);
@@ -54,12 +54,14 @@ public sealed class JiraTicketProvider : ITicketProvider
             return null;
         // Jira v3 uses Atlassian Document Format; extract plain text from paragraphs
         if (d.ValueKind == JsonValueKind.Object &&
-            d.TryGetProperty("content", out var content))
+            d.TryGetProperty("content", out var content) &&
+            content.ValueKind == JsonValueKind.Array)
         {
             var sb = new StringBuilder();
             foreach (var block in content.EnumerateArray())
             {
-                if (!block.TryGetProperty("content", out var inner)) continue;
+                if (!block.TryGetProperty("content", out var inner) ||
+                    inner.ValueKind != JsonValueKind.Array) continue;
                 foreach (var node in inner.EnumerateArray())
                 {
                     if (node.TryGetProperty("text", out var t)) sb.Append(t.GetString()).Append(' ');

--- a/src/GauntletCI.Cli/TicketProviders/LinearTicketProvider.cs
+++ b/src/GauntletCI.Cli/TicketProviders/LinearTicketProvider.cs
@@ -19,13 +19,13 @@ public sealed class LinearTicketProvider : ITicketProvider
         var query  = new { query = "query($id:String!){issue(id:$id){id title description url}}", variables = new { id = issueKey } };
         var body   = JsonSerializer.Serialize(query);
 
-        var req = new HttpRequestMessage(HttpMethod.Post, "https://api.linear.app/graphql")
+        using var req = new HttpRequestMessage(HttpMethod.Post, "https://api.linear.app/graphql")
         {
             Content = new StringContent(body, Encoding.UTF8, "application/json")
         };
         req.Headers.Authorization = new AuthenticationHeaderValue(apiKey);
 
-        var resp = await Http.SendAsync(req, ct);
+        using var resp = await Http.SendAsync(req, ct);
         if (!resp.IsSuccessStatusCode) return null;
 
         var json = await resp.Content.ReadAsStringAsync(ct);

--- a/src/GauntletCI.Cli/TicketProviders/LinearTicketProvider.cs
+++ b/src/GauntletCI.Cli/TicketProviders/LinearTicketProvider.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using GauntletCI.Core.Model;
+namespace GauntletCI.Cli.TicketProviders;
+
+public sealed class LinearTicketProvider : ITicketProvider
+{
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(15) };
+    static LinearTicketProvider() => Http.DefaultRequestHeaders.UserAgent.ParseAdd("GauntletCI/2.0");
+
+    public string ProviderName => "Linear";
+    public bool IsAvailable => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LINEAR_API_KEY"));
+
+    public async Task<TicketInfo?> FetchAsync(string issueKey, CancellationToken ct = default)
+    {
+        var apiKey = Environment.GetEnvironmentVariable("LINEAR_API_KEY")!;
+        var query  = new { query = "query($id:String!){issue(id:$id){id title description url}}", variables = new { id = issueKey } };
+        var body   = JsonSerializer.Serialize(query);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "https://api.linear.app/graphql")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue(apiKey);
+
+        var resp = await Http.SendAsync(req, ct);
+        if (!resp.IsSuccessStatusCode) return null;
+
+        var json = await resp.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("data", out var data)) return null;
+        if (!data.TryGetProperty("issue", out var issue) || issue.ValueKind == JsonValueKind.Null) return null;
+
+        var title = issue.TryGetProperty("title", out var t) ? t.GetString() : null;
+        var desc  = issue.TryGetProperty("description", out var d) ? d.GetString() : null;
+        var url   = issue.TryGetProperty("url", out var u) ? u.GetString() : null;
+
+        return new TicketInfo
+        {
+            Id          = issueKey,
+            Title       = title ?? issueKey,
+            Description = desc?.Length > 500 ? desc[..500] : desc,
+            Url         = url,
+            Provider    = "Linear",
+        };
+    }
+}

--- a/src/GauntletCI.Cli/TicketProviders/TicketResolver.cs
+++ b/src/GauntletCI.Cli/TicketProviders/TicketResolver.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.RegularExpressions;
+using GauntletCI.Core.Model;
+namespace GauntletCI.Cli.TicketProviders;
+
+public static class TicketResolver
+{
+    // Jira: e.g. PROJ-1234, COMP-456 (uppercase letters + digits, dash, digits)
+    private static readonly Regex JiraKey = new(@"\b([A-Z][A-Z0-9]+-\d+)\b", RegexOptions.Compiled);
+    // Linear: e.g. eng-123, team-456 (lowercase letters, dash, digits)
+    private static readonly Regex LinearKey = new(@"\b([a-z][a-z0-9]+-\d+)\b", RegexOptions.Compiled);
+    // GitHub: #42 or GH-42
+    private static readonly Regex GitHubKey = new(@"(?:#|GH-)(\d+)\b", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Extracts a single issue key from a branch name or PR body text.
+    /// Priority: Jira > Linear > GitHub. Returns null if none found.
+    /// </summary>
+    public static (string? Key, string? Provider) DetectIssueKey(string? branchName, string? prBody)
+    {
+        var text = $"{branchName} {prBody}".Trim();
+        if (string.IsNullOrWhiteSpace(text)) return (null, null);
+
+        var jira = JiraKey.Match(text);
+        if (jira.Success) return (jira.Groups[1].Value, "Jira");
+
+        var linear = LinearKey.Match(text);
+        if (linear.Success) return (linear.Groups[1].Value, "Linear");
+
+        var gh = GitHubKey.Match(text);
+        if (gh.Success) return (gh.Groups[1].Value, "GitHub");
+
+        return (null, null);
+    }
+
+    /// <summary>
+    /// Resolves an available provider for the detected provider name.
+    /// Returns null if no provider is available.
+    /// </summary>
+    public static ITicketProvider? ResolveProvider(string? providerName)
+    {
+        return providerName switch
+        {
+            "Jira"   => new JiraTicketProvider(),
+            "Linear" => new LinearTicketProvider(),
+            "GitHub" => new GitHubIssueProvider(),
+            _        => null
+        };
+    }
+
+    /// <summary>
+    /// Detects issue key, fetches ticket, and attaches TicketContext to all findings.
+    /// Soft-fails: logs to stderr on error, never throws.
+    /// </summary>
+    public static async Task AnnotateFindingsAsync(
+        string? branchName,
+        IReadOnlyList<Finding> findings,
+        CancellationToken ct = default)
+    {
+        var prBody = Environment.GetEnvironmentVariable("GITHUB_PR_BODY");
+        var (key, providerName) = DetectIssueKey(branchName, prBody);
+        if (key is null) return;
+
+        var provider = ResolveProvider(providerName);
+        if (provider is null || !provider.IsAvailable)
+        {
+            Console.Error.WriteLine($"[ticket] Detected {providerName} key {key} but no credentials found for {providerName}.");
+            return;
+        }
+
+        try
+        {
+            var ticket = await provider.FetchAsync(key, ct);
+            if (ticket is null)
+            {
+                Console.Error.WriteLine($"[ticket] Could not fetch {key} from {providerName}.");
+                return;
+            }
+            foreach (var finding in findings)
+                finding.TicketContext = ticket;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[ticket] Error fetching {key}: {ex.Message}");
+        }
+    }
+}

--- a/src/GauntletCI.Cli/TicketProviders/TicketResolver.cs
+++ b/src/GauntletCI.Cli/TicketProviders/TicketResolver.cs
@@ -6,10 +6,11 @@ namespace GauntletCI.Cli.TicketProviders;
 public static class TicketResolver
 {
     // Jira: e.g. PROJ-1234, COMP-456 (uppercase letters + digits, dash, digits)
+    // Note: GH-42 matches this pattern (treating "GH" as a Jira project key) — Jira takes priority.
     private static readonly Regex JiraKey = new(@"\b([A-Z][A-Z0-9]+-\d+)\b", RegexOptions.Compiled);
     // Linear: e.g. eng-123, team-456 (lowercase letters, dash, digits)
     private static readonly Regex LinearKey = new(@"\b([a-z][a-z0-9]+-\d+)\b", RegexOptions.Compiled);
-    // GitHub: #42 or GH-42
+    // GitHub: #42 (GH-42 is handled by Jira regex above)
     private static readonly Regex GitHubKey = new(@"(?:#|GH-)(\d+)\b", RegexOptions.Compiled);
 
     /// <summary>

--- a/src/GauntletCI.Core/Model/Finding.cs
+++ b/src/GauntletCI.Core/Model/Finding.cs
@@ -36,4 +36,6 @@ public class Finding
     public string? CodeSnippet { get; set; }
     /// <summary>Optional coverage annotation added by the Codecov correlation step.</summary>
     public string? CoverageNote { get; set; }
+    /// <summary>Optional ticket context fetched from Jira, Linear, or GitHub Issues.</summary>
+    public TicketInfo? TicketContext { get; set; }
 }

--- a/src/GauntletCI.Core/Model/TicketInfo.cs
+++ b/src/GauntletCI.Core/Model/TicketInfo.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Core.Model;
+
+/// <summary>Ticket metadata fetched from an issue tracker and attached to a finding.</summary>
+public sealed class TicketInfo
+{
+    /// <summary>The ticket/issue identifier, e.g. PROJ-1234, eng-123, #42.</summary>
+    public required string Id { get; init; }
+    /// <summary>The ticket title or summary.</summary>
+    public required string Title { get; init; }
+    /// <summary>The ticket description or body (truncated to 500 chars).</summary>
+    public string? Description { get; init; }
+    /// <summary>URL to the ticket in the provider's web UI.</summary>
+    public string? Url { get; init; }
+    /// <summary>The provider that served this ticket: Jira, Linear, or GitHub.</summary>
+    public required string Provider { get; init; }
+}

--- a/src/GauntletCI.Tests/TicketProviderTests.cs
+++ b/src/GauntletCI.Tests/TicketProviderTests.cs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Cli.TicketProviders;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Tests;
+
+public class TicketResolverTests
+{
+    [Theory]
+    [InlineData("feature/PROJ-1234", null, "PROJ-1234", "Jira")]
+    [InlineData("feature/eng-123-my-task", null, "eng-123", "Linear")]
+    [InlineData("fix/#42-crash", null, "42", "GitHub")]
+    [InlineData("feature/COMP-99", "Related to COMP-99", "COMP-99", "Jira")]
+    public void DetectIssueKey_DetectsCorrectKey(string branch, string? prBody, string expectedKey, string expectedProvider)
+    {
+        var (key, provider) = TicketResolver.DetectIssueKey(branch, prBody);
+        Assert.Equal(expectedKey, key);
+        Assert.Equal(expectedProvider, provider);
+    }
+
+    [Fact]
+    public void DetectIssueKey_NoBranchNoPrBody_ReturnsNull()
+    {
+        var (key, provider) = TicketResolver.DetectIssueKey("main", null);
+        Assert.Null(key);
+        Assert.Null(provider);
+    }
+
+    [Fact]
+    public void DetectIssueKey_PrBodyHasGitHubIssue_Detected()
+    {
+        var (key, provider) = TicketResolver.DetectIssueKey("fix/login", "Fixes #99");
+        Assert.Equal("99", key);
+        Assert.Equal("GitHub", provider);
+    }
+
+    [Fact]
+    public void DetectIssueKey_GhPrefix_Detected()
+    {
+        // GH-77 matches the Jira pattern (project key "GH"), which takes priority
+        var (key, provider) = TicketResolver.DetectIssueKey("fix/GH-77-crash", null);
+        Assert.Equal("GH-77", key);
+        Assert.Equal("Jira", provider);
+    }
+
+    [Fact]
+    public void DetectIssueKey_HashGitHubIssue_InBranch_Detected()
+    {
+        var (key, provider) = TicketResolver.DetectIssueKey("fix/#77-crash", null);
+        Assert.Equal("77", key);
+        Assert.Equal("GitHub", provider);
+    }
+
+    [Fact]
+    public void DetectIssueKey_JiraPriorityOverLinear_WhenBothPresent()
+    {
+        // Branch contains both a Jira key and a Linear-looking fragment
+        var (key, provider) = TicketResolver.DetectIssueKey("feature/PROJ-10/eng-5", null);
+        Assert.Equal("PROJ-10", key);
+        Assert.Equal("Jira", provider);
+    }
+
+    [Fact]
+    public void DetectIssueKey_LinearPriorityOverGitHub_WhenNoJira()
+    {
+        var (key, provider) = TicketResolver.DetectIssueKey("fix/eng-42-bug", "Closes #10");
+        Assert.Equal("eng-42", key);
+        Assert.Equal("Linear", provider);
+    }
+
+    [Fact]
+    public void DetectIssueKey_EmptyBranchAndPrBody_ReturnsNull()
+    {
+        var (key, provider) = TicketResolver.DetectIssueKey(null, null);
+        Assert.Null(key);
+        Assert.Null(provider);
+    }
+
+    [Fact]
+    public void DetectIssueKey_BranchWithNoIssueKey_ReturnsNull()
+    {
+        var (key, provider) = TicketResolver.DetectIssueKey("feature/add-login-page", null);
+        Assert.Null(key);
+        Assert.Null(provider);
+    }
+
+    [Fact]
+    public void JiraProvider_IsNotAvailable_WhenEnvVarsMissing()
+    {
+        Environment.SetEnvironmentVariable("JIRA_BASE_URL", null);
+        Environment.SetEnvironmentVariable("JIRA_API_TOKEN", null);
+        Environment.SetEnvironmentVariable("JIRA_USER_EMAIL", null);
+        var provider = new JiraTicketProvider();
+        Assert.False(provider.IsAvailable);
+    }
+
+    [Fact]
+    public void LinearProvider_IsNotAvailable_WhenEnvVarMissing()
+    {
+        Environment.SetEnvironmentVariable("LINEAR_API_KEY", null);
+        var provider = new LinearTicketProvider();
+        Assert.False(provider.IsAvailable);
+    }
+
+    [Fact]
+    public void GitHubProvider_IsNotAvailable_WhenEnvVarMissing()
+    {
+        Environment.SetEnvironmentVariable("GITHUB_TOKEN", null);
+        Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", null);
+        var provider = new GitHubIssueProvider();
+        Assert.False(provider.IsAvailable);
+    }
+
+    [Fact]
+    public void TicketInfo_Properties_RoundTrip()
+    {
+        var t = new TicketInfo { Id = "PROJ-1", Title = "Fix login", Provider = "Jira", Url = "https://x.atlassian.net/browse/PROJ-1" };
+        Assert.Equal("PROJ-1", t.Id);
+        Assert.Equal("Fix login", t.Title);
+        Assert.Equal("Jira", t.Provider);
+        Assert.Equal("https://x.atlassian.net/browse/PROJ-1", t.Url);
+        Assert.Null(t.Description);
+    }
+
+    [Fact]
+    public void TicketInfo_Description_Truncation_CanBeSet()
+    {
+        var longDesc = new string('x', 600);
+        var truncated = longDesc.Length > 500 ? longDesc[..500] : longDesc;
+        var t = new TicketInfo { Id = "ENG-1", Title = "Long desc", Provider = "Linear", Description = truncated };
+        Assert.Equal(500, t.Description!.Length);
+    }
+
+    [Fact]
+    public void ResolveProvider_ReturnsJiraProvider_ForJira()
+    {
+        var provider = TicketResolver.ResolveProvider("Jira");
+        Assert.NotNull(provider);
+        Assert.Equal("Jira", provider.ProviderName);
+    }
+
+    [Fact]
+    public void ResolveProvider_ReturnsLinearProvider_ForLinear()
+    {
+        var provider = TicketResolver.ResolveProvider("Linear");
+        Assert.NotNull(provider);
+        Assert.Equal("Linear", provider.ProviderName);
+    }
+
+    [Fact]
+    public void ResolveProvider_ReturnsGitHubProvider_ForGitHub()
+    {
+        var provider = TicketResolver.ResolveProvider("GitHub");
+        Assert.NotNull(provider);
+        Assert.Equal("GitHub", provider.ProviderName);
+    }
+
+    [Fact]
+    public void ResolveProvider_ReturnsNull_ForUnknownProvider()
+    {
+        var provider = TicketResolver.ResolveProvider("Unknown");
+        Assert.Null(provider);
+    }
+
+    [Fact]
+    public void Finding_TicketContext_CanBeAssigned()
+    {
+        var finding = new Finding
+        {
+            RuleId = "GCI0001",
+            RuleName = "Test Rule",
+            Summary = "Test",
+            Evidence = "evidence",
+            WhyItMatters = "why",
+            SuggestedAction = "action",
+        };
+        var ticket = new TicketInfo { Id = "PROJ-42", Title = "Deploy fix", Provider = "Jira" };
+        finding.TicketContext = ticket;
+
+        Assert.NotNull(finding.TicketContext);
+        Assert.Equal("PROJ-42", finding.TicketContext.Id);
+        Assert.Equal("Jira", finding.TicketContext.Provider);
+    }
+
+    [Fact]
+    public async Task AnnotateFindingsAsync_NoFindings_DoesNotThrow()
+    {
+        // Should soft-fail without throwing even when branch has a key but no credentials
+        Environment.SetEnvironmentVariable("GITHUB_PR_BODY", null);
+        await TicketResolver.AnnotateFindingsAsync("main", [], CancellationToken.None);
+    }
+}

--- a/src/GauntletCI.Tests/TicketProviderTests.cs
+++ b/src/GauntletCI.Tests/TicketProviderTests.cs
@@ -87,28 +87,58 @@ public class TicketResolverTests
     [Fact]
     public void JiraProvider_IsNotAvailable_WhenEnvVarsMissing()
     {
-        Environment.SetEnvironmentVariable("JIRA_BASE_URL", null);
-        Environment.SetEnvironmentVariable("JIRA_API_TOKEN", null);
-        Environment.SetEnvironmentVariable("JIRA_USER_EMAIL", null);
-        var provider = new JiraTicketProvider();
-        Assert.False(provider.IsAvailable);
+        var prevUrl   = Environment.GetEnvironmentVariable("JIRA_BASE_URL");
+        var prevToken = Environment.GetEnvironmentVariable("JIRA_API_TOKEN");
+        var prevEmail = Environment.GetEnvironmentVariable("JIRA_USER_EMAIL");
+        try
+        {
+            Environment.SetEnvironmentVariable("JIRA_BASE_URL",   null);
+            Environment.SetEnvironmentVariable("JIRA_API_TOKEN",  null);
+            Environment.SetEnvironmentVariable("JIRA_USER_EMAIL", null);
+            var provider = new JiraTicketProvider();
+            Assert.False(provider.IsAvailable);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("JIRA_BASE_URL",   prevUrl);
+            Environment.SetEnvironmentVariable("JIRA_API_TOKEN",  prevToken);
+            Environment.SetEnvironmentVariable("JIRA_USER_EMAIL", prevEmail);
+        }
     }
 
     [Fact]
     public void LinearProvider_IsNotAvailable_WhenEnvVarMissing()
     {
-        Environment.SetEnvironmentVariable("LINEAR_API_KEY", null);
-        var provider = new LinearTicketProvider();
-        Assert.False(provider.IsAvailable);
+        var prev = Environment.GetEnvironmentVariable("LINEAR_API_KEY");
+        try
+        {
+            Environment.SetEnvironmentVariable("LINEAR_API_KEY", null);
+            var provider = new LinearTicketProvider();
+            Assert.False(provider.IsAvailable);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("LINEAR_API_KEY", prev);
+        }
     }
 
     [Fact]
     public void GitHubProvider_IsNotAvailable_WhenEnvVarMissing()
     {
-        Environment.SetEnvironmentVariable("GITHUB_TOKEN", null);
-        Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", null);
-        var provider = new GitHubIssueProvider();
-        Assert.False(provider.IsAvailable);
+        var prevToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        var prevRepo  = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_TOKEN",      null);
+            Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", null);
+            var provider = new GitHubIssueProvider();
+            Assert.False(provider.IsAvailable);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_TOKEN",      prevToken);
+            Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", prevRepo);
+        }
     }
 
     [Fact]
@@ -185,8 +215,16 @@ public class TicketResolverTests
     [Fact]
     public async Task AnnotateFindingsAsync_NoFindings_DoesNotThrow()
     {
-        // Should soft-fail without throwing even when branch has a key but no credentials
-        Environment.SetEnvironmentVariable("GITHUB_PR_BODY", null);
-        await TicketResolver.AnnotateFindingsAsync("main", [], CancellationToken.None);
+        // No findings → should return immediately without throwing, even on branches with no key.
+        var prev = Environment.GetEnvironmentVariable("GITHUB_PR_BODY");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_PR_BODY", null);
+            await TicketResolver.AnnotateFindingsAsync("main", [], CancellationToken.None);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_PR_BODY", prev);
+        }
     }
 }


### PR DESCRIPTION
Adds \--with-ticket-context\ to \gauntletci analyze\. Parses the current branch name or GITHUB_PR_BODY for issue keys, fetches ticket details from Jira, Linear, or GitHub Issues, and attaches them to findings. When combined with \--with-llm\, runs LLM adjudication to surface whether the change aligns with the ticket's stated intent.