### PR TITLE
fix(site): add Footer to docs layout

### DIFF
--- a/site/app/docs/layout.tsx
+++ b/site/app/docs/layout.tsx
@@ -1,4 +1,5 @@
 import { Header } from "@/components/header";
+import { Footer } from "@/components/footer";
 import { DocsSidebar } from "@/components/docs-sidebar";
 
 export default function DocsLayout({ children }: { children: React.ReactNode }) {
@@ -15,6 +16,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
           </div>
         </div>
       </div>
+      <Footer />
     </>
   );
 }


### PR DESCRIPTION
The /docs/* pages were missing a footer. Root layout doesn't include Footer (each page imports it directly), and docs/layout.tsx only added Header + DocsSidebar. Adding Footer to the shared docs layout fixes all docs pages in one place.

Risk: Low — single layout file, additive JSX, reuses the same Footer component used site-wide.