### PR TITLE
[RULE] GCI0024: add KnownNonDisposableTypes allowlist for Context suffix FPs

### DIFF
--- a/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
@@ -43,6 +43,23 @@ public class GCI0024_ResourceLifecycle : RuleBase
         "Certificate", "Scope", "Timer", "Enumerator"
     ];
 
+    // Types that end with a disposable-looking suffix but do NOT implement IDisposable.
+    // The suffix heuristic is skipped for these to avoid false positives.
+    private static readonly HashSet<string> KnownNonDisposableTypes = new(StringComparer.Ordinal)
+    {
+        // Microsoft.CodeAnalysis / Roslyn analysis context types
+        "SyntaxContext", "AnalysisContext", "SemanticContext",
+        "SyntaxNodeAnalysisContext", "OperationAnalysisContext", "CodeBlockAnalysisContext",
+        // System.CommandLine types
+        "InvocationContext", "ParseResult",
+        // ASP.NET Core filter/action context types (not disposable on their own)
+        "HttpContext", "RouteContext", "FilterContext", "ActionContext",
+        "AuthorizationFilterContext", "ResourceExecutingContext", "ResourceExecutedContext",
+        "ResultExecutingContext", "ResultExecutedContext", "ExceptionContext",
+        // Other common non-disposable context types
+        "ValidationContext", "NavigationContext",
+    };
+
     private static readonly Regex NewTypeRegex =
         new(@"new ([A-Z][A-Za-z0-9]+)\(", RegexOptions.Compiled);
 
@@ -132,11 +149,13 @@ public class GCI0024_ResourceLifecycle : RuleBase
                 return (knownType.Replace("new ", "").TrimEnd('('), true);
         }
 
-        // Suffix heuristic — Medium confidence (type name resembles a disposable but isn't confirmed)
+        // Suffix heuristic — Medium confidence
         var match = NewTypeRegex.Match(content);
         if (match.Success)
         {
             var name = match.Groups[1].Value;
+            // Skip types known NOT to be disposable despite having a disposable-looking suffix
+            if (KnownNonDisposableTypes.Contains(name)) return (null, false);
             if (DisposableSuffixes.Any(suffix => name.EndsWith(suffix, StringComparison.Ordinal)))
                 return (name, false);
         }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
@@ -51,7 +51,7 @@ public class GCI0024_ResourceLifecycle : RuleBase
         "SyntaxContext", "AnalysisContext", "SemanticContext",
         "SyntaxNodeAnalysisContext", "OperationAnalysisContext", "CodeBlockAnalysisContext",
         // System.CommandLine types
-        "InvocationContext", "ParseResult",
+        "InvocationContext",
         // ASP.NET Core filter/action context types (not disposable on their own)
         "HttpContext", "RouteContext", "FilterContext", "ActionContext",
         "AuthorizationFilterContext", "ResourceExecutingContext", "ResourceExecutedContext",
@@ -154,10 +154,15 @@ public class GCI0024_ResourceLifecycle : RuleBase
         if (match.Success)
         {
             var name = match.Groups[1].Value;
-            // Skip types known NOT to be disposable despite having a disposable-looking suffix
-            if (KnownNonDisposableTypes.Contains(name)) return (null, false);
-            if (DisposableSuffixes.Any(suffix => name.EndsWith(suffix, StringComparison.Ordinal)))
-                return (name, false);
+            foreach (var suffix in DisposableSuffixes)
+            {
+                if (name.EndsWith(suffix, StringComparison.Ordinal))
+                {
+                    // Skip types known NOT to be disposable despite having a disposable-looking suffix
+                    if (KnownNonDisposableTypes.Contains(name)) return (null, false);
+                    return (name, false);
+                }
+            }
         }
 
         return (null, false);

--- a/src/GauntletCI.Tests/Rules/GCI0024Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0024Tests.cs
@@ -189,7 +189,7 @@ public class GCI0024Tests
             +++ b/src/Rules/MyRule.cs
             @@ -1,2 +1,3 @@
              public class MyRule {
-            +    var ctx = new SyntaxContext(node, semanticModel);
+            +    public void Do() { var ctx = new SyntaxContext(node, semanticModel); }
              }
             """;
 
@@ -210,7 +210,7 @@ public class GCI0024Tests
             +++ b/src/Cli/MyCommand.cs
             @@ -1,2 +1,3 @@
              public class MyCommand {
-            +    var ctx = new InvocationContext(parseResult);
+            +    public void Do() { var ctx = new InvocationContext(parseResult); }
              }
             """;
 

--- a/src/GauntletCI.Tests/Rules/GCI0024Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0024Tests.cs
@@ -177,4 +177,46 @@ public class GCI0024Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("Command"));
     }
+
+    [Fact]
+    public async Task SyntaxContextAllocation_ShouldNotFlag()
+    {
+        // SyntaxContext ends with "Context" (a DisposableSuffix) but is not IDisposable.
+        var raw = """
+            diff --git a/src/Rules/MyRule.cs b/src/Rules/MyRule.cs
+            index abc..def 100644
+            --- a/src/Rules/MyRule.cs
+            +++ b/src/Rules/MyRule.cs
+            @@ -1,2 +1,3 @@
+             public class MyRule {
+            +    var ctx = new SyntaxContext(node, semanticModel);
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("SyntaxContext"));
+    }
+
+    [Fact]
+    public async Task InvocationContextAllocation_ShouldNotFlag()
+    {
+        // InvocationContext (System.CommandLine) ends with "Context" but is not IDisposable.
+        var raw = """
+            diff --git a/src/Cli/MyCommand.cs b/src/Cli/MyCommand.cs
+            index abc..def 100644
+            --- a/src/Cli/MyCommand.cs
+            +++ b/src/Cli/MyCommand.cs
+            @@ -1,2 +1,3 @@
+             public class MyCommand {
+            +    var ctx = new InvocationContext(parseResult);
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("InvocationContext"));
+    }
 }


### PR DESCRIPTION
## Problem

GCI0024's suffix heuristic includes \Context\ in \DisposableSuffixes\. This causes false positives for common framework types like \SyntaxContext\, \InvocationContext\, \HttpContext\, etc., which end with \Context\ but do NOT implement \IDisposable\.

## Fix

Added \KnownNonDisposableTypes\ — a static \HashSet<string>\ of type names that are confirmed NOT to be disposable despite having a disposable-looking suffix. The suffix heuristic in \MatchDisposableType\ now skips types in this set.

**Note**: \DbContext\ is intentionally excluded from this allowlist — it IS \IDisposable\/\IAsyncDisposable\ and must continue to be flagged.

## Tests

- \SyntaxContextAllocation_ShouldNotFlag\
- \InvocationContextAllocation_ShouldNotFlag\

Fixes review findings from PR #117.