### PR TITLE
[DOCS] Add husky, dotnet-husky, and Lefthook integration guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ artifacts/
 !docs/risky-diffs/stackexchange-redis-context-mutation.md
 !docs/risky-diffs/sharpcompress-overflow.md
 !docs/risky-diffs/anglesharp-enum-removal.md
+!docs/integrations/husky.md
+!docs/integrations/dotnet-husky.md
+!docs/integrations/lefthook.md
 
 # Publish artifacts (self-contained EXE - too large for GitHub)
 publish/

--- a/docs/integrations/dotnet-husky.md
+++ b/docs/integrations/dotnet-husky.md
@@ -1,0 +1,87 @@
+# GauntletCI + dotnet-husky
+
+[dotnet-husky](https://alirezanet.github.io/Husky.Net/) is a .NET-native git hooks manager that
+stores hooks in `.husky/` and installs them via `dotnet husky install`. This guide wires
+GauntletCI into a pre-commit hook so every commit is analyzed before it lands.
+
+## Prerequisites
+
+- .NET 8+ SDK
+- GauntletCI CLI: `dotnet tool install -g GauntletCI`
+- dotnet-husky: `dotnet tool install -g Husky`
+
+## Setup
+
+### 1. Initialize dotnet-husky
+
+```bash
+cd your-repo
+dotnet husky install
+```
+
+This creates `.husky/` and adds a `prepare` target to your project.
+
+### 2. Add the pre-commit task
+
+Create `.husky/task-runner.json` (or add to the existing one):
+
+```json
+{
+  "tasks": [
+    {
+      "name": "GauntletCI",
+      "command": "gauntletci",
+      "args": ["analyze", "--sensitivity", "balanced"],
+      "pathFilter": ["**/*.cs", "**/*.csproj", "**/*.sln", "**/*.slnx"],
+      "output": "always"
+    }
+  ]
+}
+```
+
+### 3. Run the task runner from the hook
+
+`.husky/pre-commit`:
+
+```bash
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+dotnet husky run --name GauntletCI
+```
+
+### 4. Verify
+
+```bash
+git commit --allow-empty -m "test: verify GauntletCI hook"
+```
+
+You should see GauntletCI output before the commit completes.
+
+## Configuration
+
+Any valid GauntletCI arguments work in `args`. Examples:
+
+```json
+"args": ["analyze", "--sensitivity", "strict"]
+"args": ["analyze", "--sensitivity", "permissive", "--output", "text"]
+```
+
+To use a custom config file: `"args": ["analyze", "--config", ".gauntletci.json"]`
+
+## Team setup
+
+Add both `dotnet tool restore` and `dotnet husky install` to your CI setup step so
+every developer gets the hook automatically after cloning:
+
+```yaml
+- run: dotnet tool restore
+- run: dotnet husky install
+```
+
+Or add to a `.NET restore` target in your build script.
+
+## Links
+
+- [dotnet-husky docs](https://alirezanet.github.io/Husky.Net/)
+- [GauntletCI CLI reference](https://gauntletci.com/docs/cli)
+- [GauntletCI configuration](https://gauntletci.com/docs/configuration)

--- a/docs/integrations/husky.md
+++ b/docs/integrations/husky.md
@@ -1,0 +1,77 @@
+# GauntletCI + husky
+
+[husky](https://typicode.github.io/husky/) is the most popular git hooks manager for
+JavaScript and TypeScript projects. This guide wires GauntletCI into a `pre-commit` hook
+for repos that use a Node.js toolchain alongside .NET code (monorepos, full-stack apps).
+
+## Prerequisites
+
+- .NET 8+ SDK
+- GauntletCI CLI: `dotnet tool install -g GauntletCI`
+- husky: `npm install --save-dev husky`
+
+## Setup
+
+### 1. Initialize husky
+
+```bash
+npx husky init
+```
+
+This creates `.husky/pre-commit` with a sample hook.
+
+### 2. Replace the pre-commit hook
+
+`.husky/pre-commit`:
+
+```sh
+#!/bin/sh
+gauntletci analyze --sensitivity balanced
+```
+
+That is all that is needed. GauntletCI exits 1 on block-level findings, which
+causes husky to abort the commit.
+
+### 3. Make it configurable per developer
+
+If team members run different sensitivity levels, use an env var:
+
+```sh
+#!/bin/sh
+SENSITIVITY="${GAUNTLETCI_SENSITIVITY:-balanced}"
+gauntletci analyze --sensitivity "$SENSITIVITY"
+```
+
+### 4. Verify
+
+```bash
+git add .
+git commit -m "test: verify GauntletCI hook"
+```
+
+### 5. Share with the team
+
+Add the `prepare` script to `package.json` so the hook installs for every developer
+after `npm install`:
+
+```json
+{
+  "scripts": {
+    "prepare": "husky"
+  }
+}
+```
+
+## Skipping the hook
+
+Individual developers can skip the hook for a commit when needed:
+
+```bash
+HUSKY=0 git commit -m "..."
+```
+
+## Links
+
+- [husky docs](https://typicode.github.io/husky/)
+- [GauntletCI CLI reference](https://gauntletci.com/docs/cli)
+- [GauntletCI configuration](https://gauntletci.com/docs/configuration)

--- a/docs/integrations/lefthook.md
+++ b/docs/integrations/lefthook.md
@@ -1,0 +1,89 @@
+# GauntletCI + Lefthook
+
+[Lefthook](https://github.com/evilmartians/lefthook) is a fast, cross-platform git hooks
+manager with no Node.js dependency. It is a good fit for pure .NET repositories.
+
+## Prerequisites
+
+- .NET 8+ SDK
+- GauntletCI CLI: `dotnet tool install -g GauntletCI`
+- Lefthook: see [installation options](https://github.com/evilmartians/lefthook/blob/master/docs/install.md)
+
+Common install methods:
+
+```bash
+# via npm
+npm install --save-dev lefthook
+
+# via Homebrew (macOS/Linux)
+brew install lefthook
+
+# via Scoop (Windows)
+scoop install lefthook
+```
+
+## Setup
+
+### 1. Initialize
+
+```bash
+lefthook install
+```
+
+### 2. Configure `lefthook.yml`
+
+Create `lefthook.yml` in the repository root:
+
+```yaml
+pre-commit:
+  commands:
+    gauntletci:
+      run: gauntletci analyze --sensitivity balanced
+      glob: "*.cs"
+```
+
+The `glob` filter means Lefthook only runs GauntletCI when `.cs` files are staged.
+Remove it to run on every commit regardless of staged files.
+
+### 3. Verify
+
+```bash
+lefthook run pre-commit
+```
+
+## Parallel execution
+
+Lefthook supports running hooks in parallel. To run GauntletCI alongside other hooks:
+
+```yaml
+pre-commit:
+  parallel: true
+  commands:
+    gauntletci:
+      run: gauntletci analyze --sensitivity balanced
+      glob: "*.cs"
+    dotnet-format:
+      run: dotnet format --verify-no-changes
+      glob: "*.cs"
+```
+
+## Per-environment sensitivity
+
+```yaml
+pre-commit:
+  commands:
+    gauntletci:
+      run: gauntletci analyze --sensitivity {GAUNTLETCI_SENSITIVITY:-balanced}
+```
+
+## Team setup
+
+Commit `lefthook.yml` to the repository. Each developer runs `lefthook install` once
+after cloning. You can automate this via a `dotnet restore` target or project `targets`
+in your `.csproj`.
+
+## Links
+
+- [Lefthook docs](https://github.com/evilmartians/lefthook)
+- [GauntletCI CLI reference](https://gauntletci.com/docs/cli)
+- [GauntletCI configuration](https://gauntletci.com/docs/configuration)


### PR DESCRIPTION
Adds integration guide docs for three git hooks managers:

- \docs/integrations/husky.md\: husky pre-commit hook setup
- \docs/integrations/dotnet-husky.md\: dotnet-husky task-runner.json config
- \docs/integrations/lefthook.md\: lefthook.yml config with parallel execution example

Also adds the three files to the .gitignore allowlist.