### PR TITLE
[INFRA] Add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,42 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    paths:
+      - "site/**"
+      - ".github/workflows/lighthouse.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "site/**"
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./site/.lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/site/.lighthouserc.json
+++ b/site/.lighthouserc.json
@@ -1,0 +1,25 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./out",
+      "url": [
+        "http://localhost/",
+        "http://localhost/about/",
+        "http://localhost/releases/"
+      ],
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "preset": "lighthouse:no-pwa",
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.8 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.85 }],
+        "categories:seo": ["error", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
Adds automated Lighthouse CI scoring on every site change.

## What
- \.github/workflows/lighthouse.yml\: triggers on \site/**\ PRs and main pushes; builds static export then runs Lighthouse CI
- \site/.lighthouserc.json\: tests \/\, \/about/\, \/releases/\ against the static \out/\ directory

## Assertions
| Category | Threshold | Failure mode |
|---|---|---|
| Accessibility | >= 0.9 | error (blocks merge) |
| SEO | >= 0.9 | error (blocks merge) |
| Performance | >= 0.8 | warning |
| Best Practices | >= 0.85 | warning |

Reports upload to temporary-public-storage and as GitHub artifacts.

## Tests
- 1197 passing (0 failures)
- GauntletCI self-analysis: 0 findings