### PR TITLE
[RULE] GCI0003: fix access-modifier match on string literals

### DIFF
--- a/src/GauntletCI.Core/Rules/Implementations/GCI0003_BehavioralChangeDetection.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0003_BehavioralChangeDetection.cs
@@ -67,17 +67,17 @@ public class GCI0003_BehavioralChangeDetection : RuleBase
             if (WellKnownPatterns.IsTestFile(file.NewPath) || WellKnownPatterns.IsGeneratedFile(file.NewPath)) continue;
 
             var removedSigs = file.RemovedLines
-                .Where(l => { var t = l.Content.TrimStart(); return AccessModifiers.Any(m => t.StartsWith(m)) && l.Content.Contains('('); })
+                .Where(l => { var t = l.Content.TrimStart(); return HasAccessModifier(t) && l.Content.Contains('('); })
                 .ToList();
 
             var addedSigs = file.AddedLines
-                .Where(l => { var t = l.Content.TrimStart(); return AccessModifiers.Any(m => t.StartsWith(m)) && l.Content.Contains('('); })
+                .Where(l => { var t = l.Content.TrimStart(); return HasAccessModifier(t) && l.Content.Contains('('); })
                 .ToList();
 
             foreach (var removed in removedSigs)
             {
                 // Private methods cannot break external callers — skip entirely.
-                if (removed.Content.Contains("private ", StringComparison.Ordinal)) continue;
+                if (removed.Content.TrimStart().StartsWith("private ", StringComparison.Ordinal)) continue;
 
                 var removedName = ExtractMethodName(removed.Content);
                 if (removedName is null) continue;
@@ -141,12 +141,54 @@ public class GCI0003_BehavioralChangeDetection : RuleBase
         var s = sig.Replace("async ", "", StringComparison.Ordinal).Trim();
         var open = s.IndexOf('(');
         if (open < 0) return s;
+
+        // Find the matching closing paren with string-literal-aware depth tracking
+        // so default values like string s = ")" don't cause early termination.
         int depth = 0;
+        bool inString = false;
+        char delim = '"';
+        int closeIdx = -1;
         for (int i = open; i < s.Length; i++)
         {
-            if (s[i] == '(') depth++;
-            else if (s[i] == ')') { depth--; if (depth == 0) return s[..(i + 1)]; }
+            char c = s[i];
+            if (inString)
+            {
+                if (c == '\\') { i++; continue; } // skip escaped char in regular string
+                if (c == delim) inString = false;
+                continue;
+            }
+            if (c is '"' or '\'') { inString = true; delim = c; continue; }
+            if (c == '(') depth++;
+            else if (c == ')') { depth--; if (depth == 0) { closeIdx = i; break; } }
+        }
+        if (closeIdx < 0) return s;
+
+        // Include where-clauses (which precede the body) but drop method body (=> or {).
+        for (int i = closeIdx + 1; i < s.Length; i++)
+        {
+            if (s[i] == '{') return s[..i].TrimEnd();
+            if (s[i] == '=' && i + 1 < s.Length && s[i + 1] == '>') return s[..i].TrimEnd();
         }
         return s;
+    }
+
+    // Returns true when the trimmed line starts with a C# access modifier,
+    // accounting for optional attribute prefix(es) like [Obsolete].
+    private static bool HasAccessModifier(string trimmedLine)
+    {
+        int idx = 0;
+        while (idx < trimmedLine.Length && trimmedLine[idx] == '[')
+        {
+            int depth = 0;
+            while (idx < trimmedLine.Length)
+            {
+                char c = trimmedLine[idx++];
+                if (c == '[') depth++;
+                else if (c == ']') { if (--depth == 0) break; }
+            }
+            while (idx < trimmedLine.Length && trimmedLine[idx] == ' ') idx++;
+        }
+        var rest = trimmedLine[idx..];
+        return AccessModifiers.Any(m => rest.StartsWith(m, StringComparison.Ordinal));
     }
 }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0003_BehavioralChangeDetection.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0003_BehavioralChangeDetection.cs
@@ -67,11 +67,11 @@ public class GCI0003_BehavioralChangeDetection : RuleBase
             if (WellKnownPatterns.IsTestFile(file.NewPath) || WellKnownPatterns.IsGeneratedFile(file.NewPath)) continue;
 
             var removedSigs = file.RemovedLines
-                .Where(l => AccessModifiers.Any(m => l.Content.Contains(m)) && l.Content.Contains('('))
+                .Where(l => { var t = l.Content.TrimStart(); return AccessModifiers.Any(m => t.StartsWith(m)) && l.Content.Contains('('); })
                 .ToList();
 
             var addedSigs = file.AddedLines
-                .Where(l => AccessModifiers.Any(m => l.Content.Contains(m)) && l.Content.Contains('('))
+                .Where(l => { var t = l.Content.TrimStart(); return AccessModifiers.Any(m => t.StartsWith(m)) && l.Content.Contains('('); })
                 .ToList();
 
             foreach (var removed in removedSigs)
@@ -136,6 +136,17 @@ public class GCI0003_BehavioralChangeDetection : RuleBase
         return before[(lastSpace + 1)..];
     }
 
-    private static string NormalizeSignature(string sig) =>
-        sig.Replace("async ", "", StringComparison.Ordinal).Trim();
+    private static string NormalizeSignature(string sig)
+    {
+        var s = sig.Replace("async ", "", StringComparison.Ordinal).Trim();
+        var open = s.IndexOf('(');
+        if (open < 0) return s;
+        int depth = 0;
+        for (int i = open; i < s.Length; i++)
+        {
+            if (s[i] == '(') depth++;
+            else if (s[i] == ')') { depth--; if (depth == 0) return s[..(i + 1)]; }
+        }
+        return s;
+    }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0003Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0003Tests.cs
@@ -138,9 +138,9 @@ public class GCI0003Tests
     }
 
     [Fact]
-    public async Task AccessModifierInsideStringLiteral_ShouldNotFlagSignatureChange()
+    public async Task ExpressionBodyChange_ShouldNotFlagSignatureChange()
     {
-        // "internal " appears inside a string literal, not as an actual access modifier.
+        // Only the expression body changes — the signature (name + params) is identical.
         var raw = """
             diff --git a/src/Core/Checker.cs b/src/Core/Checker.cs
             index abc..def 100644
@@ -157,5 +157,72 @@ public class GCI0003Tests
         var findings = await Rule.EvaluateAsync(diff, null);
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("signature changed"));
+    }
+
+    [Fact]
+    public async Task AccessModifierInStringLiteralWithParen_ShouldNotFlagSignatureChange()
+    {
+        // A non-signature line containing "internal " in a string plus "(" should not
+        // be treated as a method signature (exercises TrimStart().StartsWith() guard).
+        var raw = """
+            diff --git a/src/Core/Checker.cs b/src/Core/Checker.cs
+            index abc..def 100644
+            --- a/src/Core/Checker.cs
+            +++ b/src/Core/Checker.cs
+            @@ -1,3 +1,3 @@
+             public class Checker {
+            -    var msg = "internal method(old)";
+            +    var msg = "internal method(new)";
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("signature changed"));
+    }
+
+    [Fact]
+    public async Task AttributeDecoratedMethod_ShouldFlagSignatureChange()
+    {
+        // [Obsolete] attribute before "public" should not prevent signature detection.
+        var raw = """
+            diff --git a/src/Core/Api.cs b/src/Core/Api.cs
+            index abc..def 100644
+            --- a/src/Core/Api.cs
+            +++ b/src/Core/Api.cs
+            @@ -1,3 +1,3 @@
+             public class Api {
+            -    [Obsolete] public void Process(string input) { }
+            +    [Obsolete] public void Process(string input, int timeout) { }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.Summary.Contains("signature changed"));
+    }
+
+    [Fact]
+    public async Task GenericConstraintChange_ShouldFlagSignatureChange()
+    {
+        // A where-clause change is a signature-level breaking change and must be flagged.
+        var raw = """
+            diff --git a/src/Core/Api.cs b/src/Core/Api.cs
+            index abc..def 100644
+            --- a/src/Core/Api.cs
+            +++ b/src/Core/Api.cs
+            @@ -1,3 +1,3 @@
+             public class Api {
+            -    public void Process<T>(T input) where T : struct { }
+            +    public void Process<T>(T input) where T : class { }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.Summary.Contains("signature changed"));
     }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0003Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0003Tests.cs
@@ -136,4 +136,26 @@ public class GCI0003Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("logic line(s) removed"));
     }
+
+    [Fact]
+    public async Task AccessModifierInsideStringLiteral_ShouldNotFlagSignatureChange()
+    {
+        // "internal " appears inside a string literal, not as an actual access modifier.
+        var raw = """
+            diff --git a/src/Core/Checker.cs b/src/Core/Checker.cs
+            index abc..def 100644
+            --- a/src/Core/Checker.cs
+            +++ b/src/Core/Checker.cs
+            @@ -1,3 +1,3 @@
+             public class Checker {
+            -    public bool HasModifier(string content) => content.Contains("internal ");
+            +    public bool HasModifier(string content) => content.Contains("internal ", StringComparison.Ordinal);
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("signature changed"));
+    }
 }


### PR DESCRIPTION
Fixes false positive where access modifiers like 'internal ' matched inside string literals. Switches from Content.Contains(m) to TrimStart().StartsWith(m).

Also fixes NormalizeSignature to extract only the method signature declaration (up to the closing paren), so expression-bodied method body changes are not flagged as signature changes.

Closes review comment from #117.