### PR TITLE
[RULE] GCI0006: flag only nullable params; add .Success as null guard

### DIFF
--- a/src/GauntletCI.Core/Rules/Implementations/GCI0006_EdgeCaseHandling.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0006_EdgeCaseHandling.cs
@@ -49,7 +49,8 @@ public class GCI0006_EdgeCaseHandling : RuleBase
                     .Any(l => l.Content.Contains("null", StringComparison.Ordinal) ||
                                l.Content.Contains("HasValue", StringComparison.Ordinal) ||
                                l.Content.Contains("is not null", StringComparison.Ordinal) ||
-                               l.Content.Contains("!= null", StringComparison.Ordinal));
+                               l.Content.Contains("!= null", StringComparison.Ordinal) ||
+                               l.Content.Contains(".Success", StringComparison.Ordinal));
 
                 if (!hasGuard)
                 {
@@ -84,8 +85,7 @@ public class GCI0006_EdgeCaseHandling : RuleBase
                 // Check "string" or "object" in the parameter section, not just the return type
                 var parenIdx = content.IndexOf('(');
                 var paramSection = parenIdx >= 0 ? content[parenIdx..] : "";
-                if (!paramSection.Contains("string ", StringComparison.Ordinal) &&
-                    !paramSection.Contains("object ", StringComparison.Ordinal)) continue;
+                if (!HasNullableReferenceParam(paramSection)) continue;
 
                 // Check next 5 lines for null/range validation
                 int end = Math.Min(addedLines.Count, i + 6);
@@ -109,6 +109,26 @@ public class GCI0006_EdgeCaseHandling : RuleBase
                 }
             }
         }
+    }
+
+    private static bool HasNullableReferenceParam(string paramSection)
+    {
+        foreach (var keyword in new[] { "string?", "object?" })
+        {
+            int idx = 0;
+            while (idx < paramSection.Length)
+            {
+                int found = paramSection.IndexOf(keyword, idx, StringComparison.Ordinal);
+                if (found < 0) break;
+                int afterQ = found + keyword.Length;
+                if (afterQ >= paramSection.Length) return true; // at end
+                char next = paramSection[afterQ];
+                if (next == ' ' || next == '[' || next == ',' || next == ')' || next == '<')
+                    return true;
+                idx = found + 1;
+            }
+        }
+        return false;
     }
 
     private static bool IsPublicOrProtectedSignature(string line)

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0006_EdgeCaseHandling.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0006_EdgeCaseHandling.cs
@@ -50,7 +50,7 @@ public class GCI0006_EdgeCaseHandling : RuleBase
                                l.Content.Contains("HasValue", StringComparison.Ordinal) ||
                                l.Content.Contains("is not null", StringComparison.Ordinal) ||
                                l.Content.Contains("!= null", StringComparison.Ordinal) ||
-                               l.Content.Contains(".Success", StringComparison.Ordinal));
+                               IsSuccessGuardFor(content, l.Content));
 
                 if (!hasGuard)
                 {
@@ -113,22 +113,56 @@ public class GCI0006_EdgeCaseHandling : RuleBase
 
     private static bool HasNullableReferenceParam(string paramSection)
     {
-        foreach (var keyword in new[] { "string?", "object?" })
+        // Walk character by character, tracking generic depth so we skip type arguments
+        // like Dictionary<string?, int> and only match top-level parameters.
+        int angleDepth = 0;
+        for (int i = 0; i < paramSection.Length; i++)
         {
-            int idx = 0;
-            while (idx < paramSection.Length)
+            char c = paramSection[i];
+            if (c == '<') { angleDepth++; continue; }
+            if (c == '>') { angleDepth = Math.Max(0, angleDepth - 1); continue; }
+            if (angleDepth > 0) continue;
+
+            foreach (var keyword in new[] { "string?", "object?" })
             {
-                int found = paramSection.IndexOf(keyword, idx, StringComparison.Ordinal);
-                if (found < 0) break;
-                int afterQ = found + keyword.Length;
-                if (afterQ >= paramSection.Length) return true; // at end
-                char next = paramSection[afterQ];
-                if (next == ' ' || next == '[' || next == ',' || next == ')' || next == '<')
-                    return true;
-                idx = found + 1;
+                if (i + keyword.Length > paramSection.Length) continue;
+                if (!paramSection.AsSpan(i).StartsWith(keyword, StringComparison.Ordinal)) continue;
+
+                // Leading boundary: must be preceded by a non-identifier char
+                bool leadOk = i == 0 || paramSection[i - 1] is ' ' or '(' or ',' or '<';
+                if (!leadOk) continue;
+
+                // Trailing boundary: must be followed by a non-identifier char
+                int after = i + keyword.Length;
+                bool trailOk = after >= paramSection.Length ||
+                               paramSection[after] is ' ' or '[' or ',' or ')' or '<';
+                if (trailOk) return true;
             }
         }
         return false;
+    }
+
+    // Returns true only when the .Success check in guardLine refers to the same root
+    // identifier as the .Value access in valueLine (e.g. "match.Success" guards "match.Groups[1].Value").
+    private static bool IsSuccessGuardFor(string valueLine, string guardLine)
+    {
+        int valIdx = valueLine.IndexOf(".Value", StringComparison.Ordinal);
+        if (valIdx <= 0) return false;
+
+        // Walk backward from the dot to collect the expression chain (e.g. "match.Groups[1]")
+        int start = valIdx - 1;
+        while (start > 0 && valueLine[start - 1] is char pc &&
+               (char.IsLetterOrDigit(pc) || pc is '_' or '.' or '[' or ']'))
+            start--;
+
+        var expr = valueLine[start..valIdx]; // e.g. "match.Groups[1]"
+
+        // Extract the root identifier — the first segment before '.' or '['
+        int boundary = expr.IndexOfAny(['.', '[']);
+        var root = boundary > 0 ? expr[..boundary] : expr;
+        root = new string(root.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+
+        return root.Length > 0 && guardLine.Contains(root + ".Success", StringComparison.Ordinal);
     }
 
     private static bool IsPublicOrProtectedSignature(string line)

--- a/src/GauntletCI.Tests/Rules/GCI0006Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0006Tests.cs
@@ -156,7 +156,7 @@ public class GCI0006Tests
     [Fact]
     public async Task PublicMethodNonNullableStringParam_ShouldNotFlag()
     {
-        // Non-nullable string in .NET 8 nullable context cannot be null — no guard needed.
+        // Non-nullable string annotation in nullable context; this rule does not require a guard here.
         var raw = """
             diff --git a/src/Processor.cs b/src/Processor.cs
             index abc..def 100644
@@ -194,6 +194,49 @@ public class GCI0006Tests
         var findings = await Rule.EvaluateAsync(diff, null);
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("null dereference"));
+    }
+
+    [Fact]
+    public async Task UnrelatedSuccessGuard_ShouldStillFlag()
+    {
+        // op.Success does not prove that nullable is non-null — should still flag
+        var raw = """
+            diff --git a/src/Parser.cs b/src/Parser.cs
+            index abc..def 100644
+            --- a/src/Parser.cs
+            +++ b/src/Parser.cs
+            @@ -1,1 +1,4 @@
+             // existing
+            +if (op.Success)
+            +    return nullable.Value;
+            +return string.Empty;
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.Summary.Contains("null dereference"));
+    }
+
+    [Fact]
+    public async Task NullableInsideGenericParam_ShouldNotFlag()
+    {
+        // Dictionary<string?, int> is non-nullable at the top level — no guard needed
+        var raw = """
+            diff --git a/src/Processor.cs b/src/Processor.cs
+            index abc..def 100644
+            --- a/src/Processor.cs
+            +++ b/src/Processor.cs
+            @@ -1,1 +1,3 @@
+             // existing
+            +public void Process(Dictionary<string?, int> map)
+            +{
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("parameter(s) added"));
     }
 
     [Fact]

--- a/src/GauntletCI.Tests/Rules/GCI0006Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0006Tests.cs
@@ -59,7 +59,7 @@ public class GCI0006Tests
             +++ b/src/Processor.cs
             @@ -1,1 +1,3 @@
              // existing
-            +public void Process(string input)
+            +public void Process(string? input)
             +{
             """;
 
@@ -151,6 +151,49 @@ public class GCI0006Tests
         var findings = await Rule.EvaluateAsync(diff, null);
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("parameter(s) added"));
+    }
+
+    [Fact]
+    public async Task PublicMethodNonNullableStringParam_ShouldNotFlag()
+    {
+        // Non-nullable string in .NET 8 nullable context cannot be null — no guard needed.
+        var raw = """
+            diff --git a/src/Processor.cs b/src/Processor.cs
+            index abc..def 100644
+            --- a/src/Processor.cs
+            +++ b/src/Processor.cs
+            @@ -1,1 +1,3 @@
+             // existing
+            +public void Process(string input)
+            +{
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("parameter(s) added"));
+    }
+
+    [Fact]
+    public async Task ValueAccessAfterSuccessGuard_ShouldNotFlag()
+    {
+        // match.Success is a valid null guard for match.Groups[1].Value
+        var raw = """
+            diff --git a/src/Parser.cs b/src/Parser.cs
+            index abc..def 100644
+            --- a/src/Parser.cs
+            +++ b/src/Parser.cs
+            @@ -1,1 +1,4 @@
+             // existing
+            +if (match.Success)
+            +    return match.Groups[1].Value;
+            +return string.Empty;
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("null dereference"));
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

**False positive 1**: In .NET 8 nullable-enabled projects, non-nullable `string` parameters cannot be null — flagging them for missing null guards is incorrect. Only `string?` and `object?` params need guards.

**False positive 2**: `match.Groups[1].Value` was flagged when preceded by a `match.Success` check, which is a valid null guard — a successful regex match guarantees all captured groups exist.

## Fix

1. Replaced `Contains("string ")` / `Contains("object ")` check with `HasNullableReferenceParam()` helper that only matches nullable reference type annotations (`string?`, `object?`) with proper boundary detection.
2. Added `.Success` to the list of recognized null-guard patterns in `CheckNullDereferences`.

## Tests

- Updated `PublicMethodWithStringParam_ShouldFlag` to use `string?` (nullable — still flags correctly)
- Added `PublicMethodNonNullableStringParam_ShouldNotFlag`
- Added `ValueAccessAfterSuccessGuard_ShouldNotFlag`

Fixes review findings from PR #117.
