### PR TITLE
[RULE] GCI0007: scan Added+Context lines for swallowed catch body detection

### DIFF
--- a/src/GauntletCI.Core/Rules/Implementations/GCI0007_ErrorHandlingIntegrity.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0007_ErrorHandlingIntegrity.cs
@@ -42,32 +42,38 @@ public class GCI0007_ErrorHandlingIntegrity : RuleBase
     {
         foreach (var file in diff.Files)
         {
-            var addedLines = file.AddedLines.ToList();
-            for (int i = 0; i < addedLines.Count; i++)
+            foreach (var hunk in file.Hunks)
             {
-                var content = addedLines[i].Content.Trim();
+                // Added+Context only — Removed lines excluded so a previously deleted
+                // throw/log cannot mask a genuinely empty new catch body.
+                var nonRemovedLines = hunk.Lines
+                    .Where(l => l.Kind != DiffLineKind.Removed)
+                    .ToList();
 
-                // Detect catch blocks
-                if (!content.StartsWith("catch", StringComparison.Ordinal)) continue;
-
-                // Cancellation exceptions are commonly swallowed intentionally (shutdown/background work).
-                if (content.Contains("TaskCanceledException", StringComparison.Ordinal) ||
-                    content.Contains("OperationCanceledException", StringComparison.Ordinal))
+                for (int i = 0; i < nonRemovedLines.Count; i++)
                 {
-                    continue;
-                }
+                    // Only flag catch blocks that are newly added.
+                    if (nonRemovedLines[i].Kind != DiffLineKind.Added) continue;
 
-                bool isSwallowed = IsCatchSwallowed(addedLines, i, out string evidence);
-                if (isSwallowed)
-                {
-                    findings.Add(CreateFinding(
-                        file,
-                        summary: $"Swallowed exception detected in {file.NewPath}",
-                        evidence: evidence,
-                        whyItMatters: "Empty or silent catch blocks hide failures, making bugs invisible and debugging nearly impossible.",
-                        suggestedAction: "Log the exception, rethrow it, or handle it explicitly. Never swallow silently.",
-                        confidence: Confidence.High,
-                        line: addedLines[i]));
+                    var content = nonRemovedLines[i].Content.Trim();
+                    if (!content.StartsWith("catch", StringComparison.Ordinal)) continue;
+
+                    if (content.Contains("TaskCanceledException", StringComparison.Ordinal) ||
+                        content.Contains("OperationCanceledException", StringComparison.Ordinal))
+                        continue;
+
+                    bool isSwallowed = IsCatchSwallowed(nonRemovedLines, i, out string evidence);
+                    if (isSwallowed)
+                    {
+                        findings.Add(CreateFinding(
+                            file,
+                            summary: $"Swallowed exception detected in {file.NewPath}",
+                            evidence: evidence,
+                            whyItMatters: "Empty or silent catch blocks hide failures, making bugs invisible and debugging nearly impossible.",
+                            suggestedAction: "Log the exception, rethrow it, or handle it explicitly. Never swallow silently.",
+                            confidence: Confidence.High,
+                            line: nonRemovedLines[i]));
+                    }
                 }
             }
         }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0007_ErrorHandlingIntegrity.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0007_ErrorHandlingIntegrity.cs
@@ -44,25 +44,25 @@ public class GCI0007_ErrorHandlingIntegrity : RuleBase
         {
             foreach (var hunk in file.Hunks)
             {
-                // Added+Context only — Removed lines excluded so a previously deleted
-                // throw/log cannot mask a genuinely empty new catch body.
-                var nonRemovedLines = hunk.Lines
-                    .Where(l => l.Kind != DiffLineKind.Removed)
-                    .ToList();
+                // Collect Added+Context lines only — excluding Removed lines so a previously
+                // deleted throw/log cannot mask a genuinely empty new catch body.
+                var hunkLines = new List<DiffLine>();
+                foreach (var l in hunk.Lines)
+                    if (l.Kind != DiffLineKind.Removed) hunkLines.Add(l);
 
-                for (int i = 0; i < nonRemovedLines.Count; i++)
+                for (int i = 0; i < hunkLines.Count; i++)
                 {
-                    // Only flag catch blocks that are newly added.
-                    if (nonRemovedLines[i].Kind != DiffLineKind.Added) continue;
+                    // Only evaluate catch blocks on Added lines (newly introduced catch).
+                    if (hunkLines[i].Kind != DiffLineKind.Added) continue;
 
-                    var content = nonRemovedLines[i].Content.Trim();
+                    var content = hunkLines[i].Content.Trim();
                     if (!content.StartsWith("catch", StringComparison.Ordinal)) continue;
 
                     if (content.Contains("TaskCanceledException", StringComparison.Ordinal) ||
                         content.Contains("OperationCanceledException", StringComparison.Ordinal))
                         continue;
 
-                    bool isSwallowed = IsCatchSwallowed(nonRemovedLines, i, out string evidence);
+                    bool isSwallowed = IsCatchSwallowed(hunkLines, i, out string evidence);
                     if (isSwallowed)
                     {
                         findings.Add(CreateFinding(
@@ -72,25 +72,25 @@ public class GCI0007_ErrorHandlingIntegrity : RuleBase
                             whyItMatters: "Empty or silent catch blocks hide failures, making bugs invisible and debugging nearly impossible.",
                             suggestedAction: "Log the exception, rethrow it, or handle it explicitly. Never swallow silently.",
                             confidence: Confidence.High,
-                            line: nonRemovedLines[i]));
+                            line: hunkLines[i]));
                     }
                 }
             }
         }
     }
 
-    private static bool IsCatchSwallowed(List<DiffLine> addedLines, int catchIdx, out string evidence)
+    private static bool IsCatchSwallowed(List<DiffLine> hunkLines, int catchIdx, out string evidence)
     {
-        evidence = addedLines[catchIdx].Content.Trim();
+        evidence = hunkLines[catchIdx].Content.Trim();
 
         // Look for { and } around the catch body
         int depth = 0;
         bool inBody = false;
         bool hasContent = false;
 
-        for (int j = catchIdx; j < Math.Min(addedLines.Count, catchIdx + 10); j++)
+        for (int j = catchIdx; j < Math.Min(hunkLines.Count, catchIdx + 10); j++)
         {
-            var line = addedLines[j].Content.Trim();
+            var line = hunkLines[j].Content.Trim();
             foreach (char c in line)
             {
                 if (c == '{') { depth++; inBody = true; }

--- a/src/GauntletCI.Tests/Rules/GCI0007Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0007Tests.cs
@@ -128,7 +128,7 @@ public class GCI0007Tests
             index abc..def 100644
             --- a/src/Service.cs
             +++ b/src/Service.cs
-            @@ -1,4 +1,6 @@
+            @@ -1,2 +1,5 @@
              // service
             +catch (Exception ex)
             +{
@@ -152,7 +152,7 @@ public class GCI0007Tests
             index abc..def 100644
             --- a/src/Service.cs
             +++ b/src/Service.cs
-            @@ -1,5 +1,5 @@
+            @@ -1,2 +1,4 @@
              // service
             +catch (Exception ex)
             +{

--- a/src/GauntletCI.Tests/Rules/GCI0007Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0007Tests.cs
@@ -117,4 +117,54 @@ public class GCI0007Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("Swallowed exception"));
     }
+
+    [Fact]
+    public async Task CatchWithContextLineLog_ShouldNotFlag()
+    {
+        // The log call is a context line (pre-existing code), not a newly added line.
+        // Body scan must include context lines to correctly suppress this finding.
+        var raw = """
+            diff --git a/src/Service.cs b/src/Service.cs
+            index abc..def 100644
+            --- a/src/Service.cs
+            +++ b/src/Service.cs
+            @@ -1,4 +1,6 @@
+             // service
+            +catch (Exception ex)
+            +{
+             _logger.LogError(ex, "Error occurred");
+            +}
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("Swallowed exception"));
+    }
+
+    [Fact]
+    public async Task CatchWithRemovedThrowAndEmptyBody_ShouldFlag()
+    {
+        // A throw was removed from the catch body; the body is now empty.
+        // The removed throw must NOT suppress detection — Removed lines are excluded.
+        var raw = """
+            diff --git a/src/Service.cs b/src/Service.cs
+            index abc..def 100644
+            --- a/src/Service.cs
+            +++ b/src/Service.cs
+            @@ -1,5 +1,5 @@
+             // service
+            +catch (Exception ex)
+            +{
+            -    throw;
+            +}
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f =>
+            f.Summary.Contains("Swallowed exception") &&
+            f.Confidence == Confidence.High);
+    }
 }


### PR DESCRIPTION
## Problem

GCI0007 swallowed-exception detection scanned only `file.AddedLines` for both catch keyword detection and body content. When a new catch block was added but its body contained pre-existing context lines (e.g. a logger call that was already there), the rule missed the logging and incorrectly flagged the catch as swallowed — a false positive.

Additionally, scanning ALL hunk lines (including Removed) caused a false negative: a previously removed `throw` or log statement could suppress detection of a genuinely empty new catch body.

## Fix

Refactored `CheckSwallowedExceptions` to operate per-hunk on **Added+Context** lines (Removed lines filtered out). The catch keyword must be on an Added line — only newly introduced catch blocks are checked.

## Tests

- `CatchWithContextLineLog_ShouldNotFlag`: pre-existing log in context line correctly suppresses the finding
- `CatchWithRemovedThrowAndEmptyBody_ShouldFlag`: removed throw does not mask detection of a new empty catch body

Fixes review findings from PR #117.