### PR TITLE
[DOCS] Add GitHub stars badge to header and fix README badge link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **GitHub stars badge in site header**: Stars badge (shields.io social style) added to the desktop nav, linking to /stargazers.
+
 ### Fixed
+- **README custom badge link**: First badge (custom endpoint) now links to the GitHub repository instead of displaying as an unlinked image.
 - **GCI0045 recall improvement**: Rule now fires when a new interface has 0 visible implementers in the diff (not just exactly 1). Change: `implCount != 1` guard replaced with `implCount > 1`. Interfaces added with no implementation in the same PR are often premature abstraction. Finding message distinguishes "no visible" from "exactly one" implementer. Added `NewInterfaceWithNoImplementorInDiff_ShouldFire` regression test. 1191 tests pass.
 - **GCI0045 labeler false positives**: Heuristic changed from `addedLines` (all files, all extensions) to `prodCsLines` (non-test `.cs` files only) to mirror the rule's own filtering. Previously, interface definitions in `.txt` API-approval snapshots and test files created false positive expected labels that the rule correctly never fires on - pulling down apparent recall from labeler noise, not real rule misses.
 - **GCI0032 rule bug - removed assertion lines**: The throw-assertion check now filters out `DiffLineKind.Removed` hunk lines from test files. Previously a deleted `Assert.Throws` line (evidence that coverage was removed) incorrectly suppressed the finding. Added `ThrowNewWithRemovedAssertionInTestFile_ShouldFlag` regression test.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GauntletCI
 <div><img src="GauntletCI.png" alt="GauntletCI Logo" width="200" align="right"/></div>
 
-![GauntletCI](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/EricCogen/db3979f1a5d69ce37d425b73bdcf4ada/raw/gauntletci-badge.json)
+[![GauntletCI](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/EricCogen/db3979f1a5d69ce37d425b73bdcf4ada/raw/gauntletci-badge.json)](https://github.com/EricCogen/GauntletCI)
 [![GitHub last commit](https://img.shields.io/github/last-commit/EricCogen/GauntletCI)](https://github.com/EricCogen/GauntletCI/commits/main)
 [![GitHub stars](https://img.shields.io/github/stars/EricCogen/GauntletCI?style=social)](https://github.com/EricCogen/GauntletCI/stargazers)
 [![License](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](LICENSE)

--- a/site/components/header.tsx
+++ b/site/components/header.tsx
@@ -100,6 +100,11 @@ export function Header() {
               <Link href="https://github.com/ericcogen/gauntletci" target="_blank" rel="noopener noreferrer">
                 <Github className="mr-2 h-4 w-4" />
                 GitHub
+                <img
+                  src="https://img.shields.io/github/stars/EricCogen/GauntletCI?style=social"
+                  alt="GitHub stars"
+                  className="ml-2 h-4 w-auto"
+                />
               </Link>
             </Button>
             <Button variant="outline" size="sm" asChild>


### PR DESCRIPTION
## Summary

- Embeds GitHub stars badge (shields.io social style) inside the existing GitHub button in the site header - no extra button/link added
- Wraps the custom endpoint badge in README.md with a link to the GitHub repo (was an unlinked image)

## Closes
- growth-github-stars-badge todo