### PR TITLE
feat(platform): delivery, domain gating, and paired-implementation rule

### DIFF
--- a/src/GauntletCI.Core/Analysis/DiffProvenanceAnalyzer.cs
+++ b/src/GauntletCI.Core/Analysis/DiffProvenanceAnalyzer.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.RegularExpressions;
+using GauntletCI.Core.Diff;
+
+namespace GauntletCI.Core.Analysis;
+
+/// <summary>
+/// Classifies added diff lines as net-new vs relocated by matching normalized content against removed lines (PG-PROVENANCE).
+/// </summary>
+public static class DiffProvenanceAnalyzer
+{
+    private static readonly Regex WhitespaceCollapse = new(@"\s+", RegexOptions.Compiled);
+
+    /// <summary>Lookup of added line locations classified as relocated code.</summary>
+    public sealed class Index
+    {
+        private readonly HashSet<(string File, int Line)> _relocatedAddedLines;
+
+        internal Index(HashSet<(string File, int Line)> relocatedAddedLines)
+        {
+            _relocatedAddedLines = relocatedAddedLines;
+        }
+
+        /// <summary>Returns true when the added line at <paramref name="filePath"/>:<paramref name="line"/> matches a removed line.</summary>
+        public bool IsRelocated(string? filePath, int line)
+        {
+            if (string.IsNullOrEmpty(filePath))
+                return false;
+
+            return _relocatedAddedLines.Contains((NormalizePath(filePath), line));
+        }
+    }
+
+    /// <summary>Builds a provenance index for all added lines in <paramref name="diff"/>.</summary>
+    public static Index Build(DiffContext diff)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+
+        var removedBuckets = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var file in diff.Files)
+        {
+            foreach (var line in file.RemovedLines)
+            {
+                var normalized = NormalizeLine(line.Content);
+                if (normalized.Length == 0)
+                    continue;
+
+                removedBuckets.TryGetValue(normalized, out var count);
+                removedBuckets[normalized] = count + 1;
+            }
+        }
+
+        var relocated = new HashSet<(string File, int Line)>();
+        foreach (var file in diff.Files)
+        {
+            var filePath = NormalizePath(file.NewPath);
+            foreach (var line in file.AddedLines)
+            {
+                var normalized = NormalizeLine(line.Content);
+                if (normalized.Length == 0)
+                    continue;
+
+                if (!removedBuckets.TryGetValue(normalized, out var remaining) || remaining <= 0)
+                    continue;
+
+                removedBuckets[normalized] = remaining - 1;
+                relocated.Add((filePath, line.LineNumber));
+            }
+        }
+
+        return new Index(relocated);
+    }
+
+    internal static string NormalizeLine(string content)
+    {
+        var trimmed = content.Trim();
+        if (trimmed.Length == 0)
+            return string.Empty;
+
+        var commentIndex = trimmed.IndexOf("//", StringComparison.Ordinal);
+        if (commentIndex >= 0)
+            trimmed = trimmed[..commentIndex].TrimEnd();
+
+        return WhitespaceCollapse.Replace(trimmed, " ");
+    }
+
+    private static string NormalizePath(string path) =>
+        path.Replace('\\', '/').TrimStart('/');
+}

--- a/src/GauntletCI.Core/Analysis/PairedImplementationAnalyzer.cs
+++ b/src/GauntletCI.Core/Analysis/PairedImplementationAnalyzer.cs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.RegularExpressions;
+using GauntletCI.Core.Diff;
+
+namespace GauntletCI.Core.Analysis;
+
+/// <summary>
+/// Detects sibling class implementations that apply opposite boolean polarity to the same predicate (PG-RELATION).
+/// </summary>
+internal static class PairedImplementationAnalyzer
+{
+    private static readonly Regex ClassDeclarationRegex =
+        new(@"\b(?:class|record|struct)\s+(\w+)", RegexOptions.Compiled);
+
+    private static readonly Regex MethodDeclarationRegex =
+        new(@"\b(?:public|private|protected|internal)\s+(?:static\s+)?(?:override\s+)?(?:async\s+)?[\w<>\[\]?]+\s+(\w+)\s*\(",
+            RegexOptions.Compiled);
+
+    private static readonly Regex IfConditionRegex =
+        new(@"if\s*\((.+?)\)", RegexOptions.Compiled);
+
+    internal sealed record ConditionObservation(
+        string ClassName,
+        string MethodName,
+        int LineNumber,
+        string Condition,
+        string Callee,
+        bool IsNegated,
+        bool IsAddedLine);
+
+    internal static IReadOnlyList<ConditionObservation> AnalyzeFile(DiffFile file)
+    {
+        var observations = new List<ConditionObservation>();
+        var orderedLines = file.Hunks
+            .SelectMany(h => h.Lines)
+            .Where(l => l.Kind is DiffLineKind.Added or DiffLineKind.Context)
+            .OrderBy(l => l.LineNumber)
+            .ToList();
+
+        string? currentClass = null;
+        string? currentMethod = null;
+
+        foreach (var line in orderedLines)
+        {
+            var content = line.Content;
+            var classMatch = ClassDeclarationRegex.Match(content);
+            if (classMatch.Success)
+                currentClass = classMatch.Groups[1].Value;
+
+            var methodMatch = MethodDeclarationRegex.Match(content);
+            if (methodMatch.Success)
+                currentMethod = methodMatch.Groups[1].Value;
+
+            if (currentClass is null || currentMethod is null)
+                continue;
+
+            if (!IfConditionRegex.IsMatch(content))
+                continue;
+
+            foreach (var extracted in ExtractConditions(content))
+            {
+                observations.Add(new ConditionObservation(
+                    currentClass,
+                    currentMethod,
+                    line.LineNumber,
+                    extracted.Condition,
+                    extracted.Callee,
+                    extracted.IsNegated,
+                    line.Kind == DiffLineKind.Added));
+            }
+        }
+
+        return observations;
+    }
+
+    internal static IReadOnlyList<(ConditionObservation Left, ConditionObservation Right)> FindPolarityMismatches(
+        IReadOnlyList<ConditionObservation> observations)
+    {
+        var mismatches = new List<(ConditionObservation, ConditionObservation)>();
+
+        var groups = observations
+            .GroupBy(o => (o.MethodName, o.Callee))
+            .Where(g => g.Select(x => x.ClassName).Distinct(StringComparer.Ordinal).Count() >= 2);
+
+        foreach (var group in groups)
+        {
+            var byClass = group
+                .GroupBy(o => o.ClassName, StringComparer.Ordinal)
+                .Select(g => g.OrderByDescending(o => o.IsAddedLine).ThenByDescending(o => o.LineNumber).First())
+                .ToList();
+
+            for (var i = 0; i < byClass.Count; i++)
+            {
+                for (var j = i + 1; j < byClass.Count; j++)
+                {
+                    var left = byClass[i];
+                    var right = byClass[j];
+                    if (left.IsNegated == right.IsNegated)
+                        continue;
+
+                    var preferred = left.IsAddedLine ? left : right.IsAddedLine ? right : left;
+                    var reference = ReferenceEquals(preferred, left) ? right : left;
+                    mismatches.Add((preferred, reference));
+                }
+            }
+        }
+
+        return mismatches;
+    }
+
+    private static IEnumerable<(string Condition, string Callee, bool IsNegated)> ExtractConditions(string line)
+    {
+        var ifMatch = IfConditionRegex.Match(line);
+        if (!ifMatch.Success)
+            yield break;
+
+        var condition = ifMatch.Groups[1].Value.Trim();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (Match pattern in Regex.Matches(condition, @"(\w+)\s*:\s*(true|false)\b", RegexOptions.IgnoreCase))
+        {
+            var member = pattern.Groups[1].Value;
+            if (!IsBooleanMember(member) || !seen.Add(member))
+                continue;
+
+            var expectsTrue = pattern.Groups[2].Value.Equals("true", StringComparison.OrdinalIgnoreCase);
+            yield return (condition, member, !expectsTrue);
+        }
+
+        foreach (Match call in Regex.Matches(condition, @"(!)?\s*([A-Za-z_][A-Za-z0-9_]*)\s*\("))
+        {
+            var callee = call.Groups[2].Value;
+            if (!IsBooleanMember(callee) || !seen.Add(callee))
+                continue;
+
+            var negated = call.Groups[1].Success
+                || Regex.IsMatch(condition, $@"{callee}\s*\([^)]*\)\s*==\s*false", RegexOptions.CultureInvariant);
+
+            yield return (condition, callee, negated);
+        }
+
+        foreach (Match prop in Regex.Matches(condition, @"\.(?<member>Is[A-Z]\w+)\b"))
+        {
+            var member = prop.Groups["member"].Value;
+            if (!seen.Add(member))
+                continue;
+
+            var negated = Regex.IsMatch(condition, $@"(?<![:\w])!{member}\b|{member}\s*==\s*false", RegexOptions.CultureInvariant);
+            yield return (condition, member, negated);
+        }
+    }
+
+    private static bool IsBooleanMember(string name) =>
+        name.StartsWith("Is", StringComparison.Ordinal) ||
+        name.EndsWith("Connected", StringComparison.Ordinal) ||
+        name.EndsWith("Enabled", StringComparison.Ordinal);
+}

--- a/src/GauntletCI.Core/Analysis/PairedImplementationAnalyzer.cs
+++ b/src/GauntletCI.Core/Analysis/PairedImplementationAnalyzer.cs
@@ -45,11 +45,11 @@ internal static class PairedImplementationAnalyzer
             var content = line.Content;
             var classMatch = ClassDeclarationRegex.Match(content);
             if (classMatch.Success)
-                currentClass = classMatch.Groups[1].Value;
+                currentClass = classMatch.Groups[1].Value!;
 
             var methodMatch = MethodDeclarationRegex.Match(content);
             if (methodMatch.Success)
-                currentMethod = methodMatch.Groups[1].Value;
+                currentMethod = methodMatch.Groups[1].Value!;
 
             if (currentClass is null || currentMethod is null)
                 continue;
@@ -89,12 +89,13 @@ internal static class PairedImplementationAnalyzer
                 .Select(g => g.OrderByDescending(o => o.IsAddedLine).ThenByDescending(o => o.LineNumber).First())
                 .ToList();
 
-            for (var i = 0; i < byClass.Count; i++)
+            var n = byClass.Count;
+            for (var a = 0; a < n; a++)
             {
-                for (var j = i + 1; j < byClass.Count; j++)
+                for (var b = a + 1; b < n; b++)
                 {
-                    var left = byClass[i];
-                    var right = byClass[j];
+                    var left = byClass[a];
+                    var right = byClass[b];
                     if (left.IsNegated == right.IsNegated)
                         continue;
 
@@ -114,22 +115,22 @@ internal static class PairedImplementationAnalyzer
         if (!ifMatch.Success)
             yield break;
 
-        var condition = ifMatch.Groups[1].Value.Trim();
+        var condition = ifMatch.Groups[1].Value!.Trim();
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (Match pattern in Regex.Matches(condition, @"(\w+)\s*:\s*(true|false)\b", RegexOptions.IgnoreCase))
         {
-            var member = pattern.Groups[1].Value;
+            var member = pattern.Groups[1].Value!;
             if (!IsBooleanMember(member) || !seen.Add(member))
                 continue;
 
-            var expectsTrue = pattern.Groups[2].Value.Equals("true", StringComparison.OrdinalIgnoreCase);
+            var expectsTrue = pattern.Groups[2].Value!.Equals("true", StringComparison.OrdinalIgnoreCase);
             yield return (condition, member, !expectsTrue);
         }
 
         foreach (Match call in Regex.Matches(condition, @"(!)?\s*([A-Za-z_][A-Za-z0-9_]*)\s*\("))
         {
-            var callee = call.Groups[2].Value;
+            var callee = call.Groups[2].Value!;
             if (!IsBooleanMember(callee) || !seen.Add(callee))
                 continue;
 
@@ -141,7 +142,7 @@ internal static class PairedImplementationAnalyzer
 
         foreach (Match prop in Regex.Matches(condition, @"\.(?<member>Is[A-Z]\w+)\b"))
         {
-            var member = prop.Groups["member"].Value;
+            var member = prop.Groups["member"].Value!;
             if (!seen.Add(member))
                 continue;
 

--- a/src/GauntletCI.Core/Analysis/RepoDomainClassifier.cs
+++ b/src/GauntletCI.Core/Analysis/RepoDomainClassifier.cs
@@ -118,7 +118,12 @@ public static class RepoDomainClassifier
                     continue;
 
                 string xml;
-                try { xml = File.ReadAllText(csproj); }
+                try
+                {
+                    using var stream = File.OpenRead(csproj);
+                    using var reader = new StreamReader(stream);
+                    xml = reader.ReadToEnd();
+                }
                 catch (IOException) { continue; }
 
                 if (WebProjectMarkers.Any(m => xml.Contains(m, StringComparison.OrdinalIgnoreCase)))

--- a/src/GauntletCI.Core/Analysis/RepoDomainClassifier.cs
+++ b/src/GauntletCI.Core/Analysis/RepoDomainClassifier.cs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Diff;
+
+namespace GauntletCI.Core.Analysis;
+
+/// <summary>
+/// Classifies a repository as web host vs class library to suppress web/DI rule noise (RC-4 / PG-DOMAIN).
+/// </summary>
+public static class RepoDomainClassifier
+{
+    private static readonly string[] WebProjectMarkers =
+    [
+        "Microsoft.NET.Sdk.Web",
+        "Microsoft.AspNetCore.App",
+        "Microsoft.AspNetCore.Mvc",
+        "Microsoft.AspNetCore.Hosting",
+        "Microsoft.AspNetCore.Authentication",
+        "Microsoft.AspNetCore.Routing",
+    ];
+
+    private static readonly string[] WebDiffMarkers =
+    [
+        "[HttpPost]",
+        "[HttpGet]",
+        "[HttpPut]",
+        "[HttpDelete]",
+        "[ApiController]",
+        "WebApplication.CreateBuilder",
+        "AddControllers(",
+        "MapControllers(",
+        "AddEndpointsApiExplorer",
+        "UseAuthentication(",
+        "UseAuthorization(",
+    ];
+
+    /// <summary>Classifies the repo using config override, on-disk csproj scan, and diff heuristics.</summary>
+    public static RepoDomainProfile Classify(string? repoPath, DiffContext diff, RepoDomainConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (TryParseOverride(config.Profile, out var overrideKind))
+        {
+            return new RepoDomainProfile
+            {
+                Kind = overrideKind,
+                Reason = $"Configured domain profile override: {config.Profile}",
+            };
+        }
+
+        var (webProjects, libraryProjects) = ScanProjects(repoPath);
+        if (webProjects > 0)
+        {
+            return new RepoDomainProfile
+            {
+                Kind = RepoDomainKind.WebApplication,
+                Reason = $"Detected {webProjects} ASP.NET/web project(s) under repository root.",
+            };
+        }
+
+        if (libraryProjects > 0 && !DiffContainsWebSignals(diff))
+        {
+            return new RepoDomainProfile
+            {
+                Kind = RepoDomainKind.ClassLibrary,
+                Reason = $"Detected {libraryProjects} non-web .csproj file(s) with no ASP.NET markers in diff.",
+            };
+        }
+
+        if (DiffContainsWebSignals(diff))
+        {
+            return new RepoDomainProfile
+            {
+                Kind = RepoDomainKind.WebApplication,
+                Reason = "Diff contains ASP.NET controller or host composition markers.",
+            };
+        }
+
+        return new RepoDomainProfile
+        {
+            Kind = RepoDomainKind.Unknown,
+            Reason = "Insufficient signals to classify repository domain.",
+        };
+    }
+
+    private static bool TryParseOverride(string profile, out RepoDomainKind kind)
+    {
+        if (profile.Equals("library", StringComparison.OrdinalIgnoreCase))
+        {
+            kind = RepoDomainKind.ClassLibrary;
+            return true;
+        }
+
+        if (profile.Equals("web", StringComparison.OrdinalIgnoreCase))
+        {
+            kind = RepoDomainKind.WebApplication;
+            return true;
+        }
+
+        kind = RepoDomainKind.Unknown;
+        return false;
+    }
+
+    private static (int WebProjects, int LibraryProjects) ScanProjects(string? repoPath)
+    {
+        if (string.IsNullOrEmpty(repoPath) || !Directory.Exists(repoPath))
+            return (0, 0);
+
+        var web = 0;
+        var library = 0;
+
+        try
+        {
+            foreach (var csproj in Directory.EnumerateFiles(repoPath, "*.csproj", SearchOption.AllDirectories))
+            {
+                if (IsUnderExcludedFolder(csproj))
+                    continue;
+
+                string xml;
+                try { xml = File.ReadAllText(csproj); }
+                catch (IOException) { continue; }
+
+                if (WebProjectMarkers.Any(m => xml.Contains(m, StringComparison.OrdinalIgnoreCase)))
+                {
+                    web++;
+                    continue;
+                }
+
+                if (xml.Contains("<Project", StringComparison.OrdinalIgnoreCase))
+                    library++;
+            }
+        }
+        catch (Exception)
+        {
+            // Best-effort classification only
+        }
+
+        return (web, library);
+    }
+
+    private static bool IsUnderExcludedFolder(string path)
+    {
+        var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return parts.Any(p =>
+            p.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+            p.Equals("obj", StringComparison.OrdinalIgnoreCase) ||
+            p.Equals("node_modules", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool DiffContainsWebSignals(DiffContext diff) =>
+        diff.Files.Any(f =>
+            f.AddedLines.Any(l =>
+                WebDiffMarkers.Any(m => l.Content.Contains(m, StringComparison.Ordinal))));
+}

--- a/src/GauntletCI.Core/Analysis/RepoDomainKind.cs
+++ b/src/GauntletCI.Core/Analysis/RepoDomainKind.cs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Core.Analysis;
+
+/// <summary>High-level repository domain used to gate web/DI-specific rules (PG-DOMAIN).</summary>
+public enum RepoDomainKind
+{
+    /// <summary>Could not classify; domain rules are not suppressed.</summary>
+    Unknown = 0,
+
+    /// <summary>Class library, client SDK, or infrastructure package without ASP.NET host.</summary>
+    ClassLibrary = 1,
+
+    /// <summary>Web app, API host, or ASP.NET composition root.</summary>
+    WebApplication = 2,
+}

--- a/src/GauntletCI.Core/Analysis/RepoDomainProfile.cs
+++ b/src/GauntletCI.Core/Analysis/RepoDomainProfile.cs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Core.Analysis;
+
+/// <summary>Result of <see cref="RepoDomainClassifier"/> for the current evaluation.</summary>
+public sealed class RepoDomainProfile
+{
+    public RepoDomainKind Kind { get; init; } = RepoDomainKind.Unknown;
+
+    /// <summary>Human-readable explanation of how the profile was resolved.</summary>
+    public string Reason { get; init; } = string.Empty;
+
+    public bool IsClassLibrary => Kind == RepoDomainKind.ClassLibrary;
+
+    public bool IsWebApplication => Kind == RepoDomainKind.WebApplication;
+}

--- a/src/GauntletCI.Core/Configuration/ConfigurationService.cs
+++ b/src/GauntletCI.Core/Configuration/ConfigurationService.cs
@@ -24,9 +24,13 @@ public sealed class ConfigurationService
         @"^\s*dotnet_diagnostic\.(GCI\d+)\.severity\s*=\s*(\w+)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    /// <summary>Repository root passed at construction; used for domain classification and .editorconfig resolution.</summary>
+    public string? RepoPath { get; }
+
     public ConfigurationService(GauntletConfig config, string? repoPath = null)
     {
         _config = config;
+        RepoPath = repoPath;
         _editorConfigOverrides = repoPath is not null
             ? ParseEditorConfig(repoPath)
             : new Dictionary<string, RuleSeverity>();

--- a/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
+++ b/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
@@ -52,6 +52,7 @@ internal static class DefaultSeverities
             ["GCI0047"] = RuleSeverity.Info,
             ["GCI0049"] = RuleSeverity.Info,
             ["GCI0056"] = RuleSeverity.Info,
+            ["GCI0058"] = RuleSeverity.Block,
 
             // None: disabled by default (duplicate coverage elsewhere)
             ["GCI0054"] = RuleSeverity.None, // duplicate coverage — see GCI0016

--- a/src/GauntletCI.Core/Configuration/FindingDeliveryConfig.cs
+++ b/src/GauntletCI.Core/Configuration/FindingDeliveryConfig.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Core.Configuration;
+
+/// <summary>
+/// Controls post-rule finding delivery: per-rule caps, global limits, ranking, and file-level demotion.
+/// Part of platform gap PG-DELIVERY.
+/// </summary>
+public class FindingDeliveryConfig
+{
+    /// <summary>When false, findings pass through unchanged (coordination and caps skipped).</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Maximum findings returned after ranking. Additional findings are dropped.</summary>
+    public int GlobalMaxFindings { get; set; } = 25;
+
+    /// <summary>Default cap per (rule, file) group before global ranking.</summary>
+    public int DefaultPerRulePerFileCap { get; set; } = 5;
+
+    /// <summary>Per-rule overrides for noisy rules (key: rule ID, value: max findings per file).</summary>
+    public Dictionary<string, int> PerRulePerFileCap { get; set; } = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["GCI0038"] = 3,
+        ["GCI0043"] = 3,
+        ["GCI0006"] = 5,
+        ["GCI0044"] = 3,
+    };
+
+    /// <summary>
+    /// File-level-only findings from these rules are dropped when any line-anchored finding exists.
+    /// </summary>
+    public string[] FileLevelRulesToDemote { get; set; } = ["GCI0001", "GCI0003"];
+}

--- a/src/GauntletCI.Core/Configuration/GauntletConfig.cs
+++ b/src/GauntletCI.Core/Configuration/GauntletConfig.cs
@@ -46,6 +46,9 @@ public class GauntletConfig
     /// <summary>Default output and display settings.</summary>
     public OutputConfig Output { get; set; } = new();
 
+    /// <summary>Repository domain classifier for suppressing web/DI rules on libraries.</summary>
+    public RepoDomainConfig Domain { get; set; } = new();
+
     /// <summary>Ticket provider integration settings (Jira, Linear, GitHub Issues).</summary>
     public TicketProviderConfig TicketProvider { get; set; } = new();
 
@@ -277,6 +280,9 @@ public class OutputConfig
 
     /// <summary>Output format: text, json, or sarif. Defaults to text. Equivalent to --output.</summary>
     public string Format { get; set; } = "text";
+
+    /// <summary>Finding delivery caps, ranking, and coordination for the analyze path.</summary>
+    public FindingDeliveryConfig Delivery { get; set; } = new();
 }
 
 /// <summary>Ticket provider integration settings.</summary>

--- a/src/GauntletCI.Core/Configuration/GauntletConfig.cs
+++ b/src/GauntletCI.Core/Configuration/GauntletConfig.cs
@@ -49,6 +49,9 @@ public class GauntletConfig
     /// <summary>Repository domain classifier for suppressing web/DI rules on libraries.</summary>
     public RepoDomainConfig Domain { get; set; } = new();
 
+    /// <summary>Diff provenance filter for suppressing findings on relocated lines (PG-PROVENANCE).</summary>
+    public ProvenanceConfig Provenance { get; set; } = new();
+
     /// <summary>Ticket provider integration settings (Jira, Linear, GitHub Issues).</summary>
     public TicketProviderConfig TicketProvider { get; set; } = new();
 

--- a/src/GauntletCI.Core/Configuration/ProvenanceConfig.cs
+++ b/src/GauntletCI.Core/Configuration/ProvenanceConfig.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Core.Configuration;
+
+/// <summary>
+/// Diff provenance settings (PG-PROVENANCE). Suppresses findings on added lines that match removed lines (RC-1).
+/// </summary>
+public class ProvenanceConfig
+{
+    /// <summary>When false, provenance filtering is skipped.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Rules that still fire when the anchored line is classified as relocated code.
+    /// Signature and cross-entity rules remain enabled by default.
+    /// </summary>
+    public string[] ExemptRules { get; set; } =
+    [
+        "GCI0003",
+        "GCI0058",
+    ];
+}

--- a/src/GauntletCI.Core/Configuration/RepoDomainConfig.cs
+++ b/src/GauntletCI.Core/Configuration/RepoDomainConfig.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Core.Configuration;
+
+/// <summary>
+/// Repo/domain classifier settings (PG-DOMAIN). Suppresses web/DI-specific rules on class libraries.
+/// </summary>
+public class RepoDomainConfig
+{
+    /// <summary>When false, domain gating is skipped.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Profile override: <c>auto</c> (default), <c>library</c>, or <c>web</c>.
+    /// </summary>
+    public string Profile { get; set; } = "auto";
+
+    /// <summary>
+    /// Rules dropped entirely on <see cref="Analysis.RepoDomainKind.ClassLibrary"/> repos.
+    /// </summary>
+    public string[] LibrarySuppressRules { get; set; } =
+    [
+        "GCI0022",
+        "GCI0038",
+        "GCI0046",
+        "GCI0024",
+        "GCI0035",
+    ];
+}

--- a/src/GauntletCI.Core/Rules/Delivery/DomainFindingProcessor.cs
+++ b/src/GauntletCI.Core/Rules/Delivery/DomainFindingProcessor.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Delivery;
+
+/// <summary>Suppresses web/DI-specific rule findings on class-library repositories (PG-DOMAIN).</summary>
+public static class DomainFindingProcessor
+{
+    /// <summary>Result of domain filtering.</summary>
+    public sealed class Result
+    {
+        public required IReadOnlyList<Finding> Findings { get; init; }
+        public int DroppedCount { get; init; }
+    }
+
+    /// <summary>
+    /// Removes findings for rules that assume a web/DI host when the repo is classified as a library.
+    /// </summary>
+    public static Result Apply(
+        IReadOnlyList<Finding> findings,
+        RepoDomainProfile profile,
+        RepoDomainConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(findings);
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!config.Enabled || !profile.IsClassLibrary || findings.Count == 0)
+        {
+            return new Result { Findings = findings.ToList(), DroppedCount = 0 };
+        }
+
+        var suppress = config.LibrarySuppressRules.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var kept = new List<Finding>(findings.Count);
+        var dropped = 0;
+
+        foreach (var finding in findings)
+        {
+            if (suppress.Contains(finding.RuleId))
+                dropped++;
+            else
+                kept.Add(finding);
+        }
+
+        return new Result { Findings = kept, DroppedCount = dropped };
+    }
+}

--- a/src/GauntletCI.Core/Rules/Delivery/FindingCoordinationEngine.cs
+++ b/src/GauntletCI.Core/Rules/Delivery/FindingCoordinationEngine.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Delivery;
+
+/// <summary>
+/// Ports Phase 21/23 rule coordinations from corpus silver labeling to the analyze path.
+/// Boosts confidence on related findings when compound-risk patterns are present.
+/// </summary>
+public static class FindingCoordinationEngine
+{
+    /// <summary>
+    /// Applies coordination boosts in-place. Returns the number of findings whose confidence increased.
+    /// </summary>
+    public static int Apply(IList<Finding> findings)
+    {
+        ArgumentNullException.ThrowIfNull(findings);
+        if (findings.Count == 0)
+            return 0;
+
+        var ruleIds = findings.Select(f => f.RuleId).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var boosts = 0;
+
+        boosts += ApplyAsyncExecutionCoordination(findings, ruleIds);
+        boosts += ApplyExceptionHandlingCoordination(findings, ruleIds);
+        boosts += ApplyResourceManagementCoordination(findings, ruleIds);
+        boosts += ApplyDataSecurityCoordination(findings, ruleIds);
+
+        return boosts;
+    }
+
+    private static int ApplyAsyncExecutionCoordination(IList<Finding> findings, HashSet<string> ruleIds)
+    {
+        if (!ruleIds.Contains("GCI0016"))
+            return 0;
+
+        var boosts = 0;
+        boosts += BoostRule(findings, "GCI0039", Confidence.Medium);
+        boosts += BoostRule(findings, "GCI0044", Confidence.Medium);
+        return boosts;
+    }
+
+    private static int ApplyExceptionHandlingCoordination(IList<Finding> findings, HashSet<string> ruleIds)
+    {
+        var boosts = 0;
+
+        if (ruleIds.Contains("GCI0032") && ruleIds.Contains("GCI0003"))
+        {
+            boosts += BoostRule(findings, "GCI0003", Confidence.High);
+            boosts += BoostRule(findings, "GCI0032", Confidence.Medium);
+        }
+
+        if (ruleIds.Contains("GCI0032") && ruleIds.Contains("GCI0016"))
+        {
+            boosts += BoostRule(findings, "GCI0016", Confidence.High);
+            boosts += BoostRule(findings, "GCI0032", Confidence.Medium);
+        }
+
+        return boosts;
+    }
+
+    private static int ApplyResourceManagementCoordination(IList<Finding> findings, HashSet<string> ruleIds)
+    {
+        if (!ruleIds.Contains("GCI0024") || !ruleIds.Contains("GCI0015"))
+            return 0;
+
+        var boosts = 0;
+        boosts += BoostRule(findings, "GCI0024", Confidence.Medium);
+        boosts += BoostRule(findings, "GCI0015", Confidence.Medium);
+        return boosts;
+    }
+
+    private static int ApplyDataSecurityCoordination(IList<Finding> findings, HashSet<string> ruleIds)
+    {
+        if (!ruleIds.Contains("GCI0015") || !ruleIds.Contains("GCI0029"))
+            return 0;
+
+        var boosts = 0;
+        boosts += BoostRule(findings, "GCI0015", Confidence.High);
+        boosts += BoostRule(findings, "GCI0029", Confidence.High);
+        return boosts;
+    }
+
+    private static int BoostRule(IList<Finding> findings, string ruleId, Confidence minimum)
+    {
+        var boosts = 0;
+        foreach (var finding in findings.Where(f => f.RuleId.Equals(ruleId, StringComparison.OrdinalIgnoreCase)))
+        {
+            if (finding.Confidence >= minimum)
+                continue;
+
+            finding.Confidence = minimum;
+            boosts++;
+        }
+
+        return boosts;
+    }
+}

--- a/src/GauntletCI.Core/Rules/Delivery/FindingDeliveryProcessor.cs
+++ b/src/GauntletCI.Core/Rules/Delivery/FindingDeliveryProcessor.cs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Delivery;
+
+/// <summary>
+/// Post-processes rule findings for delivery: coordination boosts, file-level demotion,
+/// per-rule caps, ranked output, and global limit.
+/// </summary>
+public static class FindingDeliveryProcessor
+{
+    /// <summary>Result of delivery processing including the filtered findings and summary metrics.</summary>
+    public sealed class Result
+    {
+        public required IReadOnlyList<Finding> Findings { get; init; }
+        public required FindingDeliverySummary Summary { get; init; }
+    }
+
+    /// <summary>
+    /// Applies delivery policy to <paramref name="findings"/> without mutating the input list.
+    /// </summary>
+    public static Result Apply(IReadOnlyList<Finding> findings, FindingDeliveryConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(findings);
+        ArgumentNullException.ThrowIfNull(config);
+
+        var inputCount = findings.Count;
+        if (!config.Enabled || inputCount == 0)
+        {
+            return new Result
+            {
+                Findings = findings.ToList(),
+                Summary = new FindingDeliverySummary
+                {
+                    InputCount = inputCount,
+                    OutputCount = inputCount,
+                },
+            };
+        }
+
+        var working = findings.Select(CloneFinding).ToList();
+        var coordinationBoosts = FindingCoordinationEngine.Apply(working);
+
+        var demoted = DemoteFileLevelFindings(working, config.FileLevelRulesToDemote);
+        var afterDemotion = working.Count;
+
+        var (capped, droppedByCap) = ApplyPerRulePerFileCaps(working, config);
+        var ranked = RankFindings(capped);
+        var (final, droppedByGlobal) = ApplyGlobalCap(ranked, config.GlobalMaxFindings);
+
+        return new Result
+        {
+            Findings = final,
+            Summary = new FindingDeliverySummary
+            {
+                InputCount = inputCount,
+                OutputCount = final.Count,
+                DroppedByFileLevelDemotion = demoted,
+                DroppedByPerRuleCap = droppedByCap,
+                DroppedByGlobalCap = droppedByGlobal,
+                CoordinationBoostsApplied = coordinationBoosts,
+            },
+        };
+    }
+
+    private static Finding CloneFinding(Finding source) => new()
+    {
+        RuleId = source.RuleId,
+        RuleName = source.RuleName,
+        Summary = source.Summary,
+        Evidence = source.Evidence,
+        WhyItMatters = source.WhyItMatters,
+        SuggestedAction = source.SuggestedAction,
+        Confidence = source.Confidence,
+        Severity = source.Severity,
+        SeverityOverride = source.SeverityOverride,
+        FilePath = source.FilePath,
+        Line = source.Line,
+        LlmExplanation = source.LlmExplanation,
+        ExpertContext = source.ExpertContext,
+        CodeSnippet = source.CodeSnippet,
+        CoverageNote = source.CoverageNote,
+        TicketContext = source.TicketContext,
+    };
+
+    private static int DemoteFileLevelFindings(List<Finding> findings, string[] rulesToDemote)
+    {
+        if (rulesToDemote.Length == 0)
+            return 0;
+
+        var hasLineAnchored = findings.Any(f => f.Line.HasValue);
+        if (!hasLineAnchored)
+            return 0;
+
+        var demoteSet = rulesToDemote.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var before = findings.Count;
+        findings.RemoveAll(f =>
+            demoteSet.Contains(f.RuleId) &&
+            !f.Line.HasValue);
+        return before - findings.Count;
+    }
+
+    private static (List<Finding> Kept, int Dropped) ApplyPerRulePerFileCaps(
+        List<Finding> findings,
+        FindingDeliveryConfig config)
+    {
+        var groups = findings
+            .GroupBy(f => $"{f.RuleId}|{f.FilePath ?? string.Empty}", StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var kept = new List<Finding>(findings.Count);
+        var dropped = 0;
+
+        foreach (var group in groups)
+        {
+            var ruleId = group.First().RuleId;
+            var cap = config.PerRulePerFileCap.TryGetValue(ruleId, out var ruleCap)
+                ? ruleCap
+                : config.DefaultPerRulePerFileCap;
+
+            var ordered = group
+                .OrderByDescending(ComputeDeliveryScore)
+                .ThenBy(f => f.Line ?? int.MaxValue)
+                .ToList();
+
+            kept.AddRange(ordered.Take(cap));
+            dropped += Math.Max(0, ordered.Count - cap);
+        }
+
+        return (kept, dropped);
+    }
+
+    private static List<Finding> RankFindings(IEnumerable<Finding> findings) =>
+        findings
+            .OrderByDescending(ComputeDeliveryScore)
+            .ThenBy(f => f.RuleId, StringComparer.Ordinal)
+            .ThenBy(f => f.FilePath ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(f => f.Line ?? int.MaxValue)
+            .ToList();
+
+    private static (List<Finding> Kept, int Dropped) ApplyGlobalCap(List<Finding> ranked, int globalMax)
+    {
+        if (globalMax <= 0 || ranked.Count <= globalMax)
+            return (ranked, 0);
+
+        return (ranked.Take(globalMax).ToList(), ranked.Count - globalMax);
+    }
+
+    /// <summary>
+    /// Higher scores surface first: Block severity, line anchoring, and confidence dominate.
+    /// </summary>
+    internal static int ComputeDeliveryScore(Finding finding) =>
+        SeverityScore(finding.Severity)
+        + (finding.Line.HasValue ? 50 : 0)
+        + (string.IsNullOrEmpty(finding.FilePath) ? 0 : 10)
+        + ConfidenceScore(finding.Confidence);
+
+    private static int SeverityScore(RuleSeverity severity) => severity switch
+    {
+        RuleSeverity.Block => 1000,
+        RuleSeverity.Warn => 100,
+        RuleSeverity.Advisory => 50,
+        RuleSeverity.Info => 10,
+        _ => 0,
+    };
+
+    private static int ConfidenceScore(Confidence confidence) => confidence switch
+    {
+        Confidence.High => 30,
+        Confidence.Medium => 20,
+        Confidence.Low => 0,
+        _ => 0,
+    };
+}

--- a/src/GauntletCI.Core/Rules/Delivery/FindingDeliverySummary.cs
+++ b/src/GauntletCI.Core/Rules/Delivery/FindingDeliverySummary.cs
@@ -22,6 +22,9 @@ public sealed class FindingDeliverySummary
     /// <summary>Number of findings whose confidence was boosted by rule coordination.</summary>
     public int CoordinationBoostsApplied { get; init; }
 
+    /// <summary>Findings removed because the anchored added line matches a removed line (relocated code).</summary>
+    public int DroppedByProvenanceFilter { get; init; }
+
     /// <summary>Findings removed because the repo was classified as a class library.</summary>
     public int DroppedByDomainFilter { get; init; }
 }

--- a/src/GauntletCI.Core/Rules/Delivery/FindingDeliverySummary.cs
+++ b/src/GauntletCI.Core/Rules/Delivery/FindingDeliverySummary.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Elastic-2.0
+namespace GauntletCI.Core.Rules.Delivery;
+
+/// <summary>Metrics from <see cref="FindingDeliveryProcessor"/> for diagnostics and telemetry.</summary>
+public sealed class FindingDeliverySummary
+{
+    /// <summary>Findings count before delivery processing.</summary>
+    public int InputCount { get; init; }
+
+    /// <summary>Findings count after delivery processing.</summary>
+    public int OutputCount { get; init; }
+
+    /// <summary>Findings removed because file-level rules were demoted when line-anchored findings exist.</summary>
+    public int DroppedByFileLevelDemotion { get; init; }
+
+    /// <summary>Findings removed by per-rule per-file caps.</summary>
+    public int DroppedByPerRuleCap { get; init; }
+
+    /// <summary>Findings removed by the global cap after ranking.</summary>
+    public int DroppedByGlobalCap { get; init; }
+
+    /// <summary>Number of findings whose confidence was boosted by rule coordination.</summary>
+    public int CoordinationBoostsApplied { get; init; }
+
+    /// <summary>Findings removed because the repo was classified as a class library.</summary>
+    public int DroppedByDomainFilter { get; init; }
+}

--- a/src/GauntletCI.Core/Rules/Delivery/ProvenanceFindingProcessor.cs
+++ b/src/GauntletCI.Core/Rules/Delivery/ProvenanceFindingProcessor.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Delivery;
+
+/// <summary>Suppresses findings anchored to added lines that are relocated, not net-new (PG-PROVENANCE / RC-1).</summary>
+public static class ProvenanceFindingProcessor
+{
+    /// <summary>Result of provenance filtering.</summary>
+    public sealed class Result
+    {
+        public required IReadOnlyList<Finding> Findings { get; init; }
+        public int DroppedCount { get; init; }
+    }
+
+    /// <summary>
+    /// Removes line-anchored findings on relocated added lines unless the rule is exempt.
+    /// </summary>
+    public static Result Apply(
+        IReadOnlyList<Finding> findings,
+        DiffProvenanceAnalyzer.Index provenance,
+        ProvenanceConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(findings);
+        ArgumentNullException.ThrowIfNull(provenance);
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!config.Enabled || findings.Count == 0)
+        {
+            return new Result { Findings = findings.ToList(), DroppedCount = 0 };
+        }
+
+        var exempt = config.ExemptRules.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var kept = new List<Finding>(findings.Count);
+        var dropped = 0;
+
+        foreach (var finding in findings)
+        {
+            if (ShouldKeep(finding, provenance, exempt))
+                kept.Add(finding);
+            else
+                dropped++;
+        }
+
+        return new Result { Findings = kept, DroppedCount = dropped };
+    }
+
+    private static bool ShouldKeep(
+        Finding finding,
+        DiffProvenanceAnalyzer.Index provenance,
+        HashSet<string> exemptRules)
+    {
+        if (exemptRules.Contains(finding.RuleId))
+            return true;
+
+        if (!finding.Line.HasValue)
+            return true;
+
+        return !provenance.IsRelocated(finding.FilePath, finding.Line.Value);
+    }
+}

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0058_PairedImplementationConsistency.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0058_PairedImplementationConsistency.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0058, Paired Implementation Consistency
+/// Compares sibling class implementations for opposite boolean polarity on the same predicate.
+/// Closes the sibling-implementation drift gap (PG-RELATION / RC-3).
+/// </summary>
+public class GCI0058_PairedImplementationConsistency : RuleBase
+{
+    public GCI0058_PairedImplementationConsistency(IPatternProvider patterns) : base(patterns)
+    {
+    }
+
+    public override string Id => "GCI0058";
+    public override string Name => "Paired Implementation Consistency";
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        foreach (var file in context.Diff.Files)
+        {
+            if (WellKnownPatterns.IsTestFile(file.NewPath))
+                continue;
+
+            var observations = PairedImplementationAnalyzer.AnalyzeFile(file);
+            foreach (var (suspect, reference) in PairedImplementationAnalyzer.FindPolarityMismatches(observations))
+            {
+                findings.Add(CreateFinding(
+                    file,
+                    summary: $"Sibling implementations disagree on '{suspect.Callee}' polarity in {suspect.MethodName}()",
+                    evidence: $"{file.NewPath}:{suspect.LineNumber} — {suspect.ClassName}.{suspect.MethodName} uses `{suspect.Condition}` while {reference.ClassName}.{reference.MethodName} uses `{reference.Condition}`.",
+                    whyItMatters: "Parallel implementations of the same behavior with inverted predicates usually indicate a copy/paste logic bug rather than an intentional difference.",
+                    suggestedAction: $"Align {suspect.ClassName}.{suspect.MethodName} with {reference.ClassName} or document why the polarity must differ.",
+                    confidence: Confidence.High,
+                    line: new DiffLine { LineNumber = suspect.LineNumber, Content = suspect.Condition, Kind = DiffLineKind.Added }));
+            }
+        }
+
+        return Task.FromResult(findings);
+    }
+}

--- a/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
+++ b/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
@@ -5,6 +5,7 @@ using GauntletCI.Core.Configuration;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.FileAnalysis;
 using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules.Delivery;
 using GauntletCI.Core.StaticAnalysis;
 
 namespace GauntletCI.Core.Rules;
@@ -22,6 +23,7 @@ public class RuleOrchestrator
     private readonly ConfigurationService _configService;
     private readonly TimeSpan _ruleTimeout;
     private readonly IChangedFileAnalyzer _fileAnalyzer;
+    private readonly string? _repoPath;
 
     /// <summary>
     /// Initializes the orchestrator with an explicit set of rules and optional configuration.
@@ -31,13 +33,21 @@ public class RuleOrchestrator
     /// <param name="ruleTimeout">Per-rule evaluation time limit; defaults to 30 seconds when null.</param>
     /// <param name="fileAnalyzer">File eligibility classifier; defaults to <see cref="ChangedFileAnalyzer"/> when null.</param>
     /// <param name="configService">Severity resolver; created from <paramref name="config"/> when null.</param>
-    public RuleOrchestrator(IEnumerable<IRule> rules, GauntletConfig? config = null, TimeSpan? ruleTimeout = null, IChangedFileAnalyzer? fileAnalyzer = null, ConfigurationService? configService = null)
+    /// <param name="repoPath">Repository root for domain classification and severity resolution.</param>
+    public RuleOrchestrator(
+        IEnumerable<IRule> rules,
+        GauntletConfig? config = null,
+        TimeSpan? ruleTimeout = null,
+        IChangedFileAnalyzer? fileAnalyzer = null,
+        ConfigurationService? configService = null,
+        string? repoPath = null)
     {
         _rules = [.. rules.OrderBy(r => r.Id)];
         _config = config ?? new GauntletConfig();
         _configService = configService ?? new ConfigurationService(_config);
         _ruleTimeout = ruleTimeout ?? TimeSpan.FromSeconds(30);
         _fileAnalyzer = fileAnalyzer ?? new ChangedFileAnalyzer();
+        _repoPath = repoPath;
     }
 
     /// <summary>The rules registered with this orchestrator, ordered by ID.</summary>
@@ -123,7 +133,7 @@ public class RuleOrchestrator
         foreach (var rule in rules.OfType<IConfigurableRule>())
             rule.Configure(config);
 
-        return new RuleOrchestrator(rules, config, ruleTimeout, configService: configService);
+        return new RuleOrchestrator(rules, config, ruleTimeout, configService: configService, repoPath: repoPath);
     }
 
     /// <summary>
@@ -241,13 +251,23 @@ public class RuleOrchestrator
         ApplyIgnoreList(allFindings, ignoreList);
         PostProcess(filteredDiff, allFindings);
 
+        var domainProfile = RepoDomainClassifier.Classify(_repoPath, filteredDiff, _config.Domain);
+        var domain = DomainFindingProcessor.Apply(allFindings, domainProfile, _config.Domain);
+        allFindings.Clear();
+        allFindings.AddRange(domain.Findings);
+
+        var delivery = ApplyDelivery(allFindings, domain.DroppedCount);
+        var finalFindings = delivery.Findings.ToList();
+
         return new EvaluationResult
         {
             CommitSha = diff.CommitSha,
-            Findings = allFindings,
+            Findings = finalFindings,
             RulesEvaluated = _rules.Count,
             RuleMetrics = metrics,
             FileStatistics = fileStatistics,
+            DeliverySummary = delivery.Summary,
+            DomainProfile = domainProfile,
         };
     }
 
@@ -287,6 +307,31 @@ public class RuleOrchestrator
             Console.Error.WriteLine($"[GauntletCI] PostProcess threw an exception: {ex.Message}");
         }
     }
+
+    private FindingDeliveryProcessor.Result ApplyDelivery(List<Finding> allFindings, int droppedByDomain)
+    {
+        var deliveryConfig = _config.Output.Delivery;
+        var result = FindingDeliveryProcessor.Apply(allFindings, deliveryConfig);
+
+        if (droppedByDomain <= 0)
+            return result;
+
+        var summary = result.Summary;
+        return new FindingDeliveryProcessor.Result
+        {
+            Findings = result.Findings,
+            Summary = new FindingDeliverySummary
+            {
+                InputCount = summary.InputCount,
+                OutputCount = summary.OutputCount,
+                DroppedByFileLevelDemotion = summary.DroppedByFileLevelDemotion,
+                DroppedByPerRuleCap = summary.DroppedByPerRuleCap,
+                DroppedByGlobalCap = summary.DroppedByGlobalCap,
+                CoordinationBoostsApplied = summary.CoordinationBoostsApplied,
+                DroppedByDomainFilter = droppedByDomain,
+            },
+        };
+    }
 }
 
 /// <summary>Aggregated output of a single <see cref="RuleOrchestrator.RunAsync"/> call.</summary>
@@ -302,6 +347,10 @@ public class EvaluationResult
     public IReadOnlyList<RuleExecutionMetric> RuleMetrics { get; init; } = [];
     /// <summary>Summary of how each changed file was classified for eligibility.</summary>
     public FileEligibilityStatistics FileStatistics { get; init; } = new();
+    /// <summary>Metrics from finding delivery processing (caps, demotion, coordination).</summary>
+    public FindingDeliverySummary? DeliverySummary { get; init; }
+    /// <summary>Repository domain classification applied during this run.</summary>
+    public RepoDomainProfile? DomainProfile { get; init; }
     /// <summary>True when at least one finding was produced by this evaluation run.</summary>
     public bool HasFindings => Findings.Count > 0;
     /// <summary>

--- a/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
+++ b/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
@@ -23,7 +23,6 @@ public class RuleOrchestrator
     private readonly ConfigurationService _configService;
     private readonly TimeSpan _ruleTimeout;
     private readonly IChangedFileAnalyzer _fileAnalyzer;
-    private readonly string? _repoPath;
 
     /// <summary>
     /// Initializes the orchestrator with an explicit set of rules and optional configuration.
@@ -33,21 +32,13 @@ public class RuleOrchestrator
     /// <param name="ruleTimeout">Per-rule evaluation time limit; defaults to 30 seconds when null.</param>
     /// <param name="fileAnalyzer">File eligibility classifier; defaults to <see cref="ChangedFileAnalyzer"/> when null.</param>
     /// <param name="configService">Severity resolver; created from <paramref name="config"/> when null.</param>
-    /// <param name="repoPath">Repository root for domain classification and severity resolution.</param>
-    public RuleOrchestrator(
-        IEnumerable<IRule> rules,
-        GauntletConfig? config = null,
-        TimeSpan? ruleTimeout = null,
-        IChangedFileAnalyzer? fileAnalyzer = null,
-        ConfigurationService? configService = null,
-        string? repoPath = null)
+    public RuleOrchestrator(IEnumerable<IRule> rules, GauntletConfig? config = null, TimeSpan? ruleTimeout = null, IChangedFileAnalyzer? fileAnalyzer = null, ConfigurationService? configService = null)
     {
         _rules = [.. rules.OrderBy(r => r.Id)];
         _config = config ?? new GauntletConfig();
         _configService = configService ?? new ConfigurationService(_config);
         _ruleTimeout = ruleTimeout ?? TimeSpan.FromSeconds(30);
         _fileAnalyzer = fileAnalyzer ?? new ChangedFileAnalyzer();
-        _repoPath = repoPath;
     }
 
     /// <summary>The rules registered with this orchestrator, ordered by ID.</summary>
@@ -133,7 +124,7 @@ public class RuleOrchestrator
         foreach (var rule in rules.OfType<IConfigurableRule>())
             rule.Configure(config);
 
-        return new RuleOrchestrator(rules, config, ruleTimeout, configService: configService, repoPath: repoPath);
+        return new RuleOrchestrator(rules, config, ruleTimeout, configService: configService);
     }
 
     /// <summary>
@@ -251,12 +242,17 @@ public class RuleOrchestrator
         ApplyIgnoreList(allFindings, ignoreList);
         PostProcess(filteredDiff, allFindings);
 
-        var domainProfile = RepoDomainClassifier.Classify(_repoPath, filteredDiff, _config.Domain);
+        var provenanceIndex = DiffProvenanceAnalyzer.Build(filteredDiff);
+        var provenance = ProvenanceFindingProcessor.Apply(allFindings, provenanceIndex, _config.Provenance);
+        allFindings.Clear();
+        allFindings.AddRange(provenance.Findings);
+
+        var domainProfile = RepoDomainClassifier.Classify(_configService.RepoPath, filteredDiff, _config.Domain);
         var domain = DomainFindingProcessor.Apply(allFindings, domainProfile, _config.Domain);
         allFindings.Clear();
         allFindings.AddRange(domain.Findings);
 
-        var delivery = ApplyDelivery(allFindings, domain.DroppedCount);
+        var delivery = ApplyDelivery(allFindings, provenance.DroppedCount, domain.DroppedCount);
         var finalFindings = delivery.Findings.ToList();
 
         return new EvaluationResult
@@ -308,12 +304,15 @@ public class RuleOrchestrator
         }
     }
 
-    private FindingDeliveryProcessor.Result ApplyDelivery(List<Finding> allFindings, int droppedByDomain)
+    private FindingDeliveryProcessor.Result ApplyDelivery(
+        List<Finding> allFindings,
+        int droppedByProvenance,
+        int droppedByDomain)
     {
         var deliveryConfig = _config.Output.Delivery;
         var result = FindingDeliveryProcessor.Apply(allFindings, deliveryConfig);
 
-        if (droppedByDomain <= 0)
+        if (droppedByProvenance <= 0 && droppedByDomain <= 0)
             return result;
 
         var summary = result.Summary;
@@ -328,6 +327,7 @@ public class RuleOrchestrator
                 DroppedByPerRuleCap = summary.DroppedByPerRuleCap,
                 DroppedByGlobalCap = summary.DroppedByGlobalCap,
                 CoordinationBoostsApplied = summary.CoordinationBoostsApplied,
+                DroppedByProvenanceFilter = droppedByProvenance,
                 DroppedByDomainFilter = droppedByDomain,
             },
         };

--- a/src/GauntletCI.Tests/OrchestratorTests.cs
+++ b/src/GauntletCI.Tests/OrchestratorTests.cs
@@ -22,7 +22,7 @@ public class OrchestratorTests
             +var x = 1;
             """);
         var result = await orchestrator.RunAsync(diff);
-        Assert.Equal(34, result.RulesEvaluated);
+        Assert.Equal(35, result.RulesEvaluated);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class OrchestratorTests
             """);
         var result = await orchestrator.RunAsync(diff);
         Assert.NotNull(result);
-        Assert.Equal(34, result.RulesEvaluated);
+        Assert.Equal(35, result.RulesEvaluated);
     }
 
     [Fact]

--- a/src/GauntletCI.Tests/Phase5IntegrationTests.cs
+++ b/src/GauntletCI.Tests/Phase5IntegrationTests.cs
@@ -39,7 +39,7 @@ public class Phase5IntegrationTests
 
         // Verify that behavioral change detection ran and context signals were evaluated
         Assert.NotNull(result);
-        Assert.Equal(34, result.RulesEvaluated);
+        Assert.Equal(35, result.RulesEvaluated);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class Phase5IntegrationTests
         var result = await orchestrator.RunAsync(diff);
 
         Assert.NotNull(result);
-        Assert.Equal(34, result.RulesEvaluated);
+        Assert.Equal(35, result.RulesEvaluated);
     }
 
     [Fact]
@@ -201,6 +201,6 @@ public class Phase5IntegrationTests
             """);
 
         var result = await orchestrator.RunAsync(cleanDiff);
-        Assert.Equal(34, result.RulesEvaluated);
+        Assert.Equal(35, result.RulesEvaluated);
     }
 }

--- a/src/GauntletCI.Tests/Rules/FindingDeliveryProcessorTests.cs
+++ b/src/GauntletCI.Tests/Rules/FindingDeliveryProcessorTests.cs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules.Delivery;
+
+namespace GauntletCI.Tests.Rules;
+
+public sealed class FindingDeliveryProcessorTests
+{
+    private static Finding MakeFinding(
+        string ruleId,
+        string? filePath = "src/Foo.cs",
+        int? line = 1,
+        RuleSeverity severity = RuleSeverity.Warn,
+        Confidence confidence = Confidence.Medium) => new()
+        {
+            RuleId = ruleId,
+            RuleName = ruleId,
+            Summary = $"Finding for {ruleId}",
+            Evidence = $"{filePath}:{line}",
+            WhyItMatters = "test",
+            SuggestedAction = "fix",
+            FilePath = filePath,
+            Line = line,
+            Severity = severity,
+            Confidence = confidence,
+        };
+
+    [Fact]
+    public void Apply_WhenDisabled_PassesThroughUnchanged()
+    {
+        var findings = new[] { MakeFinding("GCI0038", line: 10) };
+        var config = new FindingDeliveryConfig { Enabled = false };
+
+        var result = FindingDeliveryProcessor.Apply(findings, config);
+
+        Assert.Single(result.Findings);
+        Assert.Equal(1, result.Summary.OutputCount);
+        Assert.Equal(0, result.Summary.DroppedByPerRuleCap);
+    }
+
+    [Fact]
+    public void Apply_PerRulePerFileCap_KeepsHighestScoredFindings()
+    {
+        var findings = Enumerable.Range(1, 6)
+            .Select(i => MakeFinding("GCI0038", line: i, confidence: i == 6 ? Confidence.High : Confidence.Low))
+            .ToList();
+
+        var config = new FindingDeliveryConfig
+        {
+            PerRulePerFileCap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["GCI0038"] = 3 },
+        };
+
+        var result = FindingDeliveryProcessor.Apply(findings, config);
+
+        Assert.Equal(3, result.Findings.Count);
+        Assert.Equal(3, result.Summary.DroppedByPerRuleCap);
+        Assert.Contains(result.Findings, f => f.Line == 6 && f.Confidence == Confidence.High);
+    }
+
+    [Fact]
+    public void Apply_GlobalCap_DropsLowestRankedAfterPerRuleCap()
+    {
+        var findings = new List<Finding>();
+        for (var i = 0; i < 30; i++)
+            findings.Add(MakeFinding("GCI0006", filePath: $"src/File{i}.cs", line: 1, severity: RuleSeverity.Info));
+
+        var config = new FindingDeliveryConfig
+        {
+            GlobalMaxFindings = 10,
+            DefaultPerRulePerFileCap = 10,
+        };
+
+        var result = FindingDeliveryProcessor.Apply(findings, config);
+
+        Assert.Equal(10, result.Findings.Count);
+        Assert.True(result.Summary.DroppedByGlobalCap > 0);
+    }
+
+    [Fact]
+    public void Apply_DemotesFileLevelGci0001WhenLineAnchoredFindingsExist()
+    {
+        var findings = new[]
+        {
+            MakeFinding("GCI0001", line: null, severity: RuleSeverity.Block),
+            MakeFinding("GCI0038", line: 42),
+        };
+
+        var result = FindingDeliveryProcessor.Apply(findings, new FindingDeliveryConfig());
+
+        Assert.Single(result.Findings);
+        Assert.Equal("GCI0038", result.Findings[0].RuleId);
+        Assert.Equal(1, result.Summary.DroppedByFileLevelDemotion);
+    }
+
+    [Fact]
+    public void Apply_KeepsFileLevelWhenNoLineAnchoredFindingsExist()
+    {
+        var findings = new[]
+        {
+            MakeFinding("GCI0001", line: null, severity: RuleSeverity.Block),
+        };
+
+        var result = FindingDeliveryProcessor.Apply(findings, new FindingDeliveryConfig());
+
+        Assert.Single(result.Findings);
+        Assert.Equal(0, result.Summary.DroppedByFileLevelDemotion);
+    }
+
+    [Fact]
+    public void Apply_RanksBlockLineAnchoredHighConfidenceFirst()
+    {
+        var findings = new[]
+        {
+            MakeFinding("GCI0043", line: 1, severity: RuleSeverity.Info, confidence: Confidence.Low),
+            MakeFinding("GCI0007", line: 10, severity: RuleSeverity.Block, confidence: Confidence.High),
+            MakeFinding("GCI0038", line: 5, severity: RuleSeverity.Warn, confidence: Confidence.Medium),
+        };
+
+        var config = new FindingDeliveryConfig { GlobalMaxFindings = 25 };
+        var result = FindingDeliveryProcessor.Apply(findings, config);
+
+        Assert.Equal("GCI0007", result.Findings[0].RuleId);
+    }
+}
+
+public sealed class FindingCoordinationEngineTests
+{
+    private static Finding MakeFinding(string ruleId, Confidence confidence = Confidence.Low) => new()
+    {
+        RuleId = ruleId,
+        RuleName = ruleId,
+        Summary = ruleId,
+        Evidence = "evidence",
+        WhyItMatters = "why",
+        SuggestedAction = "fix",
+        Confidence = confidence,
+    };
+
+    [Fact]
+    public void Apply_Gci0016Present_BoostsGci0039AndGci0044()
+    {
+        var findings = new List<Finding>
+        {
+            MakeFinding("GCI0016", Confidence.High),
+            MakeFinding("GCI0039", Confidence.Low),
+            MakeFinding("GCI0044", Confidence.Low),
+        };
+
+        var boosts = FindingCoordinationEngine.Apply(findings);
+
+        Assert.Equal(2, boosts);
+        Assert.All(findings.Where(f => f.RuleId is "GCI0039" or "GCI0044"), f => Assert.Equal(Confidence.Medium, f.Confidence));
+    }
+
+    [Fact]
+    public void Apply_Gci0032AndGci0003_BoostsBoth()
+    {
+        var findings = new List<Finding>
+        {
+            MakeFinding("GCI0032", Confidence.Low),
+            MakeFinding("GCI0003", Confidence.Low),
+        };
+
+        var boosts = FindingCoordinationEngine.Apply(findings);
+
+        Assert.Equal(2, boosts);
+        Assert.Equal(Confidence.High, findings.Single(f => f.RuleId == "GCI0003").Confidence);
+        Assert.Equal(Confidence.Medium, findings.Single(f => f.RuleId == "GCI0032").Confidence);
+    }
+
+    [Fact]
+    public void Apply_Gci0024AndGci0015_BoostsBoth()
+    {
+        var findings = new List<Finding>
+        {
+            MakeFinding("GCI0024", Confidence.Low),
+            MakeFinding("GCI0015", Confidence.Low),
+        };
+
+        var boosts = FindingCoordinationEngine.Apply(findings);
+
+        Assert.Equal(2, boosts);
+        Assert.All(findings, f => Assert.Equal(Confidence.Medium, f.Confidence));
+    }
+
+    [Fact]
+    public void Apply_NoCoordinationPattern_LeavesConfidenceUnchanged()
+    {
+        var findings = new List<Finding> { MakeFinding("GCI0038", Confidence.Low) };
+
+        var boosts = FindingCoordinationEngine.Apply(findings);
+
+        Assert.Equal(0, boosts);
+        Assert.Equal(Confidence.Low, findings[0].Confidence);
+    }
+}

--- a/src/GauntletCI.Tests/Rules/GCI0058Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0058Tests.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Rules.Implementations;
+
+namespace GauntletCI.Tests.Rules;
+
+public sealed class GCI0058Tests
+{
+    private static readonly GCI0058_PairedImplementationConsistency Rule = new(new StubPatternProvider());
+
+    [Fact]
+    public async Task InvertedSiblingPredicate_ShouldFire()
+    {
+        var raw = """
+            diff --git a/src/Subscription.cs b/src/Subscription.cs
+            index abc..def 100644
+            --- a/src/Subscription.cs
+            +++ b/src/Subscription.cs
+            @@ -10,20 +10,30 @@
+             internal sealed class SingleNodeSubscription : Subscription
+             {
+                 protected override void RemoveDisconnectedEndpoints()
+                 {
+                     foreach (var endpoint in endpoints)
+                     {
+                         if (!IsSubscriberConnected(endpoint))
+                         {
+                             endpoints.Remove(endpoint);
+                         }
+                     }
+                 }
+             }
+             
+             internal sealed class MultiNodeSubscription : Subscription
+             {
+                 protected override void RemoveDisconnectedEndpoints()
+                 {
+                     foreach (var endpoint in endpoints)
+                     {
+            +            if (IsSubscriberConnected(endpoint))
+            +            {
+            +                endpoints.Remove(endpoint);
+            +            }
+                     }
+                 }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal("GCI0058", finding.RuleId);
+        Assert.Contains("IsSubscriberConnected", finding.Evidence, StringComparison.Ordinal);
+        Assert.Contains("MultiNodeSubscription", finding.Evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MatchingSiblingPredicate_ShouldNotFire()
+    {
+        var raw = """
+            diff --git a/src/Subscription.cs b/src/Subscription.cs
+            index abc..def 100644
+            --- a/src/Subscription.cs
+            +++ b/src/Subscription.cs
+            @@ -10,20 +10,30 @@
+             internal sealed class SingleNodeSubscription : Subscription
+             {
+                 protected override void RemoveDisconnectedEndpoints()
+                 {
+                     foreach (var endpoint in endpoints)
+                     {
+                         if (!IsSubscriberConnected(endpoint))
+                         {
+                             endpoints.Remove(endpoint);
+                         }
+                     }
+                 }
+             }
+             
+             internal sealed class MultiNodeSubscription : Subscription
+             {
+                 protected override void RemoveDisconnectedEndpoints()
+                 {
+                     foreach (var endpoint in endpoints)
+                     {
+            +            if (!IsSubscriberConnected(endpoint))
+            +            {
+            +                endpoints.Remove(endpoint);
+            +            }
+                     }
+                 }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task RedisStylePropertyPattern_ShouldFire()
+    {
+        var raw = """
+            diff --git a/src/Subscription.cs b/src/Subscription.cs
+            index abc..def 100644
+            --- a/src/Subscription.cs
+            +++ b/src/Subscription.cs
+            @@ -1,1 +1,40 @@
+            +    internal sealed class SingleNodeSubscription : Subscription
+            +    {
+            +        internal override void RemoveDisconnectedEndpoints()
+            +        {
+            +            var server = _currentServer;
+            +            if (server is { IsSubscriberConnected: false })
+            +            {
+            +                _currentServer = null;
+            +            }
+            +        }
+            +    }
+            +
+            +    internal sealed class MultiNodeSubscription : Subscription
+            +    {
+            +        internal override void RemoveDisconnectedEndpoints()
+            +        {
+            +            foreach (var server in _servers)
+            +            {
+            +                if (server.Value.IsSubscriberConnected)
+            +                {
+            +                    scratch[count++] = server.Key;
+            +                }
+            +            }
+            +        }
+            +    }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal("GCI0058", finding.RuleId);
+        Assert.Contains("IsSubscriberConnected", finding.Evidence, StringComparison.Ordinal);
+    }
+}

--- a/src/GauntletCI.Tests/Rules/ProvenanceTests.cs
+++ b/src/GauntletCI.Tests/Rules/ProvenanceTests.cs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules.Delivery;
+
+namespace GauntletCI.Tests.Rules;
+
+public sealed class DiffProvenanceAnalyzerTests
+{
+    [Fact]
+    public void Build_IdenticalRemovedAndAddedLine_MarksRelocated()
+    {
+        var diff = DiffParser.Parse("""
+            diff --git a/src/Queue.cs b/src/Queue.cs
+            index abc..def 100644
+            --- a/src/Queue.cs
+            +++ b/src/Queue.cs
+            @@ -10,3 +10,3 @@
+                 try { DoWork(); }
+            -    catch { }
+            +    catch { }
+             }
+            """);
+
+        var index = DiffProvenanceAnalyzer.Build(diff);
+        var relocatedLine = diff.Files.Single().AddedLines.Single(l => l.Content.Contains("catch", StringComparison.Ordinal));
+
+        Assert.True(index.IsRelocated("src/Queue.cs", relocatedLine.LineNumber));
+    }
+
+    [Fact]
+    public void Build_CrossFileMove_MarksRelocatedOnAddedSide()
+    {
+        var diff = DiffParser.Parse("""
+            diff --git a/old/Handler.cs b/new/Handler.cs
+            index abc..def 100644
+            --- a/old/Handler.cs
+            +++ b/new/Handler.cs
+            @@ -1,3 +0,0 @@
+            -public void Handle() { throw new NotImplementedException(); }
+            diff --git a/new/Handler.cs b/new/Handler.cs
+            index abc..def 100644
+            --- /dev/null
+            +++ b/new/Handler.cs
+            @@ -0,0 +1,1 @@
+            +public void Handle() { throw new NotImplementedException(); }
+            """);
+
+        var index = DiffProvenanceAnalyzer.Build(diff);
+
+        Assert.True(index.IsRelocated("new/Handler.cs", 1));
+    }
+
+    [Fact]
+    public void Build_NetNewAddedLine_NotRelocated()
+    {
+        var diff = DiffParser.Parse("""
+            diff --git a/src/Queue.cs b/src/Queue.cs
+            index abc..def 100644
+            --- a/src/Queue.cs
+            +++ b/src/Queue.cs
+            @@ -10,2 +10,3 @@
+                 try { DoWork(); }
+            +    catch { }
+             }
+            """);
+
+        var index = DiffProvenanceAnalyzer.Build(diff);
+
+        Assert.False(index.IsRelocated("src/Queue.cs", 11));
+    }
+}
+
+public sealed class ProvenanceFindingProcessorTests
+{
+    private static Finding MakeFinding(string ruleId, string file, int line) => new()
+    {
+        RuleId = ruleId,
+        RuleName = ruleId,
+        Summary = ruleId,
+        Evidence = $"Line {line}",
+        WhyItMatters = "why",
+        SuggestedAction = "fix",
+        FilePath = file,
+        Line = line,
+    };
+
+    [Fact]
+    public void Apply_RelocatedLine_DropsNonExemptFinding()
+    {
+        var diff = DiffParser.Parse("""
+            diff --git a/src/Queue.cs b/src/Queue.cs
+            index abc..def 100644
+            --- a/src/Queue.cs
+            +++ b/src/Queue.cs
+            @@ -10,3 +10,3 @@
+                 try { DoWork(); }
+            -    catch { }
+            +    catch { }
+             }
+            """);
+
+        var index = DiffProvenanceAnalyzer.Build(diff);
+        var relocatedLine = diff.Files.Single().AddedLines.Single(l => l.Content.Contains("catch", StringComparison.Ordinal));
+        var findings = new[] { MakeFinding("GCI0007", "src/Queue.cs", relocatedLine.LineNumber) };
+
+        var result = ProvenanceFindingProcessor.Apply(findings, index, new ProvenanceConfig());
+
+        Assert.Empty(result.Findings);
+        Assert.Equal(1, result.DroppedCount);
+    }
+
+    [Fact]
+    public void Apply_RelocatedLine_KeepsExemptRule()
+    {
+        var diff = DiffParser.Parse("""
+            diff --git a/src/Api.cs b/src/Api.cs
+            index abc..def 100644
+            --- a/src/Api.cs
+            +++ b/src/Api.cs
+            @@ -1,3 +1,3 @@
+            -public void Run(int x) { }
+            +public void Run(int x) { }
+            """);
+
+        var index = DiffProvenanceAnalyzer.Build(diff);
+        var findings = new[] { MakeFinding("GCI0003", "src/Api.cs", 1) };
+
+        var result = ProvenanceFindingProcessor.Apply(findings, index, new ProvenanceConfig());
+
+        Assert.Single(result.Findings);
+        Assert.Equal(0, result.DroppedCount);
+    }
+}

--- a/src/GauntletCI.Tests/Rules/RepoDomainTests.cs
+++ b/src/GauntletCI.Tests/Rules/RepoDomainTests.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules.Delivery;
+
+namespace GauntletCI.Tests.Rules;
+
+public sealed class RepoDomainClassifierTests
+{
+    [Fact]
+    public void Classify_ConfigOverrideLibrary_ReturnsClassLibrary()
+    {
+        var diff = new DiffContext();
+        var profile = RepoDomainClassifier.Classify(null, diff, new RepoDomainConfig { Profile = "library" });
+
+        Assert.Equal(RepoDomainKind.ClassLibrary, profile.Kind);
+    }
+
+    [Fact]
+    public void Classify_WebDiffMarkers_ReturnsWebApplication()
+    {
+        var diff = DiffParser.Parse("""
+            diff --git a/src/Api.cs b/src/Api.cs
+            index abc..def 100644
+            --- a/src/Api.cs
+            +++ b/src/Api.cs
+            @@ -1,2 +1,4 @@
+             public class Api {
+            +    [HttpPost]
+            +    public IActionResult Create() => Ok();
+             }
+            """);
+
+        var profile = RepoDomainClassifier.Classify(null, diff, new RepoDomainConfig());
+
+        Assert.Equal(RepoDomainKind.WebApplication, profile.Kind);
+    }
+
+    [Fact]
+    public void Classify_LibraryCsprojWithoutWebMarkers_ReturnsClassLibrary()
+    {
+        var repo = Path.Combine(Path.GetTempPath(), "gci-domain-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(repo);
+        try
+        {
+            File.WriteAllText(Path.Combine(repo, "Client.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var diff = DiffParser.Parse("""
+                diff --git a/src/Connection.cs b/src/Connection.cs
+                index abc..def 100644
+                --- a/src/Connection.cs
+                +++ b/src/Connection.cs
+                @@ -1,2 +1,3 @@
+                 public class Connection {
+                +    private readonly Socket _socket = new Socket();
+                 }
+                """);
+
+            var profile = RepoDomainClassifier.Classify(repo, diff, new RepoDomainConfig());
+
+            Assert.Equal(RepoDomainKind.ClassLibrary, profile.Kind);
+        }
+        finally
+        {
+            Directory.Delete(repo, recursive: true);
+        }
+    }
+}
+
+public sealed class DomainFindingProcessorTests
+{
+    private static Finding MakeFinding(string ruleId) => new()
+    {
+        RuleId = ruleId,
+        RuleName = ruleId,
+        Summary = ruleId,
+        Evidence = "evidence",
+        WhyItMatters = "why",
+        SuggestedAction = "fix",
+    };
+
+    [Fact]
+    public void Apply_ClassLibraryProfile_DropsConfiguredRules()
+    {
+        var findings = new[]
+        {
+            MakeFinding("GCI0038"),
+            MakeFinding("GCI0007"),
+        };
+
+        var result = DomainFindingProcessor.Apply(
+            findings,
+            new RepoDomainProfile { Kind = RepoDomainKind.ClassLibrary },
+            new RepoDomainConfig());
+
+        Assert.Single(result.Findings);
+        Assert.Equal("GCI0007", result.Findings[0].RuleId);
+        Assert.Equal(1, result.DroppedCount);
+    }
+}


### PR DESCRIPTION
## Summary

- **PG-DELIVERY:** Post-rule finding delivery on the analyze path — Phase 21 coordinations, per-rule/per-file caps, file-level demotion, ranked output, and a global cap (default 25). Configurable via `output.delivery` in `.gauntletci.json`.
- **PG-DOMAIN:** Repo domain classifier (library vs web) suppresses web/DI-specific rules (GCI0022, GCI0038, GCI0046, GCI0024, GCI0035) on class libraries. Configurable via `domain` in `.gauntletci.json`.
- **GCI0058:** New Block rule for sibling implementation polarity mismatches (e.g. Redis #2995 `IsSubscriberConnected` inverted between `SingleNodeSubscription` and `MultiNodeSubscription`).

Redis #2995 smoke: findings dropped from 39 → 10; GCI0058 now surfaces the adjudicated defect class.

## Test plan

- [x] `dotnet build GauntletCI.slnx`
- [x] `dotnet test GauntletCI.slnx` (1738 passed)
- [x] Unit tests: `FindingDeliveryProcessorTests`, `RepoDomainTests`, `GCI0058Tests`
- [x] Manual analyze on `%TEMP%\redis-2995-eval.diff` — GCI0058 fires, domain gating reduces GCI0038 noise
- [ ] CI green on PR
- [ ] Optional: re-run eval lab PR #7 after merge
