### PR TITLE
docs(tooling): rule audit scaffold and sanitized snapshot

### DIFF
--- a/eval/rule-audit.json
+++ b/eval/rule-audit.json
@@ -1,0 +1,2607 @@
+{
+  "schema_version": "1.0.0",
+  "generated_at": "2026-05-30T01:04:50.686035+00:00",
+  "corpus_path": "%USERPROFILE%\\.gauntletci\\corpus.db",
+  "corpus_loaded": true,
+  "rule_count": 36,
+  "pattern_taxonomy": {
+    "P1": "Added-line substring scan",
+    "P2": "Removed-line substring scan",
+    "P3": "File/diff aggregate (weak line anchor)",
+    "P4": "Token/regex without method context",
+    "P5": "Cross-entity compare (partial or required)",
+    "P6": "Web/DI/HTTP/DB domain-specific",
+    "P7": "Roslyn or syntax-guard augmented",
+    "P8": "Removed+added pair compare",
+    "P9": "Hunk-local removed vs added"
+  },
+  "root_cause_taxonomy": {
+    "RC-1": "Added-line treated as new risk (diff artifact blindness)",
+    "RC-2": "Line-local pattern without method/control-flow scope",
+    "RC-3": "No cross-entity reasoning (sibling methods, guard+use)",
+    "RC-4": "Domain assumptions (web/DI/EF) on all repos",
+    "RC-5": "Unbounded per-line fanout on large diffs",
+    "RC-6": "Confidence/severity does not gate delivery",
+    "RC-7": "Roslyn/semantics underused",
+    "RC-8": "Success metric is pattern fire, not adjudicated defect"
+  },
+  "fn_class_taxonomy": [
+    "inverted-condition",
+    "sibling-implementation-drift",
+    "guard-deletion-remote-use",
+    "logic-bug-no-token",
+    "cross-file-contract",
+    "intentional-pattern"
+  ],
+  "fp_class_taxonomy": [
+    "refactor-restructure",
+    "library-factory-new",
+    "intentional-swallow",
+    "test-fixture-context",
+    "framework-exempt-pair",
+    "benign-token-use",
+    "large-feature-volume"
+  ],
+  "platform_gaps": [
+    {
+      "gap_id": "PG-RELATION",
+      "title": "Sibling / paired-implementation compare",
+      "root_cause": "RC-3",
+      "rules_blocked": [
+        "GCI0022",
+        "GCI0029",
+        "GCI0038",
+        "GCI0042",
+        "GCI0043",
+        "GCI0044",
+        "GCI0046",
+        "GCI0003",
+        "GCI0004",
+        "GCI0016",
+        "GCI0020",
+        "GCI0024",
+        "GCI0032",
+        "GCI0035",
+        "GCI0036",
+        "GCI0039",
+        "GCI0045",
+        "GCI0050",
+        "GCI0051",
+        "GCI0054",
+        "GCI0057",
+        "GCI0001",
+        "GCI0007",
+        "GCI0010",
+        "GCI0012",
+        "GCI0015",
+        "GCI0021",
+        "GCI0041",
+        "GCI0048",
+        "GCI0049",
+        "GCI0052",
+        "GCI0053",
+        "GCI0055",
+        "GCI0056"
+      ],
+      "fix": "New cross-method layer: same override name, opposite boolean polarity, method name vs condition"
+    },
+    {
+      "gap_id": "PG-PROVENANCE",
+      "title": "Line provenance (move vs net-new)",
+      "root_cause": "RC-1",
+      "rules_blocked": [
+        "GCI0022",
+        "GCI0029",
+        "GCI0038",
+        "GCI0042",
+        "GCI0043",
+        "GCI0044",
+        "GCI0046",
+        "GCI0003",
+        "GCI0004",
+        "GCI0016",
+        "GCI0020",
+        "GCI0024",
+        "GCI0032",
+        "GCI0035",
+        "GCI0036",
+        "GCI0039",
+        "GCI0045",
+        "GCI0047",
+        "GCI0050",
+        "GCI0051",
+        "GCI0054",
+        "GCI0057",
+        "GCI0001",
+        "GCI0007",
+        "GCI0010",
+        "GCI0012",
+        "GCI0015",
+        "GCI0021",
+        "GCI0041",
+        "GCI0048",
+        "GCI0049",
+        "GCI0052",
+        "GCI0055",
+        "GCI0006"
+      ],
+      "fix": "Similarity match added hunks to removed hunks before firing"
+    },
+    {
+      "gap_id": "PG-DOMAIN",
+      "title": "Repo/domain classifier",
+      "root_cause": "RC-4",
+      "rules_blocked": [
+        "GCI0022",
+        "GCI0038",
+        "GCI0046",
+        "GCI0024",
+        "GCI0035"
+      ],
+      "fix": "Suppress or downgrade DI/HTTP rules on library/infrastructure repos"
+    },
+    {
+      "gap_id": "PG-DELIVERY",
+      "title": "Ranked actionable output",
+      "root_cause": "RC-5, RC-6",
+      "rules_blocked": [
+        "ALL"
+      ],
+      "fix": "Per-rule caps + move SilverLabel coordinations to RuleOrchestrator post-process"
+    },
+    {
+      "gap_id": "PG-SEMANTICS",
+      "title": "Method-scoped Roslyn + counterfactuals",
+      "root_cause": "RC-7",
+      "rules_blocked": [
+        "GCI0022",
+        "GCI0029",
+        "GCI0038",
+        "GCI0042",
+        "GCI0043",
+        "GCI0044",
+        "GCI0046",
+        "GCI0003",
+        "GCI0004",
+        "GCI0016",
+        "GCI0020",
+        "GCI0032",
+        "GCI0035",
+        "GCI0036",
+        "GCI0039",
+        "GCI0045",
+        "GCI0047",
+        "GCI0050",
+        "GCI0051",
+        "GCI0054",
+        "GCI0057",
+        "GCI0001",
+        "GCI0021",
+        "GCI0041",
+        "GCI0052",
+        "GCI0053",
+        "GCI0055",
+        "GCI0056"
+      ],
+      "fix": "Wire PatchCounterfactualGenerator; bind P4 tokens to control-flow sites"
+    }
+  ],
+  "core_issues_from_corpus": [
+    {
+      "issue": "high_labeled_false_positives",
+      "rule_id": "GCI0004",
+      "name": "Breaking Change Risk",
+      "labeled_fp": 9,
+      "labeled_precision": 0.775,
+      "actual_triggers": null,
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4"
+      ]
+    },
+    {
+      "issue": "structural_fn_risk_cross_method_without_p5",
+      "rule_count": 25,
+      "rule_ids": [
+        "GCI0022",
+        "GCI0029",
+        "GCI0038",
+        "GCI0042",
+        "GCI0043",
+        "GCI0044",
+        "GCI0003",
+        "GCI0004",
+        "GCI0016",
+        "GCI0020",
+        "GCI0024",
+        "GCI0032",
+        "GCI0035",
+        "GCI0036",
+        "GCI0039",
+        "GCI0050",
+        "GCI0051",
+        "GCI0054",
+        "GCI0057",
+        "GCI0007",
+        "GCI0010",
+        "GCI0012",
+        "GCI0015",
+        "GCI0048",
+        "GCI0056"
+      ],
+      "description": "Rules touching control-flow semantics but lacking cross-entity compare (Redis MultiNode class)"
+    },
+    {
+      "issue": "web_di_domain_mismatch_on_general_repos",
+      "rules": [],
+      "description": "DI/HTTP rules firing heavily on non-web corpus fixtures (library/infra PRs)"
+    }
+  ],
+  "priority_fix_order": [
+    {
+      "rank": 1,
+      "rule_id": "GCI0022",
+      "name": "Idempotency & Retry Safety",
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-4"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 86
+    },
+    {
+      "rank": 2,
+      "rule_id": "GCI0029",
+      "name": "PII Entity Logging Leak",
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": null,
+      "corpus_precision": 0.0,
+      "corpus_recall": 0.0,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 236
+    },
+    {
+      "rank": 3,
+      "rule_id": "GCI0038",
+      "name": "Dependency Injection Safety",
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-4"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 727
+    },
+    {
+      "rank": 4,
+      "rule_id": "GCI0042",
+      "name": "TODO/Stub Detection",
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": null,
+      "corpus_precision": 0.0,
+      "corpus_recall": 0.0,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 152
+    },
+    {
+      "rank": 5,
+      "rule_id": "GCI0043",
+      "name": "Nullability and Type Safety",
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": null,
+      "corpus_precision": 0.0,
+      "corpus_recall": 0.0,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 470
+    },
+    {
+      "rank": 6,
+      "rule_id": "GCI0044",
+      "name": "Performance Hotpath Risk",
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": null,
+      "corpus_precision": 0.0,
+      "corpus_recall": 0.0,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 350
+    },
+    {
+      "rank": 7,
+      "rule_id": "GCI0046",
+      "name": "Pattern Consistency Deviation",
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-4",
+        "RC-6"
+      ],
+      "corpus_fp": null,
+      "corpus_precision": 0.0,
+      "corpus_recall": 0.0,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 128
+    },
+    {
+      "rank": 8,
+      "rule_id": "GCI0003",
+      "name": "Behavioral Change Detection",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": 1.0,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 39628
+    },
+    {
+      "rank": 9,
+      "rule_id": "GCI0004",
+      "name": "Breaking Change Risk",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-6"
+      ],
+      "corpus_fp": 9,
+      "corpus_precision": 0.775,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 59965
+    },
+    {
+      "rank": 10,
+      "rule_id": "GCI0016",
+      "name": "Async Concurrency Risk",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 4040
+    },
+    {
+      "rank": 11,
+      "rule_id": "GCI0020",
+      "name": "Resource Exhaustion Pattern Detection",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 10
+    },
+    {
+      "rank": 12,
+      "rule_id": "GCI0024",
+      "name": "Resource Lifecycle",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-3",
+        "RC-4",
+        "RC-6"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 3435
+    },
+    {
+      "rank": 13,
+      "rule_id": "GCI0032",
+      "name": "Uncaught Exception Path",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-6"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 836
+    },
+    {
+      "rank": 14,
+      "rule_id": "GCI0035",
+      "name": "Architecture Layer Guard",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-4"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": null
+    },
+    {
+      "rank": 15,
+      "rule_id": "GCI0036",
+      "name": "Pure Context Mutation",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-6"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 2524
+    },
+    {
+      "rank": 16,
+      "rule_id": "GCI0039",
+      "name": "External Service Safety",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": 0,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 211
+    },
+    {
+      "rank": 17,
+      "rule_id": "GCI0045",
+      "name": "Complexity Control",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-5",
+        "RC-6"
+      ],
+      "corpus_fp": null,
+      "corpus_precision": 0.0,
+      "corpus_recall": 0.0,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 195
+    },
+    {
+      "rank": 18,
+      "rule_id": "GCI0047",
+      "name": "Naming/Contract Alignment",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-6",
+        "RC-7"
+      ],
+      "corpus_fp": null,
+      "corpus_precision": 0.0,
+      "corpus_recall": 0.0,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": 1450
+    },
+    {
+      "rank": 19,
+      "rule_id": "GCI0050",
+      "name": "SQL Column Truncation Risk",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": null,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": null
+    },
+    {
+      "rank": 20,
+      "rule_id": "GCI0051",
+      "name": "Numeric Coercion Risks",
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "top_root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5"
+      ],
+      "corpus_fp": null,
+      "corpus_precision": null,
+      "corpus_recall": null,
+      "fixtures_triggered": null,
+      "actual_triggers_all_runs": null
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "GCI0022",
+      "name": "Idempotency & Retry Safety",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0022_IdempotencyRetrySafety.cs",
+      "primary_patterns": [
+        "P1",
+        "P4",
+        "P6"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context",
+        "P6": "Web/DI/HTTP/DB domain-specific"
+      },
+      "domain": "web-di",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-4",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "framework-exempt-pair",
+        "large-feature-volume",
+        "library-factory-new",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "actual_triggers_all_runs": 86
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0029",
+      "name": "PII Entity Logging Leak",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0029_PiiLoggingLeak.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "corpus": {
+        "tier": "Discovery",
+        "trigger_rate": 0.01870748299319728,
+        "precision": 0.0,
+        "recall": 0.0,
+        "usefulness": 0.0,
+        "actual_triggers_all_runs": 236
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0038",
+      "name": "Dependency Injection Safety",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0038_DependencyInjectionSafety.cs",
+      "primary_patterns": [
+        "P1",
+        "P4",
+        "P6"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context",
+        "P6": "Web/DI/HTTP/DB domain-specific"
+      },
+      "domain": "web-di",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-4",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "large-feature-volume",
+        "library-factory-new",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "actual_triggers_all_runs": 727
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0042",
+      "name": "TODO/Stub Detection",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0042_TodoStubDetection.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "corpus": {
+        "tier": "Discovery",
+        "trigger_rate": 0.05952380952380952,
+        "precision": 0.0,
+        "recall": 0.0,
+        "usefulness": 0.0,
+        "actual_triggers_all_runs": 152
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0043",
+      "name": "Nullability and Type Safety",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0043_NullabilityTypeSafety.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "corpus": {
+        "tier": "Discovery",
+        "trigger_rate": 0.12414965986394558,
+        "precision": 0.0,
+        "recall": 0.0,
+        "usefulness": 0.0,
+        "actual_triggers_all_runs": 470
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0044",
+      "name": "Performance Hotpath Risk",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0044_PerformanceHotpathRisk.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "corpus": {
+        "tier": "Discovery",
+        "trigger_rate": 0.08843537414965986,
+        "precision": 0.0,
+        "recall": 0.0,
+        "usefulness": 0.0,
+        "actual_triggers_all_runs": 350
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0046",
+      "name": "Pattern Consistency Deviation",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0046_PatternConsistencyDeviation.cs",
+      "primary_patterns": [
+        "P1",
+        "P4",
+        "P5",
+        "P6"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)",
+        "P6": "Web/DI/HTTP/DB domain-specific"
+      },
+      "domain": "web-di",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-4",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "framework-exempt-pair",
+        "large-feature-volume",
+        "library-factory-new",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "critical",
+      "priority_tier": 1,
+      "corpus": {
+        "tier": "Discovery",
+        "trigger_rate": 0.03741496598639456,
+        "precision": 0.0,
+        "recall": 0.0,
+        "usefulness": 0.0,
+        "actual_triggers_all_runs": 128
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0003",
+      "name": "Behavioral Change Detection",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0003_BehavioralChangeDetection.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P3",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P3": "File/diff aggregate (weak line anchor)",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "medium",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.125,
+        "precision": 1.0,
+        "recall": 1.0,
+        "usefulness": 0.0,
+        "tp": 1,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 1,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": 1.0,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 27,
+        "actual_triggers_all_runs": 39628
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0004",
+      "name": "Breaking Change Risk",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0004_BreakingChangeRisk.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.6595744680851063,
+        "precision": 0.775,
+        "recall": 1.0,
+        "usefulness": 0.0,
+        "tp": 31,
+        "fp": 9,
+        "fn": 0,
+        "labeled_tp": 31,
+        "labeled_fp": 9,
+        "labeled_fn": 0,
+        "labeled_precision": 0.775,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 34,
+        "actual_triggers_all_runs": 59965
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0016",
+      "name": "Async Concurrency Risk",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0016_ConcurrencyAndStateRisk.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 6,
+        "actual_triggers_all_runs": 4040
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0020",
+      "name": "Resource Exhaustion Pattern Detection",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0020_ResourceExhaustionPatterns.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "medium",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "actual_triggers_all_runs": 10
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0024",
+      "name": "Resource Lifecycle",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs",
+      "primary_patterns": [
+        "P1",
+        "P4",
+        "P6",
+        "P7"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context",
+        "P6": "Web/DI/HTTP/DB domain-specific",
+        "P7": "Roslyn or syntax-guard augmented"
+      },
+      "domain": "web-di",
+      "uses_roslyn": true,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-3",
+        "RC-4",
+        "RC-6",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "large-feature-volume",
+        "library-factory-new",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 2,
+        "actual_triggers_all_runs": 3435
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0032",
+      "name": "Uncaught Exception Path",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0032_UncaughtExceptionPath.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P9"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P9": "Hunk-local removed vs added"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": true,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "actual_triggers_all_runs": 836
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0035",
+      "name": "Architecture Layer Guard",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0035_ArchitectureLayerGuard.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "layered-app",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-4",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0036",
+      "name": "Pure Context Mutation",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0036_PureContextMutation.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 4,
+        "actual_triggers_all_runs": 2524
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0039",
+      "name": "External Service Safety",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0039_ExternalServiceSafety.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "actual_triggers_all_runs": 211
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0045",
+      "name": "Complexity Control",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0045_ComplexityControl.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P5",
+        "P9"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)",
+        "P9": "Hunk-local removed vs added"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": true,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "Discovery",
+        "trigger_rate": 0.0663265306122449,
+        "precision": 0.0,
+        "recall": 0.0,
+        "usefulness": 0.0,
+        "actual_triggers_all_runs": 195
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0047",
+      "name": "Naming/Contract Alignment",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0047_NamingContractAlignment.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P5",
+        "P8"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)",
+        "P8": "Removed+added pair compare"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": false,
+      "requires_removed_added_pair": true,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "tier": "Discovery",
+        "trigger_rate": 0.017006802721088437,
+        "precision": 0.0,
+        "recall": 0.0,
+        "usefulness": 0.0,
+        "actual_triggers_all_runs": 1450
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0050",
+      "name": "SQL Column Truncation Risk",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0050_SqlColumnTruncationRisk.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {},
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0051",
+      "name": "Numeric Coercion Risks",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0051_NumericCoercionRisks.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {},
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0054",
+      "name": "Async Void Abuse",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0054_AsyncVoidAbuse.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {},
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0057",
+      "name": "Synchronous File I/O",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0057_BlockingAsyncViolation.cs",
+      "primary_patterns": [
+        "P1",
+        "P4"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "high",
+      "priority_tier": 2,
+      "corpus": {
+        "actual_triggers_all_runs": 10
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0001",
+      "name": "Diff Integrity",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0001_DiffIntegrity.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P5"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "actual_triggers_all_runs": 2674
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0007",
+      "name": "Error Handling Integrity",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0007_ErrorHandlingIntegrity.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P7"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P7": "Roslyn or syntax-guard augmented"
+      },
+      "domain": "general",
+      "uses_roslyn": true,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-3",
+        "RC-6",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "intentional-swallow",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 1,
+        "actual_triggers_all_runs": 1279
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0010",
+      "name": "Hardcoding and Configuration",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0010_HardcodingAndConfiguration.cs",
+      "primary_patterns": [
+        "P1",
+        "P4",
+        "P7"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context",
+        "P7": "Roslyn or syntax-guard augmented"
+      },
+      "domain": "general",
+      "uses_roslyn": true,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 2,
+        "actual_triggers_all_runs": 3225
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0012",
+      "name": "Security Risk",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0012_SecurityRisk.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P7"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P7": "Roslyn or syntax-guard augmented"
+      },
+      "domain": "general",
+      "uses_roslyn": true,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {
+        "tier": "Discovery",
+        "trigger_rate": 0.01870748299319728,
+        "precision": 0.455,
+        "recall": 0.062,
+        "usefulness": 0.0,
+        "actual_triggers_all_runs": 762
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0015",
+      "name": "Data Integrity Risk",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0015_DataIntegrityRisk.cs",
+      "primary_patterns": [
+        "P1",
+        "P4",
+        "P7"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context",
+        "P7": "Roslyn or syntax-guard augmented"
+      },
+      "domain": "general",
+      "uses_roslyn": true,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-3",
+        "RC-5",
+        "RC-6",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 11,
+        "actual_triggers_all_runs": 10389
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0021",
+      "name": "Data & Schema Compatibility",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0021_DataSchemaCompatibility.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P5",
+        "P9"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)",
+        "P9": "Hunk-local removed vs added"
+      },
+      "domain": "db",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": true,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 1,
+        "actual_triggers_all_runs": 998
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0041",
+      "name": "Test Quality Gaps",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0041_TestQualityGaps.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P5",
+        "P9"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)",
+        "P9": "Hunk-local removed vs added"
+      },
+      "domain": "repo-meta",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": true,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 2,
+        "actual_triggers_all_runs": 1325
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0048",
+      "name": "Insecure Random in Security Context",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0048_InsecureRandomInSecurityContext.cs",
+      "primary_patterns": [
+        "P1",
+        "P4",
+        "P7"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context",
+        "P7": "Roslyn or syntax-guard augmented"
+      },
+      "domain": "general",
+      "uses_roslyn": true,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-3",
+        "RC-6",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {},
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0049",
+      "name": "Float/Double Equality Comparison",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0049_FloatDoubleEqualityComparison.cs",
+      "primary_patterns": [
+        "P1",
+        "P4",
+        "P5",
+        "P7"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)",
+        "P7": "Roslyn or syntax-guard augmented"
+      },
+      "domain": "general",
+      "uses_roslyn": true,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-5",
+        "RC-6",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {
+        "tier": "Discovery",
+        "trigger_rate": 0.008503401360544218,
+        "precision": 0.0,
+        "recall": 0.0,
+        "usefulness": 0.0,
+        "actual_triggers_all_runs": 12
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0052",
+      "name": "Dependency Bot API Drift",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0052_DependencyBotApiDrift.cs",
+      "primary_patterns": [
+        "P1",
+        "P4",
+        "P5"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": true,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {},
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0053",
+      "name": "Lockfile Changed Without Source Review",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0053_LockfileChangedWithoutSource.cs",
+      "primary_patterns": [
+        "P4",
+        "P5"
+      ],
+      "pattern_notes": {
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)"
+      },
+      "domain": "repo-meta",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-2",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {},
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0055",
+      "name": "Method Signature Change Risk",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0055_MethodSignatureChange.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P5"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "high",
+      "root_causes": [
+        "RC-1",
+        "RC-2",
+        "RC-5",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "guard-deletion-remote-use",
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {
+        "actual_triggers_all_runs": 1
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0056",
+      "name": "Missing Test Framework",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0056_MissingTestFramework.cs",
+      "primary_patterns": [
+        "P4"
+      ],
+      "pattern_notes": {
+        "P4": "Token/regex without method context"
+      },
+      "domain": "repo-meta",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-2",
+        "RC-3",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "medium",
+      "priority_tier": 3,
+      "corpus": {},
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
+    },
+    {
+      "rule_id": "GCI0006",
+      "name": "Edge Case Handling",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0006_EdgeCaseHandling.cs",
+      "primary_patterns": [
+        "P1",
+        "P2",
+        "P4",
+        "P5",
+        "P7",
+        "P8",
+        "P9"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P2": "Removed-line substring scan",
+        "P4": "Token/regex without method context",
+        "P5": "Cross-entity compare (partial or required)",
+        "P7": "Roslyn or syntax-guard augmented",
+        "P8": "Removed+added pair compare",
+        "P9": "Hunk-local removed vs added"
+      },
+      "domain": "general",
+      "uses_roslyn": true,
+      "added_lines_only": true,
+      "requires_cross_method": false,
+      "requires_removed_added_pair": true,
+      "typical_fanout": "medium",
+      "root_causes": [
+        "RC-1",
+        "RC-5",
+        "RC-6",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "benign-token-use",
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [],
+      "head_to_head_risk": "low",
+      "priority_tier": 4,
+      "corpus": {
+        "tier": "all",
+        "trigger_rate": 0.0,
+        "precision": null,
+        "recall": null,
+        "usefulness": 0.0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 0,
+        "labeled_tp": 0,
+        "labeled_fp": 0,
+        "labeled_fn": 0,
+        "labeled_precision": null,
+        "labeled_recall": null,
+        "snapshot_usefulness": null,
+        "expected_triggers": 17,
+        "actual_triggers_all_runs": 10978
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": false
+    }
+  ],
+  "eval_notes": {
+    "regenerate": "python scripts/build-rule-audit.py",
+    "regenerate_full_labeled_metrics": "python scripts/build-rule-audit.py --full-corpus",
+    "corpus_default": "%USERPROFILE%\\.gauntletci\\corpus.db",
+    "metrics_sources": [
+      "aggregates (precision/recall/usefulness)",
+      "audit_snapshot_rows (labeled tp/fp/fn when snapshot exists)",
+      "fixtures_triggered_latest_run (distinct fixtures, latest completed run)"
+    ],
+    "redis_2995_regression": {
+      "adjudicated_defect": "MultiNodeSubscription.RemoveDisconnectedEndpoints inverted IsSubscriberConnected",
+      "miss_pattern": "P5 sibling-implementation (gap PG-RELATION)",
+      "noise_example_rules": [
+        "GCI0038",
+        "GCI0006",
+        "GCI0043"
+      ]
+    },
+    "audit_checklist_per_rule": [
+      "Tag P1-P9",
+      "Set requires_cross_method",
+      "Record corpus precision/fp",
+      "Add TP/FP/FN fixture triple",
+      "Score head_to_head_risk after human review"
+    ]
+  }
+}

--- a/scripts/build-rule-audit.py
+++ b/scripts/build-rule-audit.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""Build eval/rule-audit.json from rule sources and corpus.db metrics."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+RULES_DIR = REPO / "src" / "GauntletCI.Core" / "Rules" / "Implementations"
+CORPUS = Path(os.environ.get("USERPROFILE", "")) / ".gauntletci" / "corpus.db"
+CORPUS_PATH_DISPLAY = r"%USERPROFILE%\.gauntletci\corpus.db"
+OUT = REPO / "eval" / "rule-audit.json"
+FIXTURES_CSV = REPO / "data" / "corpus-fixtures.csv"
+
+ROOT_CAUSES = {
+    "RC-1": "Added-line treated as new risk (diff artifact blindness)",
+    "RC-2": "Line-local pattern without method/control-flow scope",
+    "RC-3": "No cross-entity reasoning (sibling methods, guard+use)",
+    "RC-4": "Domain assumptions (web/DI/EF) on all repos",
+    "RC-5": "Unbounded per-line fanout on large diffs",
+    "RC-6": "Confidence/severity does not gate delivery",
+    "RC-7": "Roslyn/semantics underused",
+    "RC-8": "Success metric is pattern fire, not adjudicated defect",
+}
+
+PATTERN_DEFS = {
+    "P1": "Added-line substring scan",
+    "P2": "Removed-line substring scan",
+    "P3": "File/diff aggregate (weak line anchor)",
+    "P4": "Token/regex without method context",
+    "P5": "Cross-entity compare (partial or required)",
+    "P6": "Web/DI/HTTP/DB domain-specific",
+    "P7": "Roslyn or syntax-guard augmented",
+    "P8": "Removed+added pair compare",
+    "P9": "Hunk-local removed vs added",
+}
+
+FN_CLASSES = [
+    "inverted-condition",
+    "sibling-implementation-drift",
+    "guard-deletion-remote-use",
+    "logic-bug-no-token",
+    "cross-file-contract",
+    "intentional-pattern",
+]
+
+FP_CLASSES = [
+    "refactor-restructure",
+    "library-factory-new",
+    "intentional-swallow",
+    "test-fixture-context",
+    "framework-exempt-pair",
+    "benign-token-use",
+    "large-feature-volume",
+]
+
+
+def normalize_rule_id(rid: str) -> str:
+    if rid.startswith("GCI") and len(rid) == 7 and rid[3:].isdigit():
+        return f"GCI{int(rid[3:]):04d}"
+    return rid
+
+
+def load_corpus_metrics() -> dict[str, dict]:
+    stats: dict[str, dict] = {}
+    if not CORPUS.exists():
+        return stats
+
+    con = sqlite3.connect(CORPUS)
+    cur = con.cursor()
+
+    # Silver aggregates (rule-level precision/recall/usefulness)
+    try:
+        rows = cur.execute(
+            """
+            SELECT rule_id, tier, trigger_rate, precision_score, recall_score, usefulness_score
+            FROM aggregates
+            """
+        ).fetchall()
+        for rid, tier, trig, prec, rec, useful in rows:
+            rid = normalize_rule_id(rid)
+            stats[rid] = {
+                "tier": tier,
+                "trigger_rate": trig,
+                "precision": round(float(prec), 3) if prec is not None else None,
+                "recall": round(float(rec), 3) if rec is not None else None,
+                "usefulness": round(float(useful), 3) if useful is not None else None,
+            }
+    except sqlite3.Error:
+        pass
+
+    # Latest audit snapshot TP/FP/FN (if present)
+    try:
+        snap = cur.execute(
+            "SELECT id FROM audit_snapshots ORDER BY snapped_at_utc DESC LIMIT 1"
+        ).fetchone()
+        if snap:
+            rows = cur.execute(
+                """
+                SELECT rule_id, tp, fp, fn, precision_score, recall_score, usefulness_score
+                FROM audit_snapshot_rows
+                WHERE snapshot_id = ?
+                """,
+                (snap[0],),
+            ).fetchall()
+            for rid, tp, fp, fn, prec, rec, useful in rows:
+                rid = normalize_rule_id(rid)
+                entry = stats.setdefault(rid, {})
+                entry.update(
+                    {
+                        "tp": int(tp or 0),
+                        "fp": int(fp or 0),
+                        "fn": int(fn or 0),
+                        "labeled_tp": int(tp or 0),
+                        "labeled_fp": int(fp or 0),
+                        "labeled_fn": int(fn or 0),
+                        "labeled_precision": round(float(prec), 3) if prec is not None else None,
+                        "labeled_recall": round(float(rec), 3) if rec is not None else None,
+                        "snapshot_usefulness": round(float(useful), 3) if useful is not None else None,
+                    }
+                )
+                if prec is not None:
+                    entry["precision"] = round(float(prec), 3)
+                if rec is not None:
+                    entry["recall"] = round(float(rec), 3)
+    except sqlite3.Error:
+        pass
+
+    # Expected vs actual trigger counts (label coverage signal)
+    try:
+        rows = cur.execute(
+            """
+            SELECT rule_id, COUNT(*)
+            FROM expected_findings
+            WHERE should_trigger = 1 AND COALESCE(is_inconclusive, 0) = 0
+            GROUP BY rule_id
+            """
+        ).fetchall()
+        for rid, c in rows:
+            rid = normalize_rule_id(rid)
+            stats.setdefault(rid, {})["expected_triggers"] = int(c)
+    except sqlite3.Error:
+        pass
+
+    try:
+        rows = cur.execute(
+            """
+            WITH latest_run AS (
+                SELECT fixture_id, MAX(id) AS run_id
+                FROM rule_runs
+                WHERE status = 'completed'
+                GROUP BY fixture_id
+            )
+            SELECT af.rule_id, COUNT(DISTINCT af.fixture_id)
+            FROM actual_findings af
+            INNER JOIN latest_run lr ON lr.run_id = af.run_id
+            WHERE af.did_trigger = 1
+            GROUP BY af.rule_id
+            """
+        ).fetchall()
+        for rid, c in rows:
+            rid = normalize_rule_id(rid)
+            stats.setdefault(rid, {})["fixtures_triggered_latest_run"] = int(c)
+    except sqlite3.Error:
+        pass
+
+    try:
+        rows = cur.execute(
+            """
+            SELECT rule_id, COUNT(*)
+            FROM actual_findings
+            WHERE did_trigger = 1
+            GROUP BY rule_id
+            """
+        ).fetchall()
+        for rid, c in rows:
+            rid = normalize_rule_id(rid)
+            stats.setdefault(rid, {})["actual_triggers_all_runs"] = int(c)
+    except sqlite3.Error:
+        pass
+
+    # Per-fixture labeled TP/FN/FP: use audit snapshot when available (fast path).
+    # Full recompute from actual_findings is optional via --full-corpus flag.
+    con.close()
+    return stats
+
+
+def load_labeled_classifier_metrics() -> dict[str, dict]:
+    """Heavy join across actual_findings; run only with --full-corpus."""
+    stats: dict[str, dict] = {}
+    if not CORPUS.exists():
+        return stats
+    con = sqlite3.connect(CORPUS)
+    cur = con.cursor()
+    try:
+        rows = cur.execute(
+            """
+            WITH latest_run AS (
+                SELECT fixture_id, MAX(id) AS run_id
+                FROM rule_runs
+                WHERE status = 'completed'
+                GROUP BY fixture_id
+            ),
+            fired AS (
+                SELECT af.fixture_id, af.rule_id
+                FROM actual_findings af
+                INNER JOIN latest_run lr ON lr.run_id = af.run_id
+                WHERE af.did_trigger = 1
+                GROUP BY af.fixture_id, af.rule_id
+            ),
+            expected AS (
+                SELECT fixture_id, rule_id
+                FROM expected_findings
+                WHERE should_trigger = 1 AND COALESCE(is_inconclusive, 0) = 0
+            )
+            SELECT e.rule_id,
+                   SUM(CASE WHEN f.fixture_id IS NOT NULL THEN 1 ELSE 0 END) AS tp,
+                   SUM(CASE WHEN f.fixture_id IS NULL THEN 1 ELSE 0 END) AS fn
+            FROM expected e
+            LEFT JOIN fired f ON f.fixture_id = e.fixture_id AND f.rule_id = e.rule_id
+            GROUP BY e.rule_id
+            """
+        ).fetchall()
+        for rid, tp, fn in rows:
+            rid = normalize_rule_id(rid)
+            entry = stats.setdefault(rid, {})
+            entry["labeled_tp"] = int(tp or 0)
+            entry["labeled_fn"] = int(fn or 0)
+    except sqlite3.Error:
+        pass
+
+    try:
+        rows = cur.execute(
+            """
+            WITH latest_run AS (
+                SELECT fixture_id, MAX(id) AS run_id
+                FROM rule_runs
+                WHERE status = 'completed'
+                GROUP BY fixture_id
+            ),
+            fired AS (
+                SELECT af.fixture_id, af.rule_id
+                FROM actual_findings af
+                INNER JOIN latest_run lr ON lr.run_id = af.run_id
+                WHERE af.did_trigger = 1
+                GROUP BY af.fixture_id, af.rule_id
+            ),
+            expected AS (
+                SELECT fixture_id, rule_id
+                FROM expected_findings
+                WHERE should_trigger = 1 AND COALESCE(is_inconclusive, 0) = 0
+            )
+            SELECT f.rule_id, COUNT(*) AS fp
+            FROM fired f
+            LEFT JOIN expected e
+              ON e.fixture_id = f.fixture_id AND e.rule_id = f.rule_id
+            WHERE e.fixture_id IS NULL
+            GROUP BY f.rule_id
+            """
+        ).fetchall()
+        for rid, fp in rows:
+            rid = normalize_rule_id(rid)
+            entry = stats.setdefault(rid, {})
+            entry["labeled_fp"] = int(fp or 0)
+            tp = entry.get("labeled_tp", 0)
+            fp = int(fp or 0)
+            fn = entry.get("labeled_fn", 0)
+            if tp + fp:
+                entry["labeled_precision"] = round(tp / (tp + fp), 3)
+            if tp + fn:
+                entry["labeled_recall"] = round(tp / (tp + fn), 3)
+    except sqlite3.Error:
+        pass
+
+    con.close()
+    return stats
+
+
+def load_fixture_rule_frequency() -> dict[str, int]:
+    freq: dict[str, int] = {}
+    if not FIXTURES_CSV.exists():
+        return freq
+    for line in FIXTURES_CSV.read_text(encoding="utf-8").splitlines()[1:]:
+        parts = line.split(",")
+        if len(parts) < 8:
+            continue
+        rules_field = parts[7]
+        for token in rules_field.split(";"):
+            token = token.strip()
+            if token.startswith("GCI"):
+                rid = normalize_rule_id(token)
+                freq[rid] = freq.get(rid, 0) + 1
+    return freq
+
+
+def tag_patterns(text: str) -> list[str]:
+    tags: list[str] = []
+    if "AddedLines" in text or "DiffLineKind.Added" in text:
+        tags.append("P1")
+    if "RemovedLines" in text or "DiffLineKind.Removed" in text:
+        tags.append("P2")
+    if re.search(r"CreateFinding\(\s*\n\s*(string|\$)", text) or "CheckLogicRemovedWithoutTests" in text:
+        tags.append("P3")
+    if "Contains(" in text or "Regex" in text or "IsMatch" in text:
+        tags.append("P4")
+    if any(k in text for k in ("removedContent", "addedContent", "Compare", "SingleNode", "MultiNode")):
+        tags.append("P5")
+    if any(
+        k in text
+        for k in (
+            "HttpPost",
+            "AddSingleton",
+            "AddScoped",
+            "GetService",
+            "ServiceLocator",
+            "INSERT INTO",
+            "AddTransient",
+        )
+    ):
+        tags.append("P6")
+    if any(k in text for k in ("AddRoslynFindings", "context.StaticAnalysis", "context.Syntax", "CSharpSyntaxTree")):
+        tags.append("P7")
+    if "removedContent" in text and "addedContent" in text:
+        tags.append("P8")
+    if "hunk" in text.lower() and ("removedLine" in text or "addedLine" in text):
+        tags.append("P9")
+    return [p for p in ("P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9") if p in tags]
+
+
+def infer_domain(text: str, name: str) -> str:
+    if any(k in text for k in ("HttpPost", "AddSingleton", "GetService", "ServiceLocator")):
+        return "web-di"
+    if "INSERT INTO" in text or "Sql" in name or "Schema" in name:
+        return "db"
+    if "Layer" in name or "Architecture" in name:
+        return "layered-app"
+    if "Test" in name or "Lockfile" in name:
+        return "repo-meta"
+    return "general"
+
+
+def infer_root_causes(tags: list[str], text: str, domain: str, uses_roslyn: bool) -> list[str]:
+    rcs: list[str] = []
+    if "P1" in tags:
+        rcs.extend(["RC-1", "RC-8"])
+    if "P4" in tags and "P7" not in tags:
+        rcs.append("RC-2")
+    if "P5" not in tags or ("override" not in text and "removedContent" not in text):
+        if any(k in text for k in ("if (", "while (", "catch", "IsSubscriberConnected")):
+            rcs.append("RC-3")
+    if domain in ("web-di", "layered-app"):
+        rcs.append("RC-4")
+    if "foreach (var line in file.AddedLines)" in text or text.count("CreateFinding") >= 4:
+        rcs.append("RC-5")
+    rcs.append("RC-6")
+    if not uses_roslyn:
+        rcs.append("RC-7")
+    rcs.append("RC-8")
+    return sorted(set(rcs))
+
+
+def requires_cross_method(tags: list[str], text: str) -> bool:
+    if any(k in text.lower() for k in ("condition", "catch", "async", "lock", "subscribe", "remove")):
+        return "P5" not in tags or tags.count("P5") == 1 and "removedContent" not in text
+    return False
+
+
+def head_to_head_risk(tags: list[str], domain: str, corpus: dict, fixture_freq: int) -> str:
+    score = 0
+    if "P1" in tags and "P5" not in tags:
+        score += 2
+    if "P4" in tags and "P7" not in tags:
+        score += 2
+    if domain == "web-di":
+        score += 2
+    prec = corpus.get("labeled_precision", corpus.get("precision"))
+    fp = corpus.get("labeled_fp", corpus.get("fp", 0))
+    if prec is not None and prec < 0.25:
+        score += 2
+    elif fp and fp > 20:
+        score += 1
+    if fixture_freq > 100:
+        score += 1
+    if corpus.get("fixtures_triggered_latest_run", 0) > 80 and (prec is None or prec < 0.5):
+        score += 1
+    if score >= 5:
+        return "critical"
+    if score >= 3:
+        return "high"
+    if score >= 1:
+        return "medium"
+    return "low"
+
+
+def known_fp_classes(tags: list[str], domain: str, name: str) -> list[str]:
+    fps: list[str] = []
+    if "P1" in tags:
+        fps.append("refactor-restructure")
+    if domain == "web-di":
+        fps.extend(["library-factory-new", "large-feature-volume"])
+    if "Error Handling" in name or "GCI0007" in name:
+        fps.append("intentional-swallow")
+    if "Pattern Consistency" in name or "Idempotency" in name:
+        fps.append("framework-exempt-pair")
+    if "P4" in tags:
+        fps.append("benign-token-use")
+    return sorted(set(fps))
+
+
+def known_fn_classes(tags: list[str], requires_xmethod: bool) -> list[str]:
+    fns: list[str] = []
+    if requires_xmethod:
+        fns.extend(["inverted-condition", "sibling-implementation-drift", "logic-bug-no-token"])
+    if "P2" in tags and "P8" not in tags:
+        fns.append("guard-deletion-remote-use")
+    return sorted(set(fns))
+
+
+def priority_tier(risk: str, corpus: dict) -> int:
+    base = {"critical": 1, "high": 2, "medium": 3, "low": 4}[risk]
+    fp = corpus.get("labeled_fp", corpus.get("fp", 0))
+    if fp and fp > 50:
+        return max(1, base - 1)
+    return base
+
+
+def analyze_rule(path: Path, corpus_stats: dict, fixture_freq: dict) -> dict:
+    text = path.read_text(encoding="utf-8")
+    rid_m = re.search(r'Id => "(GCI\d+)"', text)
+    name_m = re.search(r'Name => "([^"]+)"', text)
+    rid = normalize_rule_id(rid_m.group(1)) if rid_m else path.stem.split("_")[0]
+    name = name_m.group(1) if name_m else path.stem
+    tags = tag_patterns(text)
+    domain = infer_domain(text, name)
+    uses_roslyn = "AddRoslynFindings" in text or "context.Syntax" in text
+    added_only = "AddedLines" in text and "RemovedLines" not in text
+    cross_method = requires_cross_method(tags, text)
+    corpus = corpus_stats.get(rid, {})
+    ff = fixture_freq.get(rid, 0)
+    h2h = head_to_head_risk(tags, domain, corpus, ff)
+    fanout = "low"
+    if "foreach (var line in file.AddedLines)" in text:
+        fanout = "high"
+    elif "AddedLines" in text and text.count("CreateFinding") > 3:
+        fanout = "medium"
+
+    return {
+        "rule_id": rid,
+        "name": name,
+        "source_file": str(path.relative_to(REPO)).replace("\\", "/"),
+        "primary_patterns": tags,
+        "pattern_notes": {p: PATTERN_DEFS[p] for p in tags},
+        "domain": domain,
+        "uses_roslyn": uses_roslyn,
+        "added_lines_only": added_only,
+        "requires_cross_method": cross_method,
+        "requires_removed_added_pair": "P8" in tags or "P9" in tags,
+        "typical_fanout": fanout,
+        "root_causes": infer_root_causes(tags, text, domain, uses_roslyn),
+        "known_fp_classes": known_fp_classes(tags, domain, name),
+        "known_fn_classes": known_fn_classes(tags, cross_method),
+        "head_to_head_risk": h2h,
+        "priority_tier": priority_tier(h2h, corpus),
+        "corpus": corpus,
+        "fixture_trigger_count": ff,
+        "audit_status": "auto-tagged",
+        "human_review_required": cross_method or h2h in ("critical", "high"),
+    }
+
+
+def main() -> None:
+    import sys
+
+    full_corpus = "--full-corpus" in sys.argv
+    corpus_stats = load_corpus_metrics()
+    if full_corpus:
+        labeled = load_labeled_classifier_metrics()
+        for rid, extra in labeled.items():
+            corpus_stats.setdefault(rid, {}).update(extra)
+    fixture_freq = load_fixture_rule_frequency()
+    rules = [analyze_rule(p, corpus_stats, fixture_freq) for p in sorted(RULES_DIR.glob("GCI*.cs"))]
+    rules.sort(key=lambda r: (r["priority_tier"], r["rule_id"]))
+
+    # Corpus-derived systemic issues
+    core_issues: list[dict] = []
+    by_fp = sorted(
+        [r for r in rules if r["corpus"].get("labeled_fp")],
+        key=lambda r: r["corpus"]["labeled_fp"],
+        reverse=True,
+    )
+    for r in by_fp[:8]:
+        core_issues.append(
+            {
+                "issue": "high_labeled_false_positives",
+                "rule_id": r["rule_id"],
+                "name": r["name"],
+                "labeled_fp": r["corpus"]["labeled_fp"],
+                "labeled_precision": r["corpus"].get("labeled_precision"),
+                "actual_triggers": r["corpus"].get("fixtures_triggered_latest_run"),
+                "primary_patterns": r["primary_patterns"],
+            }
+        )
+
+    low_prec = sorted(
+        [
+            r
+            for r in rules
+            if r["corpus"].get("labeled_precision") is not None
+            and r["corpus"]["labeled_precision"] < 0.2
+            and r["corpus"].get("labeled_fp", 0) >= 5
+        ],
+        key=lambda r: r["corpus"]["labeled_precision"],
+    )
+    for r in low_prec[:8]:
+        core_issues.append(
+            {
+                "issue": "low_labeled_precision",
+                "rule_id": r["rule_id"],
+                "name": r["name"],
+                "labeled_precision": r["corpus"]["labeled_precision"],
+                "labeled_recall": r["corpus"].get("labeled_recall"),
+                "labeled_fp": r["corpus"].get("labeled_fp"),
+            }
+        )
+
+    high_trigger_noise = sorted(
+        [
+            r
+            for r in rules
+            if r["corpus"].get("fixtures_triggered_latest_run", 0) > 80
+            and (r["corpus"].get("usefulness") or 0) < 0.5
+        ],
+        key=lambda r: r["corpus"].get("fixtures_triggered_latest_run", 0),
+        reverse=True,
+    )
+    for r in high_trigger_noise[:6]:
+        core_issues.append(
+            {
+                "issue": "high_volume_low_usefulness",
+                "rule_id": r["rule_id"],
+                "name": r["name"],
+                "fixtures_triggered": r["corpus"].get("fixtures_triggered_latest_run"),
+                "usefulness": r["corpus"].get("usefulness"),
+                "typical_fanout": r["typical_fanout"],
+            }
+        )
+
+    cross_method_no_p5 = [
+        r["rule_id"]
+        for r in rules
+        if r["requires_cross_method"] and "P5" not in r["primary_patterns"]
+    ]
+    core_issues.append(
+        {
+            "issue": "structural_fn_risk_cross_method_without_p5",
+            "rule_count": len(cross_method_no_p5),
+            "rule_ids": cross_method_no_p5,
+            "description": "Rules touching control-flow semantics but lacking cross-entity compare (Redis MultiNode class)",
+        }
+    )
+
+    domain_mismatch = [
+        {
+            "rule_id": r["rule_id"],
+            "name": r["name"],
+            "domain": r["domain"],
+            "labeled_fp": r["corpus"].get("labeled_fp"),
+        }
+        for r in rules
+        if r["domain"] == "web-di" and r["corpus"].get("labeled_fp", 0) > 10
+    ]
+    core_issues.append(
+        {
+            "issue": "web_di_domain_mismatch_on_general_repos",
+            "rules": domain_mismatch,
+            "description": "DI/HTTP rules firing heavily on non-web corpus fixtures (library/infra PRs)",
+        }
+    )
+
+    priority_fix_order = [
+        {
+            "rank": i + 1,
+            "rule_id": r["rule_id"],
+            "name": r["name"],
+            "head_to_head_risk": r["head_to_head_risk"],
+            "priority_tier": r["priority_tier"],
+            "top_root_causes": r["root_causes"][:4],
+            "corpus_fp": r["corpus"].get("labeled_fp", r["corpus"].get("fp")),
+            "corpus_precision": r["corpus"].get("labeled_precision", r["corpus"].get("precision")),
+            "corpus_recall": r["corpus"].get("labeled_recall", r["corpus"].get("recall")),
+            "fixtures_triggered": r["corpus"].get("fixtures_triggered_latest_run"),
+            "actual_triggers_all_runs": r["corpus"].get("actual_triggers_all_runs"),
+        }
+        for i, r in enumerate(rules)
+        if r["head_to_head_risk"] in ("critical", "high") or r["priority_tier"] <= 2
+    ][:20]
+
+    platform_gaps = [
+        {
+            "gap_id": "PG-RELATION",
+            "title": "Sibling / paired-implementation compare",
+            "root_cause": "RC-3",
+            "rules_blocked": [r["rule_id"] for r in rules if r["requires_cross_method"]],
+            "fix": "New cross-method layer: same override name, opposite boolean polarity, method name vs condition",
+        },
+        {
+            "gap_id": "PG-PROVENANCE",
+            "title": "Line provenance (move vs net-new)",
+            "root_cause": "RC-1",
+            "rules_blocked": [r["rule_id"] for r in rules if "P1" in r["primary_patterns"]],
+            "fix": "Similarity match added hunks to removed hunks before firing",
+        },
+        {
+            "gap_id": "PG-DOMAIN",
+            "title": "Repo/domain classifier",
+            "root_cause": "RC-4",
+            "rules_blocked": [r["rule_id"] for r in rules if r["domain"] in ("web-di", "layered-app")],
+            "fix": "Suppress or downgrade DI/HTTP rules on library/infrastructure repos",
+        },
+        {
+            "gap_id": "PG-DELIVERY",
+            "title": "Ranked actionable output",
+            "root_cause": "RC-5, RC-6",
+            "rules_blocked": ["ALL"],
+            "fix": "Per-rule caps + move SilverLabel coordinations to RuleOrchestrator post-process",
+        },
+        {
+            "gap_id": "PG-SEMANTICS",
+            "title": "Method-scoped Roslyn + counterfactuals",
+            "root_cause": "RC-7",
+            "rules_blocked": [r["rule_id"] for r in rules if not r["uses_roslyn"] and "P4" in r["primary_patterns"]],
+            "fix": "Wire PatchCounterfactualGenerator; bind P4 tokens to control-flow sites",
+        },
+    ]
+
+    doc = {
+        "schema_version": "1.0.0",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "corpus_path": CORPUS_PATH_DISPLAY,
+        "corpus_loaded": CORPUS.exists(),
+        "rule_count": len(rules),
+        "pattern_taxonomy": PATTERN_DEFS,
+        "root_cause_taxonomy": ROOT_CAUSES,
+        "fn_class_taxonomy": FN_CLASSES,
+        "fp_class_taxonomy": FP_CLASSES,
+        "platform_gaps": platform_gaps,
+        "core_issues_from_corpus": core_issues,
+        "priority_fix_order": priority_fix_order,
+        "rules": rules,
+        "eval_notes": {
+            "regenerate": "python scripts/build-rule-audit.py",
+            "regenerate_full_labeled_metrics": "python scripts/build-rule-audit.py --full-corpus",
+            "corpus_default": "%USERPROFILE%\\.gauntletci\\corpus.db",
+            "metrics_sources": [
+                "aggregates (precision/recall/usefulness)",
+                "audit_snapshot_rows (labeled tp/fp/fn when snapshot exists)",
+                "fixtures_triggered_latest_run (distinct fixtures, latest completed run)",
+            ],
+            "redis_2995_regression": {
+                "adjudicated_defect": "MultiNodeSubscription.RemoveDisconnectedEndpoints inverted IsSubscriberConnected",
+                "miss_pattern": "P5 sibling-implementation (gap PG-RELATION)",
+                "noise_example_rules": ["GCI0038", "GCI0006", "GCI0043"],
+            },
+            "audit_checklist_per_rule": [
+                "Tag P1-P9",
+                "Set requires_cross_method",
+                "Record corpus precision/fp",
+                "Add TP/FP/FN fixture triple",
+                "Score head_to_head_risk after human review",
+            ],
+        },
+    }
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {OUT} ({len(rules)} rules, corpus rules: {len(corpus_stats)})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `scripts/build-rule-audit.py` to regenerate `eval/rule-audit.json` from the agent corpus at `%USERPROFILE%\.gauntletci\corpus.db` (not the empty repo shell DB).
- Commits a sanitized snapshot (36 rules, platform gaps PG-*, priority tiers, Redis #2995 regression notes).
- `corpus_path` in JSON is always the portable `%USERPROFILE%\.gauntletci\corpus.db` form — no machine-specific paths.

## Regenerate locally

```powershell
python scripts/build-rule-audit.py
# slow labeled TP/FP/FN recompute:
python scripts/build-rule-audit.py --full-corpus
```

## Test plan

- [x] `python scripts/build-rule-audit.py` completes and writes sanitized `corpus_path`
- [ ] CI (no .NET changes; JSON + Python only)
