### PR TITLE
[CONFIG] Add ci, notifications, output, and ticketProvider config blocks

### DIFF
--- a/schemas/gauntletci-schema.json
+++ b/schemas/gauntletci-schema.json
@@ -34,6 +34,18 @@
         "type": "array",
         "items": { "type": "string" }
       }
+    },
+    "ci": {
+      "$ref": "#/definitions/CiConfig"
+    },
+    "notifications": {
+      "$ref": "#/definitions/NotificationsConfig"
+    },
+    "output": {
+      "$ref": "#/definitions/OutputConfig"
+    },
+    "ticketProvider": {
+      "$ref": "#/definitions/TicketProviderConfig"
     }
   },
   "definitions": {
@@ -88,6 +100,94 @@
           "type": "string",
           "description": "Environment variable name that holds the GauntletCI license key.",
           "default": "GAUNTLETCI_LICENSE"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable LLM enrichment by default. Equivalent to --with-llm on every run.",
+          "default": false
+        },
+        "expertContext": {
+          "type": "boolean",
+          "description": "Attach expert context from the local vector store by default. Equivalent to --with-expert-context.",
+          "default": false
+        }
+      }
+    },
+    "CiConfig": {
+      "type": "object",
+      "description": "CI/CD output integration settings.",
+      "additionalProperties": false,
+      "properties": {
+        "prComments": {
+          "type": "boolean",
+          "description": "Post findings as a GitHub PR review with inline comments. Equivalent to --github-pr-comments.",
+          "default": false
+        },
+        "checks": {
+          "type": "boolean",
+          "description": "Post findings as a GitHub Checks API check run. Equivalent to --github-checks.",
+          "default": false
+        },
+        "annotations": {
+          "type": "boolean",
+          "description": "Emit GitHub Actions workflow commands for inline annotations. Equivalent to --github-annotations.",
+          "default": false
+        },
+        "coverage": {
+          "type": "boolean",
+          "description": "Correlate findings with Codecov coverage data. Equivalent to --with-coverage.",
+          "default": false
+        }
+      }
+    },
+    "NotificationsConfig": {
+      "type": "object",
+      "description": "Notification webhook settings.",
+      "additionalProperties": false,
+      "properties": {
+        "slackWebhook": {
+          "type": "string",
+          "description": "Slack Incoming Webhook URL. Posts Block findings to Slack. Equivalent to --notify-slack."
+        },
+        "teamsWebhook": {
+          "type": "string",
+          "description": "Microsoft Teams Incoming Webhook URL. Posts Block findings to Teams. Equivalent to --notify-teams."
+        }
+      }
+    },
+    "OutputConfig": {
+      "type": "object",
+      "description": "Default output and display settings.",
+      "additionalProperties": false,
+      "properties": {
+        "minSeverity": {
+          "type": "string",
+          "description": "Minimum severity to display. Equivalent to --severity. CLI flag overrides this.",
+          "enum": ["info", "warn", "block"],
+          "default": "warn"
+        },
+        "verbose": {
+          "type": "boolean",
+          "description": "Show Info-severity findings. Equivalent to --verbose.",
+          "default": false
+        },
+        "format": {
+          "type": "string",
+          "description": "Output format. Equivalent to --output. CLI flag overrides this.",
+          "enum": ["text", "json", "sarif"],
+          "default": "text"
+        }
+      }
+    },
+    "TicketProviderConfig": {
+      "type": "object",
+      "description": "Ticket provider integration settings.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ticket context enrichment by default. Equivalent to --with-ticket-context.",
+          "default": false
         }
       }
     }

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -56,6 +56,8 @@ public static class AnalyzeCommand
         var notifyTeamsOption = new Option<string?>("--notify-teams", "Teams Incoming Webhook URL (or set GAUNTLETCI_TEAMS_WEBHOOK env var). Posts Block findings to Teams.");
         var withCoverageFlag = new Option<bool>("--with-coverage", "Correlate findings with Codecov coverage data (requires CODECOV_TOKEN env var)");
         var githubChecksFlag = new Option<bool>("--github-checks", "Post findings as a GitHub Checks API check run with annotations (requires checks: write permission)");
+        var withTicketCtxFlag = new Option<bool>("--with-ticket-context",
+            "Fetch ticket info from Jira/Linear/GitHub Issues and attach to findings (reads branch name and JIRA_*, LINEAR_API_KEY, or GITHUB_TOKEN)");
 
         var cmd = new Command("analyze", "Analyse a git diff for pre-commit risks")
         {
@@ -82,6 +84,7 @@ public static class AnalyzeCommand
             notifyTeamsOption,
             withCoverageFlag,
             githubChecksFlag,
+            withTicketCtxFlag,
         };
 
         cmd.SetHandler(async (System.CommandLine.Invocation.InvocationContext ctx) =>
@@ -107,6 +110,9 @@ public static class AnalyzeCommand
             var prCommentSuggest = ctx.ParseResult.GetValueForOption(prCommentSuggestFlag);
             var withCoverage  = ctx.ParseResult.GetValueForOption(withCoverageFlag);
             var githubChecks  = ctx.ParseResult.GetValueForOption(githubChecksFlag);
+            var withTicketCtx = ctx.ParseResult.GetValueForOption(withTicketCtxFlag);
+            var notifySlack   = ctx.ParseResult.GetValueForOption(notifySlackOption);
+            var notifyTeams   = ctx.ParseResult.GetValueForOption(notifyTeamsOption);
             var ct = ctx.GetCancellationToken();
 
             // Enforce single diff source
@@ -157,6 +163,29 @@ public static class AnalyzeCommand
                                     : DiffParser.Parse(await Console.In.ReadToEndAsync(ct));
 
                 var config = ConfigLoader.Load(repo.FullName);
+
+                // Merge config defaults — CLI flags win when explicitly set (true), config fills in the rest.
+                withLlm        = withLlm        || (config.Llm?.Enabled       == true);
+                withExpertCtx  = withExpertCtx  || (config.Llm?.ExpertContext  == true);
+                withTicketCtx  = withTicketCtx  || (config.TicketProvider.Enabled);
+                ghPrComments   = ghPrComments   || config.Ci.PrComments;
+                ghAnnotate     = ghAnnotate     || config.Ci.Annotations;
+                githubChecks   = githubChecks   || config.Ci.Checks;
+                withCoverage   = withCoverage   || config.Ci.Coverage;
+                verbose        = verbose        || config.Output.Verbose;
+
+                // Severity: only apply config value if user did not explicitly pass --severity
+                if (ctx.ParseResult.FindResultFor(severityOption) is null)
+                    severityStr = config.Output.MinSeverity;
+
+                // Output format: only apply config value if user did not explicitly pass --output
+                if (ctx.ParseResult.FindResultFor(outputOption) is null && config.Output.Format != "text")
+                    output = config.Output.Format;
+
+                // Notifications: CLI arg takes precedence, then config, then env var (handled downstream)
+                notifySlack ??= config.Notifications.SlackWebhook;
+                notifyTeams ??= config.Notifications.TeamsWebhook;
+
                 var ignoreList = IgnoreList.Load(repo.FullName);
                 var orchestrator = RuleOrchestrator.CreateDefault(config, repoPath: repo.FullName);
 
@@ -311,10 +340,8 @@ public static class AnalyzeCommand
                 if (githubChecks)
                     await GitHubChecksWriter.WriteAsync(result, ct);
 
-                var slackUrl = ctx.ParseResult.GetValueForOption(notifySlackOption)
-                            ?? Environment.GetEnvironmentVariable("GAUNTLETCI_SLACK_WEBHOOK");
-                var teamsUrl = ctx.ParseResult.GetValueForOption(notifyTeamsOption)
-                            ?? Environment.GetEnvironmentVariable("GAUNTLETCI_TEAMS_WEBHOOK");
+                var slackUrl = notifySlack ?? Environment.GetEnvironmentVariable("GAUNTLETCI_SLACK_WEBHOOK");
+                var teamsUrl = notifyTeams ?? Environment.GetEnvironmentVariable("GAUNTLETCI_TEAMS_WEBHOOK");
                 if (slackUrl is not null || teamsUrl is not null)
                     await SlackTeamsNotifier.NotifyAsync(result, slackUrl, teamsUrl, ct);
 

--- a/src/GauntletCI.Core/Configuration/GauntletConfig.cs
+++ b/src/GauntletCI.Core/Configuration/GauntletConfig.cs
@@ -36,6 +36,18 @@ public class GauntletConfig
 
     /// <summary>Experimental feature flags. Settings here may change or be removed without notice.</summary>
     public ExperimentalConfig Experimental { get; set; } = new();
+
+    /// <summary>CI/CD output integration settings (GitHub PR comments, Checks API, annotations).</summary>
+    public CiConfig Ci { get; set; } = new();
+
+    /// <summary>Notification webhook settings (Slack, Teams).</summary>
+    public NotificationsConfig Notifications { get; set; } = new();
+
+    /// <summary>Default output and display settings.</summary>
+    public OutputConfig Output { get; set; } = new();
+
+    /// <summary>Ticket provider integration settings (Jira, Linear, GitHub Issues).</summary>
+    public TicketProviderConfig TicketProvider { get; set; } = new();
 }
 
 /// <summary>Per-rule configuration overrides.</summary>
@@ -111,6 +123,19 @@ public class LlmConfig
     /// Default: <c>phi4-mini:latest</c> (pull with: <c>ollama pull phi4-mini</c>).
     /// </summary>
     public string EmbeddingModel { get; set; } = "phi4-mini:latest";
+
+    /// <summary>
+    /// Enable LLM enrichment of High-confidence findings by default.
+    /// Equivalent to passing --with-llm on every invocation.
+    /// </summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>
+    /// Attach expert context from the local vector store by default.
+    /// Equivalent to passing --with-expert-context on every invocation.
+    /// Requires 'gauntletci llm seed' to have been run.
+    /// </summary>
+    public bool ExpertContext { get; set; } = false;
 }
 
 /// <summary>
@@ -198,4 +223,63 @@ public class PatternConsistencyConfig
     /// Example: ["Subscribe", "Unsubscribe", "Register", "Deregister"]
     /// </summary>
     public string[] AllowedSyncAsyncPairs { get; set; } = [];
+}
+
+/// <summary>CI/CD output integration settings.</summary>
+public class CiConfig
+{
+    /// <summary>Post findings as a GitHub PR review with inline comments. Equivalent to --github-pr-comments.</summary>
+    public bool PrComments { get; set; } = false;
+
+    /// <summary>Post findings as a GitHub Checks API check run with annotations. Equivalent to --github-checks.</summary>
+    public bool Checks { get; set; } = false;
+
+    /// <summary>Emit GitHub Actions workflow commands for inline PR annotations. Equivalent to --github-annotations.</summary>
+    public bool Annotations { get; set; } = false;
+
+    /// <summary>Correlate findings with Codecov coverage data. Equivalent to --with-coverage.</summary>
+    public bool Coverage { get; set; } = false;
+}
+
+/// <summary>Notification webhook settings.</summary>
+public class NotificationsConfig
+{
+    /// <summary>
+    /// Slack Incoming Webhook URL. Posts Block findings to Slack.
+    /// Equivalent to --notify-slack. Can also be set via GAUNTLETCI_SLACK_WEBHOOK env var.
+    /// </summary>
+    public string? SlackWebhook { get; set; }
+
+    /// <summary>
+    /// Microsoft Teams Incoming Webhook URL. Posts Block findings to Teams.
+    /// Equivalent to --notify-teams. Can also be set via GAUNTLETCI_TEAMS_WEBHOOK env var.
+    /// </summary>
+    public string? TeamsWebhook { get; set; }
+}
+
+/// <summary>Default output and display settings.</summary>
+public class OutputConfig
+{
+    /// <summary>
+    /// Minimum severity to display: info, warn, block. Defaults to warn.
+    /// Equivalent to --severity. CLI flag overrides this value.
+    /// </summary>
+    public string MinSeverity { get; set; } = "warn";
+
+    /// <summary>Enable verbose output (show Info-severity findings). Equivalent to --verbose.</summary>
+    public bool Verbose { get; set; } = false;
+
+    /// <summary>Output format: text, json, or sarif. Defaults to text. Equivalent to --output.</summary>
+    public string Format { get; set; } = "text";
+}
+
+/// <summary>Ticket provider integration settings.</summary>
+public class TicketProviderConfig
+{
+    /// <summary>
+    /// Enable ticket context enrichment. Parses branch name and GITHUB_PR_BODY for issue keys
+    /// and fetches ticket details from Jira, Linear, or GitHub Issues.
+    /// Equivalent to --with-ticket-context.
+    /// </summary>
+    public bool Enabled { get; set; } = false;
 }


### PR DESCRIPTION
Adds four new top-level config blocks to .gauntletci.json so persistent defaults replace per-run CLI flags. CLI flags always win when passed explicitly. Schema updated.