### PR TITLE
[DOCS] Add NuGet downloads badge to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **NuGet downloads badge**: Added to README linking to the GauntletCI NuGet package page.
+
+### Added
 - **Custom 404 page**: `not-found.tsx` added with header, footer, and helpful links to Home, Docs, Detections, Pricing, and Benchmark.
 - **GitHub stars badge in site header**: Stars badge (shields.io social style) added to the desktop nav, linking to /stargazers.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![GauntletCI](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/EricCogen/db3979f1a5d69ce37d425b73bdcf4ada/raw/gauntletci-badge.json)](https://github.com/EricCogen/GauntletCI)
 [![GitHub last commit](https://img.shields.io/github/last-commit/EricCogen/GauntletCI)](https://github.com/EricCogen/GauntletCI/commits/main)
 [![GitHub stars](https://img.shields.io/github/stars/EricCogen/GauntletCI?style=social)](https://github.com/EricCogen/GauntletCI/stargazers)
+[![NuGet downloads](https://img.shields.io/nuget/dt/GauntletCI?label=NuGet)](https://www.nuget.org/packages/GauntletCI)
 [![License](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](LICENSE)
 
 ---


### PR DESCRIPTION
Adds NuGet total downloads badge (shields.io) to the README badge row, linking to https://www.nuget.org/packages/GauntletCI.

Closes growth-nuget-shield todo.