### PR TITLE
[INFRA] Bump action.yml default gauntletci-version to 2.1.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
   gauntletci-version:
     description: "The GauntletCI NuGet tool version to install."
     required: false
-    default: "2.1.0"
+    default: "2.1.1"
 
 outputs:
   findings-count:


### PR DESCRIPTION
Updates the \gauntletci-version\ default from \2.1.0\ to \2.1.1\ in \ction.yml\.

Also done in GauntletCI-Demo: bumped \gauntlet.yml\ version pin from 2.0.3 to 2.1.1 and merged Dependabot upgrades for actions/checkout v6.0.2 and actions/setup-dotnet v5.2.0 (clears Node.js 20 deprecation warnings).