### PR TITLE
feat(redis): GCI0058 hardening, regression fixture, benchmark CI, case study

### DIFF
--- a/.github/workflows/redis-benchmark.yml
+++ b/.github/workflows/redis-benchmark.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   redis-benchmark:
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -28,6 +30,8 @@ jobs:
 
       - name: Run Redis #2995 benchmark
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/run-redis-benchmark.ps1
 

--- a/.github/workflows/redis-benchmark.yml
+++ b/.github/workflows/redis-benchmark.yml
@@ -1,0 +1,48 @@
+name: Redis PR2995 Benchmark
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/GauntletCI.Core/**"
+      - "scripts/run-redis-benchmark.ps1"
+      - ".github/workflows/redis-benchmark.yml"
+      - "eval/redis-2995-scorecard.json"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/GauntletCI.Core/**"
+      - "scripts/run-redis-benchmark.ps1"
+      - ".github/workflows/redis-benchmark.yml"
+
+jobs:
+  redis-benchmark:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Run Redis #2995 benchmark
+        shell: pwsh
+        run: |
+          ./scripts/run-redis-benchmark.ps1
+
+      - name: Assert GCI0058 ground truth
+        shell: pwsh
+        run: |
+          $path = Join-Path $env:GITHUB_WORKSPACE "eval/redis-2995-latest.json"
+          if (-not (Test-Path $path)) { throw "Missing $path" }
+          $doc = Get-Content $path -Raw | ConvertFrom-Json
+          $findings = @($doc.Findings)
+          $g58 = @($findings | Where-Object { $_.RuleId -eq "GCI0058" })
+          if ($g58.Count -lt 1) {
+            throw "Expected at least one GCI0058 finding for Redis PR #2995"
+          }
+          if ($findings.Count -gt 25) {
+            throw "Delivery cap exceeded: $($findings.Count) findings (max 25)"
+          }
+          Write-Host "OK: $($findings.Count) delivered findings, $($g58.Count) GCI0058"

--- a/eval/rule-audit.json
+++ b/eval/rule-audit.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-05-30T01:04:50.686035+00:00",
+  "generated_at": "2026-05-30T01:53:37.033923+00:00",
   "corpus_path": "%USERPROFILE%\\.gauntletci\\corpus.db",
   "corpus_loaded": true,
-  "rule_count": 36,
+  "rule_count": 37,
   "pattern_taxonomy": {
     "P1": "Added-line substring scan",
     "P2": "Removed-line substring scan",
@@ -81,7 +81,8 @@
         "GCI0052",
         "GCI0053",
         "GCI0055",
-        "GCI0056"
+        "GCI0056",
+        "GCI0058"
       ],
       "fix": "New cross-method layer: same override name, opposite boolean polarity, method name vs condition"
     },
@@ -123,7 +124,8 @@
         "GCI0049",
         "GCI0052",
         "GCI0055",
-        "GCI0006"
+        "GCI0006",
+        "GCI0058"
       ],
       "fix": "Similarity match added hunks to removed hunks before firing"
     },
@@ -2571,11 +2573,53 @@
         "labeled_recall": null,
         "snapshot_usefulness": null,
         "expected_triggers": 17,
-        "actual_triggers_all_runs": 10978
+        "actual_triggers_all_runs": 10979
       },
       "fixture_trigger_count": 0,
       "audit_status": "auto-tagged",
       "human_review_required": false
+    },
+    {
+      "rule_id": "GCI0058",
+      "name": "Paired Implementation Consistency",
+      "source_file": "src/GauntletCI.Core/Rules/Implementations/GCI0058_PairedImplementationConsistency.cs",
+      "primary_patterns": [
+        "P1",
+        "P5"
+      ],
+      "pattern_notes": {
+        "P1": "Added-line substring scan",
+        "P5": "Cross-entity compare (partial or required)"
+      },
+      "domain": "general",
+      "uses_roslyn": false,
+      "added_lines_only": false,
+      "requires_cross_method": true,
+      "requires_removed_added_pair": false,
+      "typical_fanout": "low",
+      "root_causes": [
+        "RC-1",
+        "RC-6",
+        "RC-7",
+        "RC-8"
+      ],
+      "known_fp_classes": [
+        "refactor-restructure"
+      ],
+      "known_fn_classes": [
+        "inverted-condition",
+        "logic-bug-no-token",
+        "sibling-implementation-drift"
+      ],
+      "head_to_head_risk": "low",
+      "priority_tier": 4,
+      "corpus": {
+        "expected_triggers": 1,
+        "actual_triggers_all_runs": 1
+      },
+      "fixture_trigger_count": 0,
+      "audit_status": "auto-tagged",
+      "human_review_required": true
     }
   ],
   "eval_notes": {
@@ -2590,6 +2634,8 @@
     "redis_2995_regression": {
       "adjudicated_defect": "MultiNodeSubscription.RemoveDisconnectedEndpoints inverted IsSubscriberConnected",
       "miss_pattern": "P5 sibling-implementation (gap PG-RELATION)",
+      "gold_fixture_id": "redis-2995-multinode-inverted",
+      "primary_rule": "GCI0058",
       "noise_example_rules": [
         "GCI0038",
         "GCI0006",

--- a/scripts/build-rule-audit.py
+++ b/scripts/build-rule-audit.py
@@ -663,6 +663,8 @@ def main() -> None:
             "redis_2995_regression": {
                 "adjudicated_defect": "MultiNodeSubscription.RemoveDisconnectedEndpoints inverted IsSubscriberConnected",
                 "miss_pattern": "P5 sibling-implementation (gap PG-RELATION)",
+                "gold_fixture_id": "redis-2995-multinode-inverted",
+                "primary_rule": "GCI0058",
                 "noise_example_rules": ["GCI0038", "GCI0006", "GCI0043"],
             },
             "audit_checklist_per_rule": [

--- a/scripts/eval-lab-redis-benchmark.workflow.yml
+++ b/scripts/eval-lab-redis-benchmark.workflow.yml
@@ -1,0 +1,76 @@
+# Eval lab workflow: GauntletCI Redis PR #2995 benchmark
+#
+# Copy to EricCogen/ai-review-eval-stackexchange-redis as:
+#   .github/workflows/gauntletci-redis-benchmark.yml
+#
+# Requires: checkout GauntletCI at a pinned ref or use `dotnet tool install gauntletci`
+
+name: GauntletCI Redis Benchmark
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "benchmarks/**"
+      - ".github/workflows/gauntletci-redis-benchmark.yml"
+
+jobs:
+  gauntletci-redis-2995:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Checkout GauntletCI
+        uses: actions/checkout@v6
+        with:
+          repository: EricCogen/GauntletCI
+          path: gauntletci
+          ref: main
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Fetch Redis PR #2995 diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/StackExchange/StackExchange.Redis/pulls/2995 --jq .diff_url \
+            | xargs curl -fsSL -o /tmp/redis-2995.diff
+
+      - name: Run benchmark
+        run: |
+          cd gauntletci
+          dotnet build GauntletCI.slnx -v quiet --nologo
+          CONFIG=/tmp/gci-redis-eval
+          mkdir -p "$CONFIG"
+          cat > "$CONFIG/.gauntletci.json" <<'EOF'
+          {
+            "domain": { "profile": "library" },
+            "output": { "delivery": { "enabled": true, "globalMaxFindings": 25 } },
+            "provenance": { "enabled": true },
+            "semantics": { "enabled": true }
+          }
+          EOF
+          dotnet run --project src/GauntletCI.Cli --no-build -- analyze \
+            --diff /tmp/redis-2995.diff \
+            --repo "$CONFIG" \
+            --output /tmp/redis-2995-out.json \
+            --sensitivity permissive \
+            --no-banner
+
+      - name: Assert GCI0058
+        run: |
+          python3 - <<'PY'
+          import json, sys
+          doc = json.load(open("/tmp/redis-2995-out.json", encoding="utf-8-sig"))
+          findings = doc.get("Findings") or []
+          g58 = [f for f in findings if f.get("RuleId") == "GCI0058"]
+          if not g58:
+              sys.exit("Missing GCI0058 — ground truth regression")
+          if len(findings) > 25:
+              sys.exit(f"Delivery cap exceeded: {len(findings)}")
+          print(f"OK: {len(findings)} findings, {len(g58)} GCI0058")
+          PY

--- a/scripts/run-redis-benchmark.ps1
+++ b/scripts/run-redis-benchmark.ps1
@@ -10,9 +10,30 @@ Set-Location $RepoRoot
 
 if (-not (Test-Path $DiffPath)) {
     Write-Host "Fetching diff from GitHub..."
-    gh api repos/StackExchange/StackExchange.Redis/pulls/2995 --jq .diff_url | ForEach-Object {
-        Invoke-WebRequest -Uri $_ -OutFile $DiffPath
+    $diffDir = Split-Path $DiffPath -Parent
+    if ($diffDir) {
+        New-Item -ItemType Directory -Force -Path $diffDir | Out-Null
     }
+
+    $token = if ($env:GH_TOKEN) { $env:GH_TOKEN } elseif ($env:GITHUB_TOKEN) { $env:GITHUB_TOKEN } else { $null }
+    if ($token) {
+        Invoke-WebRequest `
+            -Uri "https://api.github.com/repos/StackExchange/StackExchange.Redis/pulls/2995" `
+            -Headers @{
+                Authorization = "Bearer $token"
+                Accept        = "application/vnd.github.diff"
+            } `
+            -OutFile $DiffPath
+    }
+    else {
+        gh api repos/StackExchange/StackExchange.Redis/pulls/2995 `
+            --header "Accept: application/vnd.github.diff" `
+            -o $DiffPath
+    }
+}
+
+if (-not (Test-Path $DiffPath)) {
+    throw "Failed to fetch Redis PR #2995 diff to $DiffPath"
 }
 
 $configDir = Join-Path $env:TEMP "gci-redis-eval"

--- a/scripts/seed-redis-2995-gci0058-fixture.py
+++ b/scripts/seed-redis-2995-gci0058-fixture.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Seed gold corpus fixture redis-2995-multinode-inverted into ~/.gauntletci/corpus.db.
+
+After seeding, verify with:
+  dotnet run --project src/GauntletCI.Cli -- corpus run \\
+    --fixture redis-2995-multinode-inverted \\
+    --db %USERPROFILE%\\.gauntletci\\corpus.db \\
+    --fixtures %USERPROFILE%\\.gauntletci\\fixtures
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+FIXTURE_ID = "redis-2995-multinode-inverted"
+REPO = "StackExchange/StackExchange.Redis"
+PR_NUMBER = 2995
+
+DIFF_PATCH = """diff --git a/src/StackExchange.Redis/Subscription.cs b/src/StackExchange.Redis/Subscription.cs
+index abc..def 100644
+--- a/src/StackExchange.Redis/Subscription.cs
++++ b/src/StackExchange.Redis/Subscription.cs
+@@ -240,40 +240,60 @@
+     internal sealed class SingleNodeSubscription : Subscription
+     {
+         internal override void RemoveDisconnectedEndpoints()
+         {
+             var server = _currentServer;
+             if (server is { IsSubscriberConnected: false })
+             {
+                 _currentServer = null;
+             }
+         }
+     }
+
+     internal sealed class MultiNodeSubscription : Subscription
+     {
+         internal override void RemoveDisconnectedEndpoints()
+         {
+             foreach (var server in _servers)
+             {
++                if (server.Value.IsSubscriberConnected)
++                {
++                    scratch[count++] = server.Key;
++                }
+             }
+         }
+     }
+"""
+
+EXPECTED = [
+    {
+        "RuleId": "GCI0058",
+        "ShouldTrigger": True,
+        "ExpectedConfidence": 0.95,
+        "Reason": "MultiNodeSubscription inverts IsSubscriberConnected vs SingleNodeSubscription (Redis PR #2995 adjudicated defect).",
+        "LabelSource": "Manual",
+        "IsInconclusive": False,
+    }
+]
+
+METADATA = {
+    "FixtureId": FIXTURE_ID,
+    "Tier": "Gold",
+    "Repo": REPO,
+    "PullRequestNumber": PR_NUMBER,
+    "Language": "csharp",
+    "RuleIds": ["GCI0058"],
+    "Tags": ["redis", "paired-implementation", "regression", "library"],
+    "PrSizeBucket": "Small",
+    "FilesChanged": 1,
+    "HasTestsChanged": False,
+    "HasReviewComments": True,
+    "BaseSha": "",
+    "HeadSha": "",
+    "Source": "manual-regression-seed",
+    "CreatedAtUtc": datetime.now(timezone.utc).isoformat(),
+}
+
+
+def main() -> None:
+    home = Path(os.environ["USERPROFILE"]) / ".gauntletci"
+    fixtures_root = home / "fixtures"
+    fixture_dir = fixtures_root / "gold" / FIXTURE_ID
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+
+    (fixture_dir / "metadata.json").write_text(json.dumps(METADATA, indent=2), encoding="utf-8")
+    (fixture_dir / "diff.patch").write_text(DIFF_PATCH, encoding="utf-8")
+    (fixture_dir / "expected.json").write_text(json.dumps(EXPECTED, indent=2), encoding="utf-8")
+
+    db_path = home / "corpus.db"
+    if not db_path.exists():
+        raise SystemExit(f"Corpus database not found: {db_path}")
+
+    rel_path = str(fixture_dir).replace("\\", "/")
+    con = sqlite3.connect(db_path)
+    con.execute(
+        """
+        INSERT INTO fixtures (
+            id, fixture_id, tier, repo, pr_number, language, path,
+            rule_ids_json, tags_json, pr_size_bucket, has_tests_changed,
+            has_review_comments, source, created_at_utc
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(fixture_id) DO UPDATE SET
+            tier=excluded.tier,
+            repo=excluded.repo,
+            pr_number=excluded.pr_number,
+            language=excluded.language,
+            path=excluded.path,
+            rule_ids_json=excluded.rule_ids_json,
+            tags_json=excluded.tags_json,
+            pr_size_bucket=excluded.pr_size_bucket,
+            has_tests_changed=excluded.has_tests_changed,
+            has_review_comments=excluded.has_review_comments,
+            source=excluded.source
+        """,
+        (
+            str(uuid.uuid4()),
+            FIXTURE_ID,
+            "Gold",
+            REPO,
+            PR_NUMBER,
+            "csharp",
+            rel_path,
+            json.dumps(["GCI0058"]),
+            json.dumps(METADATA["Tags"]),
+            "Small",
+            0,
+            1,
+            METADATA["Source"],
+            METADATA["CreatedAtUtc"],
+        ),
+    )
+
+    con.execute("DELETE FROM expected_findings WHERE fixture_id = ?", (FIXTURE_ID,))
+    for row in EXPECTED:
+        con.execute(
+            """
+            INSERT INTO expected_findings (
+                id, fixture_id, rule_id, should_trigger, expected_confidence,
+                reason, label_source, is_inconclusive
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(uuid.uuid4()),
+                FIXTURE_ID,
+                row["RuleId"],
+                1 if row["ShouldTrigger"] else 0,
+                row["ExpectedConfidence"],
+                row["Reason"],
+                row["LabelSource"],
+                1 if row["IsInconclusive"] else 0,
+            ),
+        )
+
+    con.commit()
+    con.close()
+    print(f"Seeded {FIXTURE_ID} at {fixture_dir}")
+    print(f"Updated {db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/app/articles/case-studies/page.tsx
+++ b/site/app/articles/case-studies/page.tsx
@@ -10,7 +10,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 export const metadata: Metadata = {
   title: "OSS Case Studies | GauntletCI Behavioral Risk Analysis",
   description:
-    "Five deeply researched .NET open-source pull requests showing swallowed exceptions, nullable API changes, serialization risk, timeout inheritance, and telemetry review signals.",
+    "Six deeply researched .NET open-source pull requests showing swallowed exceptions, paired-implementation drift, nullable API changes, serialization risk, timeout inheritance, and telemetry review signals.",
   alternates: { canonical: "/articles/case-studies" },
   openGraph: { images: [{ url: "/og/case-studies.png", width: 1200, height: 630 }] },
 };
@@ -20,11 +20,21 @@ const jsonLd = {
   "@type": "CollectionPage",
   name: "GauntletCI OSS Case Studies",
   description:
-    "Five deeply researched .NET open-source pull requests showing behavioral risk, API contract changes, and honest coverage gaps.",
+    "Six deeply researched .NET open-source pull requests showing behavioral risk, API contract changes, and honest coverage gaps.",
   url: "https://gauntletci.com/articles/case-studies",
 };
 
 const studies = [
+  {
+    href: "/articles/case-studies/stackexchange-redis-paired-implementation",
+    repo: "StackExchange/StackExchange.Redis",
+    pr: "PR #2995",
+    rules: ["GCI0058"],
+    severity: "BLOCK",
+    summary:
+      "Cluster subscription PR inverts IsSubscriberConnected between sibling implementations",
+    tags: ["Logic Bug", "Cluster"],
+  },
   {
     href: "/articles/case-studies/stackexchange-redis-swallowed-exception",
     repo: "StackExchange/StackExchange.Redis",

--- a/site/app/articles/case-studies/stackexchange-redis-paired-implementation/page.tsx
+++ b/site/app/articles/case-studies/stackexchange-redis-paired-implementation/page.tsx
@@ -1,0 +1,157 @@
+import type { Metadata } from "next";
+import { CaseStudyLayout } from "../_components/case-study-layout";
+
+export const metadata: Metadata = {
+  title: "Case Study: Paired Implementation Drift in StackExchange.Redis | GauntletCI",
+  description:
+    "StackExchange.Redis PR #2995 shipped an inverted IsSubscriberConnected predicate in MultiNodeSubscription — the logic defect Greptile and Qodo caught while diff noise hid it from many reviewers.",
+  alternates: { canonical: "/articles/case-studies/stackexchange-redis-paired-implementation" },
+  openGraph: { images: [{ url: "/og/case-studies.png", width: 1200, height: 630 }] },
+};
+
+const diffLines = [
+  { type: "context", line: "// PR #2995: cluster-aware subscription cleanup in Subscription.cs" },
+  { type: "context", line: "internal sealed class SingleNodeSubscription : Subscription" },
+  { type: "context", line: "{" },
+  { type: "context", line: "    internal override void RemoveDisconnectedEndpoints()" },
+  { type: "context", line: "    {" },
+  { type: "context", line: "        if (server is { IsSubscriberConnected: false })" },
+  { type: "context", line: "            _currentServer = null;" },
+  { type: "context", line: "    }" },
+  { type: "context", line: "}" },
+  { type: "context", line: "" },
+  { type: "context", line: "internal sealed class MultiNodeSubscription : Subscription" },
+  { type: "context", line: "{" },
+  { type: "context", line: "    internal override void RemoveDisconnectedEndpoints()" },
+  { type: "context", line: "    {" },
+  { type: "context", line: "        foreach (var server in _servers)" },
+  { type: "added", line: "            if (server.Value.IsSubscriberConnected)" },
+  { type: "added", line: "                scratch[count++] = server.Key;" },
+  { type: "context", line: "    }" },
+  { type: "context", line: "}" },
+] as const;
+
+const findingBody = [
+  "[GCI0058] Paired Implementation Consistency",
+  "Signal   : sibling classes apply opposite polarity to IsSubscriberConnected in the same method",
+  "Location : src/StackExchange.Redis/Subscription.cs",
+  "Evidence : SingleNodeSubscription expects IsSubscriberConnected: false; MultiNodeSubscription uses IsSubscriberConnected (true branch)",
+  "Risk     : disconnected endpoints are kept (or connected ones removed) during cluster cleanup",
+  "Action   : align MultiNodeSubscription with SingleNodeSubscription or document intentional divergence",
+].join("\n");
+
+export default function StackExchangeRedisPairedImplementationPage() {
+  return (
+    <CaseStudyLayout
+      title="Paired Implementation Drift in StackExchange.Redis"
+      description="PR #2995 added cluster subscription routing across dozens of files. The adjudicated logic bug was not a missing test or a swallowed exception — it was inverted boolean polarity between SingleNodeSubscription and MultiNodeSubscription in RemoveDisconnectedEndpoints()."
+      canonicalPath="/articles/case-studies/stackexchange-redis-paired-implementation"
+      repo="StackExchange/StackExchange.Redis"
+      pr="PR #2995"
+      prUrl="https://github.com/StackExchange/StackExchange.Redis/pull/2995"
+      outcomeLabel="BLOCK"
+      outcomeTone="red"
+      tags={["Logic Bug", "Cluster", "Library"]}
+      ruleIds={["GCI0058"]}
+      stats={[
+        { value: "61", label: "files changed" },
+        { value: "4,039", label: "lines added" },
+        { value: "1", label: "inverted sibling predicate" },
+      ]}
+      sections={[
+        {
+          title: "What changed",
+          children: (
+            <>
+              <p>
+                The pull request introduced keyspace notifications and multi-node subscription
+                management. Two sibling classes implement the same cleanup method:
+                <code className="font-mono text-sm text-foreground/80 bg-muted px-1 py-0.5 rounded"> RemoveDisconnectedEndpoints()</code>.
+                Single-node mode clears the server when the subscriber is <em>not</em> connected.
+                Multi-node mode was supposed to do the equivalent sweep across servers, but the added
+                condition kept endpoints when <code className="font-mono text-sm">IsSubscriberConnected</code> was
+                true — the opposite polarity.
+              </p>
+              <p>
+                This is a classic copy/paste drift pattern: the method names match, the surrounding
+                feature work is correct, and the bug is one negation away from the reference
+                implementation.
+              </p>
+            </>
+          ),
+        },
+        {
+          title: "Why this is risky",
+          children: (
+            <>
+              <p>
+                Wrong endpoint cleanup in a Redis client does not fail loudly at compile time. Under
+                cluster failover or partial disconnects, the library may retain stale server entries
+                or drop live ones. Pub/sub routing becomes nondeterministic relative to connection
+                state, and application code still sees a healthy multiplexer.
+              </p>
+              <p>
+                Greptile and Qodo surfaced this defect in eval-lab runs. GauntletCI originally
+                missed it while emitting dozens of lower-signal findings on the same large diff.
+              </p>
+            </>
+          ),
+        },
+        {
+          title: "How GauntletCI catches it now",
+          children: (
+            <>
+              <p>
+                Rule GCI0058 compares sibling classes in the same diff: same method
+                name, same boolean predicate, opposite polarity. It is deterministic (not LLM-judged)
+                and fires on property patterns like
+                <code className="font-mono text-sm"> IsSubscriberConnected: false</code> versus
+                <code className="font-mono text-sm"> .IsSubscriberConnected</code> without a dedicated
+                Redis hardcode.
+              </p>
+              <p>
+                Platform phases PG-DELIVERY and PG-DOMAIN cap noise on library profiles so this
+                finding survives delivery instead of being buried under per-line fanout.
+              </p>
+            </>
+          ),
+        },
+        {
+          title: "Why a human reviewer can miss it",
+          children: (
+            <>
+              <p>
+                Reviewers anchor on the new public API and cluster tests. The bug sits in parallel
+                internal classes that look intentionally symmetric. Without cross-class comparison,
+                the added lines read like reasonable null/state checks rather than an inversion.
+              </p>
+            </>
+          ),
+        },
+      ]}
+      diffTitle="Diff evidence"
+      diffFile="src/StackExchange.Redis/Subscription.cs"
+      diffLines={diffLines}
+      findingTitle="GauntletCI finding"
+      findingBody={findingBody}
+      caveats={[
+        "GCI0058 currently focuses on if/while/ternary conditions; switch expressions and helper-wrapped predicates may require future hardening.",
+        "The same PR also contains swallowed-handler issues (see the GCI0007 case study on this PR).",
+        "Large feature volume still produces medium-severity edge-case findings (GCI0006) that reviewers should triage separately.",
+      ]}
+      nextActions={[
+        "Verify MultiNodeSubscription removes endpoints when IsSubscriberConnected is false, matching SingleNodeSubscription semantics.",
+        "Add a cluster integration test that asserts disconnected servers are evicted from the scratch buffer.",
+        "If polarity is intentional, document the asymmetry in XML remarks on both overrides.",
+      ]}
+      sources={[
+        { label: "PR #2995", href: "https://github.com/StackExchange/StackExchange.Redis/pull/2995" },
+        { label: "Eval scorecard", href: "https://github.com/EricCogen/GauntletCI/blob/main/eval/redis-2995-scorecard.json" },
+        {
+          label: "Rule GCI0058",
+          href: "https://gauntletci.com/docs/rules/GCI0058",
+        },
+      ]}
+    />
+  );
+}

--- a/site/app/case-studies/stackexchange-redis-paired-implementation/page.tsx
+++ b/site/app/case-studies/stackexchange-redis-paired-implementation/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+  robots: "permanent-redirect",
+  alternates: { canonical: "/articles/case-studies/stackexchange-redis-paired-implementation" },
+};
+
+export default function CaseStudyRedirect() {
+  redirect("/articles/case-studies/stackexchange-redis-paired-implementation");
+}

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -60,6 +60,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/compare/gauntletci-vs-ai-code-review`, changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE_URL}/articles/case-studies`,                                                     changeFrequency: "monthly", priority: 0.9 },
     { url: `${BASE_URL}/benchmark`,                                                         changeFrequency: "monthly", priority: 0.9 },
+    { url: `${BASE_URL}/articles/case-studies/stackexchange-redis-paired-implementation`,         changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE_URL}/articles/case-studies/stackexchange-redis-swallowed-exception`,             changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE_URL}/articles/case-studies/newtonsoft-json-assignment-in-getter`,                changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE_URL}/articles/case-studies/efcore-breaking-api-removal`,                        changeFrequency: "monthly", priority: 0.8 },

--- a/site/lib/articles.ts
+++ b/site/lib/articles.ts
@@ -262,6 +262,16 @@ export type CaseStudy = {
 
 export const caseStudies: CaseStudy[] = [
   {
+    slug: "stackexchange-redis-paired-implementation",
+    href: "/articles/case-studies/stackexchange-redis-paired-implementation",
+    repo: "StackExchange/StackExchange.Redis",
+    pr: "PR #2995",
+    title: "Paired Implementation Drift in StackExchange.Redis",
+    description:
+      "MultiNodeSubscription inverted IsSubscriberConnected relative to SingleNodeSubscription — the logic defect LLM reviewers caught on PR #2995.",
+    ruleIds: ["GCI0058"],
+  },
+  {
     slug: "stackexchange-redis-swallowed-exception",
     href: "/articles/case-studies/stackexchange-redis-swallowed-exception",
     repo: "StackExchange/StackExchange.Redis",

--- a/src/GauntletCI.Core/Analysis/PairedImplementationAnalyzer.cs
+++ b/src/GauntletCI.Core/Analysis/PairedImplementationAnalyzer.cs
@@ -16,8 +16,11 @@ internal static class PairedImplementationAnalyzer
         new(@"\b(?:public|private|protected|internal)\s+(?:static\s+)?(?:override\s+)?(?:async\s+)?[\w<>\[\]?]+\s+(\w+)\s*\(",
             RegexOptions.Compiled);
 
-    private static readonly Regex IfConditionRegex =
-        new(@"if\s*\((.+?)\)", RegexOptions.Compiled);
+    private static readonly Regex ConditionalRegex =
+        new(@"\b(?:if|while)\s*\((.+?)\)", RegexOptions.Compiled);
+
+    private static readonly Regex TernaryConditionRegex =
+        new(@"([^?:]+)\?", RegexOptions.Compiled);
 
     internal sealed record ConditionObservation(
         string ClassName,
@@ -54,19 +57,23 @@ internal static class PairedImplementationAnalyzer
             if (currentClass is null || currentMethod is null)
                 continue;
 
-            if (!IfConditionRegex.IsMatch(content))
+            var conditionSources = CollectConditionSources(content);
+            if (conditionSources.Count == 0)
                 continue;
 
-            foreach (var extracted in ExtractConditions(content))
+            foreach (var conditionText in conditionSources)
             {
-                observations.Add(new ConditionObservation(
-                    currentClass,
-                    currentMethod,
-                    line.LineNumber,
-                    extracted.Condition,
-                    extracted.Callee,
-                    extracted.IsNegated,
-                    line.Kind == DiffLineKind.Added));
+                foreach (var extracted in ExtractConditions(conditionText))
+                {
+                    observations.Add(new ConditionObservation(
+                        currentClass,
+                        currentMethod,
+                        line.LineNumber,
+                        extracted.Condition,
+                        extracted.Callee,
+                        extracted.IsNegated,
+                        line.Kind == DiffLineKind.Added));
+                }
             }
         }
 
@@ -109,13 +116,27 @@ internal static class PairedImplementationAnalyzer
         return mismatches;
     }
 
-    private static IEnumerable<(string Condition, string Callee, bool IsNegated)> ExtractConditions(string line)
+    private static List<string> CollectConditionSources(string line)
     {
-        var ifMatch = IfConditionRegex.Match(line);
-        if (!ifMatch.Success)
-            yield break;
+        var sources = new List<string>();
+        var conditionalMatch = ConditionalRegex.Match(line);
+        if (conditionalMatch.Success)
+            sources.Add(conditionalMatch.Groups[1].Value!.Trim());
 
-        var condition = ifMatch.Groups[1].Value!.Trim();
+        foreach (Match ternary in TernaryConditionRegex.Matches(line))
+        {
+            var candidate = ternary.Groups[1].Value!.Trim();
+            if (candidate.Length == 0 || candidate.Contains('{') || candidate.Contains('='))
+                continue;
+
+            sources.Add(candidate);
+        }
+
+        return sources;
+    }
+
+    private static IEnumerable<(string Condition, string Callee, bool IsNegated)> ExtractConditions(string condition)
+    {
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (Match pattern in Regex.Matches(condition, @"(\w+)\s*:\s*(true|false)\b", RegexOptions.IgnoreCase))
@@ -140,9 +161,19 @@ internal static class PairedImplementationAnalyzer
             yield return (condition, callee, negated);
         }
 
-        foreach (Match prop in Regex.Matches(condition, @"\.(?<member>Is[A-Z]\w+)\b"))
+        foreach (Match prop in Regex.Matches(condition, @"\.(?<member>(?:Is|Has|Can|Should)[A-Z]\w+)\b"))
         {
             var member = prop.Groups["member"].Value!;
+            if (!seen.Add(member))
+                continue;
+
+            var negated = Regex.IsMatch(condition, $@"(?<![:\w])!{member}\b|{member}\s*==\s*false", RegexOptions.CultureInvariant);
+            yield return (condition, member, negated);
+        }
+
+        foreach (Match bare in Regex.Matches(condition, @"\b(?<member>(?:Is|Has|Can|Should)[A-Z]\w+)\b"))
+        {
+            var member = bare.Groups["member"].Value!;
             if (!seen.Add(member))
                 continue;
 
@@ -153,6 +184,9 @@ internal static class PairedImplementationAnalyzer
 
     private static bool IsBooleanMember(string name) =>
         name.StartsWith("Is", StringComparison.Ordinal) ||
+        name.StartsWith("Has", StringComparison.Ordinal) ||
+        name.StartsWith("Can", StringComparison.Ordinal) ||
+        name.StartsWith("Should", StringComparison.Ordinal) ||
         name.EndsWith("Connected", StringComparison.Ordinal) ||
         name.EndsWith("Enabled", StringComparison.Ordinal);
 }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0022_IdempotencyRetrySafety.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0022_IdempotencyRetrySafety.cs
@@ -40,6 +40,10 @@ public class GCI0022_IdempotencyRetrySafety : RuleBase
         if (WellKnownPatterns.IsTestFile(file.NewPath))
             return;
 
+        // HTTP idempotency applies to web/API surfaces, not client libraries or domain models
+        if (!IsWebApiSurfaceFile(file.NewPath))
+            return;
+
         var allLines = file.Hunks.SelectMany(h => h.Lines).ToList();
 
         for (int i = 0; i < allLines.Count; i++)
@@ -110,6 +114,10 @@ public class GCI0022_IdempotencyRetrySafety : RuleBase
 
     private void CheckEventHandlerWithoutDedup(DiffFile file, List<Finding> findings)
     {
+        // Client/infrastructure libraries attach handlers once per connection lifecycle
+        if (IsInfrastructureClientFile(file.NewPath))
+            return;
+
         var allLines = file.Hunks.SelectMany(h => h.Lines).ToList();
 
         for (int i = 0; i < allLines.Count; i++)
@@ -171,5 +179,17 @@ public class GCI0022_IdempotencyRetrySafety : RuleBase
                path.EndsWith("Presenter.cs", StringComparison.OrdinalIgnoreCase) ||
                path.Contains(".xaml.cs", StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool IsWebApiSurfaceFile(string path) =>
+        path.Contains("Controller", StringComparison.OrdinalIgnoreCase) ||
+        path.Contains("/Controllers/", StringComparison.Ordinal) ||
+        path.Contains("\\Controllers\\", StringComparison.Ordinal) ||
+        path.EndsWith("Program.cs", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsInfrastructureClientFile(string path) =>
+        path.Contains("Subscription", StringComparison.OrdinalIgnoreCase) ||
+        path.Contains("Subscriber", StringComparison.OrdinalIgnoreCase) ||
+        path.Contains("Connection", StringComparison.OrdinalIgnoreCase) ||
+        path.Contains("Multiplexer", StringComparison.OrdinalIgnoreCase);
 }
 

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0029_PiiLoggingLeak.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0029_PiiLoggingLeak.cs
@@ -38,6 +38,9 @@ public class GCI0029_PiiLoggingLeak : RuleBase
                 // XML documentation comments are never runtime log calls
                 if (trimmed.StartsWith("///")) continue;
 
+                // Skip attribute lines (FastHash, Obsolete, etc.) — not runtime log calls
+                if (trimmed.StartsWith('[')) continue;
+
                 // Skip comment lines entirely (// or *)
                 if (trimmed.StartsWith("//") || trimmed.StartsWith("*")) continue;
 

--- a/src/GauntletCI.Tests/Rules/GCI0022Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0022Tests.cs
@@ -162,5 +162,44 @@ public class GCI0022Tests
         Assert.DoesNotContain(findings, f => f.Summary.Contains("Event handler registered without dedup"));
     }
 
+    [Fact]
+    public async Task EventHandlerInSubscriptionFile_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/StackExchange.Redis/Subscription.cs b/src/StackExchange.Redis/Subscription.cs
+            index abc..def 100644
+            --- a/src/StackExchange.Redis/Subscription.cs
+            +++ b/src/StackExchange.Redis/Subscription.cs
+            @@ -1,1 +1,1 @@
+            +MessageReceived += OnMessage;
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("Event handler"));
+    }
+
+    [Fact]
+    public async Task HttpPostInClientLibrary_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/StackExchange.Redis/RedisClient.cs b/src/StackExchange.Redis/RedisClient.cs
+            index abc..def 100644
+            --- a/src/StackExchange.Redis/RedisClient.cs
+            +++ b/src/StackExchange.Redis/RedisClient.cs
+            @@ -1,3 +1,6 @@
+             public class RedisClient {
+            +    [HttpPost]
+            +    public void Send() { }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("[HttpPost]"));
+    }
+
 }
 

--- a/src/GauntletCI.Tests/Rules/GCI0058Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0058Tests.cs
@@ -142,4 +142,74 @@ public sealed class GCI0058Tests
         Assert.Equal("GCI0058", finding.RuleId);
         Assert.Contains("IsSubscriberConnected", finding.Evidence, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public async Task WhileLoopSiblingPolarity_ShouldFire()
+    {
+        var raw = """
+            diff --git a/src/Worker.cs b/src/Worker.cs
+            index abc..def 100644
+            --- a/src/Worker.cs
+            +++ b/src/Worker.cs
+            @@ -1,1 +1,24 @@
+            +    sealed class FastWorker
+            +    {
+            +        internal void Drain()
+            +        {
+            +            while (HasPendingWork())
+            +                Process();
+            +        }
+            +    }
+            +
+            +    sealed class SlowWorker
+            +    {
+            +        internal void Drain()
+            +        {
+            +            while (!HasPendingWork())
+            +                Process();
+            +        }
+            +    }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal("GCI0058", finding.RuleId);
+        Assert.Contains("HasPendingWork", finding.Evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TernarySiblingPolarity_ShouldFire()
+    {
+        var raw = """
+            diff --git a/src/Gate.cs b/src/Gate.cs
+            index abc..def 100644
+            --- a/src/Gate.cs
+            +++ b/src/Gate.cs
+            @@ -1,1 +1,16 @@
+            +    sealed class StrictGate
+            +    {
+            +        internal bool Allow(Request r)
+            +        {
+            +            return CanAccept(r) ? true : false;
+            +        }
+            +    }
+            +
+            +    sealed class LooseGate
+            +    {
+            +        internal bool Allow(Request r)
+            +        {
+            +            return !CanAccept(r) ? true : false;
+            +        }
+            +    }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal("GCI0058", finding.RuleId);
+        Assert.Contains("CanAccept", finding.Evidence, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
## Summary
- Harden GCI0058 paired-implementation detection: while/ternary conditions and Has/Can/Should predicates.
- Tune GCI0022 and GCI0029 for client-library diffs (Redis #2995 noise reduction).
- Add gold corpus seed script, Redis PR #2995 CI benchmark workflow, GCI0058 case study, and eval-lab workflow template.

## Test plan
- [x] dotnet test GauntletCI.slnx (1553 passed)
- [x] scripts/run-redis-benchmark.ps1 (GCI0058 + delivery cap)
- [x] site npm run build
- [x] corpus run redis-2995-multinode-inverted on agent corpus DB
- [ ] CI redis-benchmark workflow on this PR