### PR TITLE
[INFRA] Add Plausible Analytics to site layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Plausible Analytics**: Privacy-first analytics script added to site layout (`gauntletci.com` domain, loads after interactive, no cookies).
+
+### Added
 - **GitHub stars badge in site header**: Stars badge (shields.io social style) added to the desktop nav, linking to /stargazers.
 
 ### Fixed

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
+import Script from 'next/script'
 import './globals.css'
 
 const jsonLd = {
@@ -179,6 +180,12 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdFaq) }}
         />
         {children}
+        <Script
+          defer
+          data-domain="gauntletci.com"
+          src="https://plausible.io/js/script.js"
+          strategy="afterInteractive"
+        />
       </body>
     </html>
   )


### PR DESCRIPTION
Adds privacy-first Plausible Analytics script to the site root layout. Loads after interactive, no cookies, scoped to gauntletci.com domain.

Closes infra-plausible todo.