### PR TITLE
Fix zero-finding Action output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
   gauntletci-version:
     description: "The GauntletCI NuGet tool version to install."
     required: false
-    default: "2.1.1"
+    default: "2.7.1"
 
 outputs:
   findings-count:
@@ -78,7 +78,8 @@ runs:
         gauntletci $args 2>&1 | tee "$TMPFILE"
         EXIT_CODE=$?
         set +o pipefail
-        FINDINGS=$(grep -cE 'GCI[0-9]{4}' "$TMPFILE" 2>/dev/null || echo "0")
+        FINDINGS=$(grep -cE 'GCI[0-9]{4}' "$TMPFILE" 2>/dev/null || true)
+        FINDINGS="${FINDINGS:-0}"
         rm -f "$TMPFILE"
         echo "findings-count=$FINDINGS" >> "$GITHUB_OUTPUT"
         [ "${{ inputs.fail-on-findings }}" = "true" ] && exit $EXIT_CODE

--- a/src/GauntletCI.Cli/Hooks/gauntletci-hook.sh
+++ b/src/GauntletCI.Cli/Hooks/gauntletci-hook.sh
@@ -35,9 +35,12 @@ if [ $HAS_JQ -eq 1 ]; then
     MEDIUM_COUNT=$(echo "$OUTPUT" | jq '[.Findings[] | select(.Confidence == 1)] | length')
     LOW_COUNT=$(echo "$OUTPUT" | jq '[.Findings[] | select(.Confidence == 0)] | length')
 else
-    HIGH_COUNT=$(echo "$OUTPUT" | grep -c '"Confidence": 2' || echo 0)
-    MEDIUM_COUNT=$(echo "$OUTPUT" | grep -c '"Confidence": 1' || echo 0)
-    LOW_COUNT=$(echo "$OUTPUT" | grep -c '"Confidence": 0' || echo 0)
+    HIGH_COUNT=$(echo "$OUTPUT" | grep -c '"Confidence": 2' || true)
+    MEDIUM_COUNT=$(echo "$OUTPUT" | grep -c '"Confidence": 1' || true)
+    LOW_COUNT=$(echo "$OUTPUT" | grep -c '"Confidence": 0' || true)
+    HIGH_COUNT="${HIGH_COUNT:-0}"
+    MEDIUM_COUNT="${MEDIUM_COUNT:-0}"
+    LOW_COUNT="${LOW_COUNT:-0}"
 fi
 
 TOTAL=$((HIGH_COUNT + MEDIUM_COUNT + LOW_COUNT))


### PR DESCRIPTION
## Summary
- Fix the GitHub Action findings-count output when GauntletCI reports zero findings
- Update the Action default NuGet tool version to 2.7.1
- Fix the bundled Bash pre-commit hook fallback counting path so zero matches stay a single numeric zero

## Validation
- dotnet build src/GauntletCI.Cli/GauntletCI.Cli.csproj --configuration Release
- git diff --check -- action.yml src/GauntletCI.Cli/Hooks/gauntletci-hook.sh

Note: local WSL2 has no installed distro, so bash execution was validated through GitHub Actions/CI rather than local WSL.