### PR TITLE
[INFRA] Fix Lighthouse CI to use staticDistDir for static export

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@v12
         with:
-          configPath: ./site/.lighthouserc.json
+          configPath: ./.lighthouserc.json
           uploadArtifacts: true
           temporaryPublicStorage: true
+          staticDistDir: ./out


### PR DESCRIPTION
Fix the Lighthouse CI workflow to properly audit the Next.js static export instead of trying to connect to a non-existent localhost server.

## Problem

The workflow was failing with:
\\\
Runtime error: Lighthouse was unable to reliably load the page you requested. (Status code: 404)
\\\

This happened because:
1. The configPath was pointing to ./site/.lighthouserc.json but working directory is already site/
2. No web server was running on localhost to serve the pages being audited
3. Lighthouse CI was trying to use HTTP to access pages instead of directly reading the static export

## Solution

- Added \staticDistDir: ./out\ parameter to tell Lighthouse CI to serve the static export
- Fixed configPath to use correct relative path \./.lighthouserc.json\
- Lighthouse CI now audits pages directly from the built output instead of via HTTP

## Testing

- Workflow should now successfully audit /, /about/, and /releases/
- Reports will be uploaded to temporary-public-storage as before
- All Lighthouse assertions (accessibility, SEO, performance, best-practices) remain unchanged