### PR TITLE
Add GCI0059 guard-deletion rule, gold fixture #2, and EF Core benchmark

### DIFF
--- a/.github/workflows/efcore-benchmark.yml
+++ b/.github/workflows/efcore-benchmark.yml
@@ -1,0 +1,52 @@
+name: EF Core PR38024 Benchmark
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/GauntletCI.Core/**"
+      - "scripts/run-efcore-benchmark.ps1"
+      - ".github/workflows/efcore-benchmark.yml"
+      - "eval/efcore-38024-scorecard.json"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/GauntletCI.Core/**"
+      - "scripts/run-efcore-benchmark.ps1"
+      - ".github/workflows/efcore-benchmark.yml"
+
+jobs:
+  efcore-benchmark:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Run EF Core #38024 benchmark
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./scripts/run-efcore-benchmark.ps1
+
+      - name: Assert GCI0004 ground truth
+        shell: pwsh
+        run: |
+          $path = Join-Path $env:GITHUB_WORKSPACE "eval/efcore-38024-latest.json"
+          if (-not (Test-Path $path)) { throw "Missing $path" }
+          $doc = Get-Content $path -Raw | ConvertFrom-Json
+          $findings = @($doc.Findings)
+          $g04 = @($findings | Where-Object { $_.RuleId -eq "GCI0004" })
+          if ($g04.Count -lt 1) {
+            throw "Expected at least one GCI0004 finding for EF Core PR #38024"
+          }
+          if ($findings.Count -gt 25) {
+            throw "Delivery cap exceeded: $($findings.Count) findings (max 25)"
+          }
+          Write-Host "OK: $($findings.Count) delivered findings, $($g04.Count) GCI0004"

--- a/eval/efcore-38024-scorecard.json
+++ b/eval/efcore-38024-scorecard.json
@@ -1,0 +1,37 @@
+{
+  "benchmark_id": "dotnet-efcore-pr-38024",
+  "source_pr": "https://github.com/dotnet/efcore/pull/38024",
+  "generated_at_utc": "2026-05-30T02:00:00Z",
+  "gauntletci_version": "platform-phases-1-5",
+  "ground_truth_defect": {
+    "summary": "Cosmos write pipeline modernization adds public Obsolete surface, internal signature churn, and JSON preservation risk",
+    "competitors_that_caught": ["manual review", "API compat tooling"],
+    "primary_rules": ["GCI0004", "GCI0003", "GCI0015"]
+  },
+  "runs": [
+    {
+      "label": "platform_phases_1_5_library_profile",
+      "config": {
+        "domain": { "profile": "library" },
+        "output": { "delivery": { "globalMaxFindings": 25 } },
+        "provenance": { "enabled": true },
+        "semantics": { "enabled": true }
+      },
+      "required_rules": ["GCI0004"],
+      "max_delivered_findings": 25,
+      "notes": "GCI0004 must fire for Obsolete/public API changes; delivery cap enforced in CI"
+    }
+  ],
+  "competitive_advantage_claims": [
+    {
+      "claim": "Breaking change detection on large framework PRs (GCI0004)",
+      "vs": ["Greptile", "CodeRabbit", "Copilot Review"],
+      "differentiator": "Deterministic Obsolete and public contract diff scan with delivery budget"
+    },
+    {
+      "claim": "Domain-aware gating for library repos (PG-DOMAIN)",
+      "vs": ["SonarQube", "Codacy"],
+      "differentiator": "Web/DI rules suppressed on EF Core-scale library diffs"
+    }
+  ]
+}

--- a/eval/gold-fixture-grid.json
+++ b/eval/gold-fixture-grid.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "1.0.0",
+  "description": "Gold corpus fixtures mapped to adjudicated FN classes and primary rules.",
+  "fixtures": [
+    {
+      "fixture_id": "redis-2995-multinode-inverted",
+      "fn_class": "sibling-implementation-drift",
+      "primary_rule": "GCI0058",
+      "repo": "StackExchange/StackExchange.Redis",
+      "pr_number": 2995,
+      "seed_script": "scripts/seed-redis-2995-gci0058-fixture.py",
+      "oss_benchmark": "scripts/run-redis-benchmark.ps1",
+      "scorecard": "eval/redis-2995-scorecard.json"
+    },
+    {
+      "fixture_id": "guard-deletion-remote-use",
+      "fn_class": "guard-deletion-remote-use",
+      "primary_rule": "GCI0059",
+      "repo": "GauntletCI/regression-fixtures",
+      "pr_number": 0,
+      "seed_script": "scripts/seed-guard-deletion-remote-use-fixture.py",
+      "oss_benchmark": null,
+      "scorecard": null,
+      "notes": "Synthetic focused diff; validated via corpus run and GCI0059 unit tests"
+    }
+  ],
+  "oss_benchmarks": [
+    {
+      "benchmark_id": "stackexchange-redis-pr-2995",
+      "repo": "StackExchange/StackExchange.Redis",
+      "pr_number": 2995,
+      "primary_rule": "GCI0058",
+      "workflow": ".github/workflows/redis-benchmark.yml"
+    },
+    {
+      "benchmark_id": "dotnet-efcore-pr-38024",
+      "repo": "dotnet/efcore",
+      "pr_number": 38024,
+      "primary_rules": ["GCI0004", "GCI0003", "GCI0015"],
+      "workflow": ".github/workflows/efcore-benchmark.yml"
+    }
+  ]
+}

--- a/scripts/run-efcore-benchmark.ps1
+++ b/scripts/run-efcore-benchmark.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
-# Runs GauntletCI against the StackExchange.Redis PR #2995 diff and writes eval/redis-2995-latest.json
+# Runs GauntletCI against dotnet/efcore PR #38024 and writes eval/efcore-38024-latest.json
 param(
-    [string]$DiffPath = "$env:TEMP\redis-2995-eval.diff",
+    [string]$DiffPath = "$env:TEMP\efcore-38024-eval.diff",
     [string]$RepoRoot = (Split-Path $PSScriptRoot -Parent)
 )
 
@@ -18,7 +18,7 @@ if (-not (Test-Path $DiffPath)) {
     $token = if ($env:GH_TOKEN) { $env:GH_TOKEN } elseif ($env:GITHUB_TOKEN) { $env:GITHUB_TOKEN } else { $null }
     if ($token) {
         Invoke-WebRequest `
-            -Uri "https://api.github.com/repos/StackExchange/StackExchange.Redis/pulls/2995" `
+            -Uri "https://api.github.com/repos/dotnet/efcore/pulls/38024" `
             -Headers @{
                 Authorization = "Bearer $token"
                 Accept        = "application/vnd.github.diff"
@@ -26,17 +26,17 @@ if (-not (Test-Path $DiffPath)) {
             -OutFile $DiffPath
     }
     else {
-        gh api repos/StackExchange/StackExchange.Redis/pulls/2995 `
+        gh api repos/dotnet/efcore/pulls/38024 `
             --header "Accept: application/vnd.github.diff" `
             | Set-Content -Path $DiffPath -Encoding utf8
     }
 }
 
 if (-not (Test-Path $DiffPath)) {
-    throw "Failed to fetch Redis PR #2995 diff to $DiffPath"
+    throw "Failed to fetch EF Core PR #38024 diff to $DiffPath"
 }
 
-$configDir = Join-Path $env:TEMP "gci-redis-eval"
+$configDir = Join-Path $env:TEMP "gci-efcore-eval"
 New-Item -ItemType Directory -Force -Path $configDir | Out-Null
 @'
 {
@@ -48,7 +48,7 @@ New-Item -ItemType Directory -Force -Path $configDir | Out-Null
 '@ | Set-Content (Join-Path $configDir ".gauntletci.json") -Encoding utf8
 
 dotnet build GauntletCI.slnx -v quiet --nologo | Out-Null
-$out = Join-Path $RepoRoot "eval\redis-2995-latest.json"
+$out = Join-Path $RepoRoot "eval\efcore-38024-latest.json"
 dotnet run --project src/GauntletCI.Cli --no-build -- analyze `
     --diff $DiffPath `
     --repo $configDir `
@@ -57,4 +57,16 @@ dotnet run --project src/GauntletCI.Cli --no-build -- analyze `
     --no-banner | Out-Null
 
 Write-Host "Wrote $out"
-python -c "import json, pathlib; p=pathlib.Path(r'$out'); d=json.loads(p.read_text(encoding='utf-8-sig')); fs=d.get('Findings',[]); print('findings',len(fs)); g58=[f for f in fs if f.get('RuleId')=='GCI0058']; print('GCI0058',len(g58)); print('ground_truth', bool(g58))"
+python -c @"
+import json, pathlib, collections
+p = pathlib.Path(r'$out')
+d = json.loads(p.read_text(encoding='utf-8-sig'))
+fs = d.get('Findings', [])
+print('findings', len(fs))
+counts = collections.Counter(f.get('RuleId') for f in fs)
+for rule, n in sorted(counts.items()):
+    print(rule, n)
+g04 = [f for f in fs if f.get('RuleId') == 'GCI0004']
+print('GCI0004', len(g04))
+print('ground_truth_gci0004', bool(g04))
+"@

--- a/scripts/seed-all-gold-fixtures.py
+++ b/scripts/seed-all-gold-fixtures.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Seed all gold regression fixtures into ~/.gauntletci/corpus.db."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = [
+    "seed-redis-2995-gci0058-fixture.py",
+    "seed-guard-deletion-remote-use-fixture.py",
+]
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent
+    for name in SCRIPTS:
+        path = root / name
+        if not path.exists():
+            raise SystemExit(f"Missing seed script: {path}")
+        print(f"Running {name}...")
+        subprocess.check_call([sys.executable, str(path)])
+    print("All gold fixtures seeded.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed-guard-deletion-remote-use-fixture.py
+++ b/scripts/seed-guard-deletion-remote-use-fixture.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Seed gold corpus fixture guard-deletion-remote-use into ~/.gauntletci/corpus.db.
+
+After seeding, verify with:
+  dotnet run --project src/GauntletCI.Cli -- corpus run \\
+    --fixture guard-deletion-remote-use \\
+    --db %USERPROFILE%\\.gauntletci\\corpus.db \\
+    --fixtures %USERPROFILE%\\.gauntletci\\fixtures
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+FIXTURE_ID = "guard-deletion-remote-use"
+REPO = "GauntletCI/regression-fixtures"
+PR_NUMBER = 0
+
+DIFF_PATCH = """diff --git a/src/OrderService.cs b/src/OrderService.cs
+index abc..def 100644
+--- a/src/OrderService.cs
++++ b/src/OrderService.cs
+@@ -10,12 +10,10 @@
+ internal sealed class OrderService
+ {
+     internal bool TryCharge(Order? order)
+     {
+-        if (order == null)
+-            return false;
+         return order.Total > 0;
+     }
+ }
+"""
+
+EXPECTED = [
+    {
+        "RuleId": "GCI0059",
+        "ShouldTrigger": True,
+        "ExpectedConfidence": 0.95,
+        "Reason": "Removed null guard on order but order.Total still used in TryCharge (guard-deletion-remote-use FN class).",
+        "LabelSource": "Manual",
+        "IsInconclusive": False,
+    }
+]
+
+METADATA = {
+    "FixtureId": FIXTURE_ID,
+    "Tier": "Gold",
+    "Repo": REPO,
+    "PullRequestNumber": PR_NUMBER,
+    "Language": "csharp",
+    "RuleIds": ["GCI0059"],
+    "Tags": ["guard-deletion", "null-guard", "regression", "fn-class"],
+    "PrSizeBucket": "Tiny",
+    "FilesChanged": 1,
+    "HasTestsChanged": False,
+    "HasReviewComments": False,
+    "BaseSha": "",
+    "HeadSha": "",
+    "Source": "manual-regression-seed",
+    "CreatedAtUtc": datetime.now(timezone.utc).isoformat(),
+}
+
+
+def main() -> None:
+    home = Path(os.environ["USERPROFILE"]) / ".gauntletci"
+    fixtures_root = home / "fixtures"
+    fixture_dir = fixtures_root / "gold" / FIXTURE_ID
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+
+    (fixture_dir / "metadata.json").write_text(json.dumps(METADATA, indent=2), encoding="utf-8")
+    (fixture_dir / "diff.patch").write_text(DIFF_PATCH, encoding="utf-8")
+    (fixture_dir / "expected.json").write_text(json.dumps(EXPECTED, indent=2), encoding="utf-8")
+
+    db_path = home / "corpus.db"
+    if not db_path.exists():
+        raise SystemExit(f"Corpus database not found: {db_path}")
+
+    rel_path = str(fixture_dir).replace("\\", "/")
+    con = sqlite3.connect(db_path)
+    con.execute(
+        """
+        INSERT INTO fixtures (
+            id, fixture_id, tier, repo, pr_number, language, path,
+            rule_ids_json, tags_json, pr_size_bucket, has_tests_changed,
+            has_review_comments, source, created_at_utc
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(fixture_id) DO UPDATE SET
+            tier=excluded.tier,
+            repo=excluded.repo,
+            pr_number=excluded.pr_number,
+            language=excluded.language,
+            path=excluded.path,
+            rule_ids_json=excluded.rule_ids_json,
+            tags_json=excluded.tags_json,
+            pr_size_bucket=excluded.pr_size_bucket,
+            has_tests_changed=excluded.has_tests_changed,
+            has_review_comments=excluded.has_review_comments,
+            source=excluded.source
+        """,
+        (
+            str(uuid.uuid4()),
+            FIXTURE_ID,
+            "Gold",
+            REPO,
+            PR_NUMBER,
+            "csharp",
+            rel_path,
+            json.dumps(["GCI0059"]),
+            json.dumps(METADATA["Tags"]),
+            "Tiny",
+            0,
+            0,
+            METADATA["Source"],
+            METADATA["CreatedAtUtc"],
+        ),
+    )
+
+    con.execute("DELETE FROM expected_findings WHERE fixture_id = ?", (FIXTURE_ID,))
+    for row in EXPECTED:
+        con.execute(
+            """
+            INSERT INTO expected_findings (
+                id, fixture_id, rule_id, should_trigger, expected_confidence,
+                reason, label_source, is_inconclusive
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(uuid.uuid4()),
+                FIXTURE_ID,
+                row["RuleId"],
+                1 if row["ShouldTrigger"] else 0,
+                row["ExpectedConfidence"],
+                row["Reason"],
+                row["LabelSource"],
+                1 if row["IsInconclusive"] else 0,
+            ),
+        )
+
+    con.commit()
+    con.close()
+    print(f"Seeded {FIXTURE_ID} at {fixture_dir}")
+    print(f"Updated {db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/GauntletCI.Core/Analysis/GuardDeletionAnalyzer.cs
+++ b/src/GauntletCI.Core/Analysis/GuardDeletionAnalyzer.cs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.RegularExpressions;
+using GauntletCI.Core.Diff;
+
+namespace GauntletCI.Core.Analysis;
+
+/// <summary>
+/// Detects removed null/validation guards with continued or new uses of the guarded symbol (PG-RELATION / RC-3).
+/// </summary>
+internal static class GuardDeletionAnalyzer
+{
+    private static readonly Regex MethodDeclarationRegex =
+        new(@"\b(?:public|private|protected|internal)\s+(?:static\s+)?(?:override\s+)?(?:async\s+)?[\w<>\[\]?]+\s+(\w+)\s*\(",
+            RegexOptions.Compiled);
+
+    private static readonly Regex GuardIfRegex =
+        new(@"if\s*\(\s*(?<ident>[A-Za-z_][A-Za-z0-9_]*)\s*(?:==|is)\s*null\s*\)", RegexOptions.Compiled);
+
+    private static readonly Regex ThrowIfNullRegex =
+        new(@"(?:ArgumentNullException\.)?ThrowIfNull\s*\(\s*(?<ident>[A-Za-z_][A-Za-z0-9_]*)\s*\)", RegexOptions.Compiled);
+
+    internal sealed record GuardRemoval(
+        string ClassName,
+        string MethodName,
+        int LineNumber,
+        int LineIndex,
+        string GuardedSymbol,
+        string GuardText,
+        bool IsRemovedLine);
+
+    internal sealed record SymbolUse(
+        string ClassName,
+        string MethodName,
+        int LineNumber,
+        int LineIndex,
+        string Symbol,
+        string UseText,
+        bool IsAddedLine);
+
+    internal static IReadOnlyList<(GuardRemoval Guard, SymbolUse Use)> FindRemoteUsesAfterGuardDeletion(DiffFile file)
+    {
+        var orderedLines = file.Hunks
+            .SelectMany(h => h.Lines)
+            .Where(l => l.Kind is DiffLineKind.Added or DiffLineKind.Removed or DiffLineKind.Context)
+            .ToList();
+
+        string? currentClass = null;
+        string? currentMethod = null;
+        var guards = new List<GuardRemoval>();
+        var uses = new List<SymbolUse>();
+
+        for (var index = 0; index < orderedLines.Count; index++)
+        {
+            var line = orderedLines[index];
+            var content = line.Content;
+            var effectiveKind = GetEffectiveKind(line);
+            var classMatch = Regex.Match(NormalizeDiffLine(content), @"\b(?:class|record|struct)\s+(\w+)\b");
+            if (classMatch.Success)
+                currentClass = classMatch.Groups[1].Value!;
+
+            var methodMatch = MethodDeclarationRegex.Match(NormalizeDiffLine(content));
+            if (methodMatch.Success)
+                currentMethod = methodMatch.Groups[1].Value!;
+
+            if (currentClass is null || currentMethod is null)
+                continue;
+
+            foreach (var guard in ExtractRemovedGuards(content, effectiveKind))
+            {
+                guards.Add(new GuardRemoval(
+                    currentClass,
+                    currentMethod,
+                    line.LineNumber,
+                    index,
+                    guard,
+                    NormalizeDiffLine(content),
+                    IsRemovedLine: true));
+            }
+
+            if (effectiveKind is EffectiveLineKind.Added or EffectiveLineKind.Context)
+            {
+                foreach (var guard in ExtractGuardSymbols(NormalizeDiffLine(content)))
+                {
+                    guards.Add(new GuardRemoval(
+                        currentClass,
+                        currentMethod,
+                        line.LineNumber,
+                        index,
+                        guard,
+                        NormalizeDiffLine(content),
+                        IsRemovedLine: false));
+                }
+            }
+
+            foreach (var symbol in ExtractSymbolUses(content))
+            {
+                uses.Add(new SymbolUse(
+                    currentClass,
+                    currentMethod,
+                    line.LineNumber,
+                    index,
+                    symbol,
+                    NormalizeDiffLine(content),
+                    effectiveKind == EffectiveLineKind.Added));
+            }
+        }
+
+        var mismatches = new List<(GuardRemoval, SymbolUse)>();
+
+        foreach (var guard in guards.Where(g => g.IsRemovedLine))
+        {
+            var replacementGuard = guards.Any(g =>
+                !g.IsRemovedLine &&
+                g.MethodName == guard.MethodName &&
+                g.GuardedSymbol.Equals(guard.GuardedSymbol, StringComparison.Ordinal) &&
+                g.LineIndex >= guard.LineIndex - 2 &&
+                g.LineIndex <= guard.LineIndex + 6);
+
+            if (replacementGuard)
+                continue;
+
+            var remoteUse = uses
+                .Where(u =>
+                    u.MethodName == guard.MethodName &&
+                    u.Symbol.Equals(guard.GuardedSymbol, StringComparison.Ordinal) &&
+                    u.LineIndex > guard.LineIndex)
+                .OrderByDescending(u => u.IsAddedLine)
+                .ThenBy(u => u.LineIndex)
+                .FirstOrDefault();
+
+            if (remoteUse is not null)
+                mismatches.Add((guard, remoteUse));
+        }
+
+        return mismatches;
+    }
+
+    private static IEnumerable<string> ExtractRemovedGuards(string content, EffectiveLineKind kind)
+    {
+        if (kind != EffectiveLineKind.Removed)
+            yield break;
+
+        foreach (var guard in ExtractGuardSymbols(NormalizeDiffLine(content)))
+            yield return guard;
+    }
+
+    private enum EffectiveLineKind
+    {
+        Context,
+        Added,
+        Removed,
+    }
+
+    private static EffectiveLineKind GetEffectiveKind(DiffLine line)
+    {
+        if (line.Kind == DiffLineKind.Added)
+            return EffectiveLineKind.Added;
+
+        if (line.Kind == DiffLineKind.Removed)
+            return EffectiveLineKind.Removed;
+
+        var trimmed = line.Content.TrimStart();
+        if (trimmed.StartsWith('+'))
+            return EffectiveLineKind.Added;
+
+        if (trimmed.StartsWith('-'))
+            return EffectiveLineKind.Removed;
+
+        return EffectiveLineKind.Context;
+    }
+
+    private static IEnumerable<string> ExtractGuardSymbols(string trimmed)
+    {
+        foreach (Match match in GuardIfRegex.Matches(trimmed))
+            yield return match.Groups["ident"].Value!;
+
+        foreach (Match match in ThrowIfNullRegex.Matches(trimmed))
+            yield return match.Groups["ident"].Value!;
+    }
+
+    private static IEnumerable<string> ExtractSymbolUses(string content)
+    {
+        var trimmed = NormalizeDiffLine(content);
+        if (trimmed.StartsWith("if", StringComparison.Ordinal) && trimmed.Contains("null", StringComparison.Ordinal))
+            yield break;
+
+        foreach (Match match in Regex.Matches(trimmed, @"\b([A-Za-z_][A-Za-z0-9_]*)\.(?!\.)"))
+        {
+            var symbol = match.Groups[1].Value!;
+            if (IsKeyword(symbol))
+                continue;
+
+            yield return symbol;
+        }
+
+        foreach (Match match in Regex.Matches(trimmed, @"\b([A-Za-z_][A-Za-z0-9_]*)\.Value\b"))
+        {
+            var symbol = match.Groups[1].Value!;
+            if (!IsKeyword(symbol))
+                yield return symbol;
+        }
+    }
+
+    private static bool IsKeyword(string symbol) =>
+        symbol is "if" or "for" or "foreach" or "while" or "return" or "var" or "new" or "this" or "base";
+
+    private static string NormalizeDiffLine(string content)
+    {
+        var trimmed = content.Trim();
+        if (trimmed.Length == 0)
+            return trimmed;
+
+        if (trimmed[0] is '+' or '-' or '\\')
+            trimmed = trimmed[1..].TrimStart();
+
+        return trimmed;
+    }
+}

--- a/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
+++ b/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
@@ -53,6 +53,7 @@ internal static class DefaultSeverities
             ["GCI0049"] = RuleSeverity.Info,
             ["GCI0056"] = RuleSeverity.Info,
             ["GCI0058"] = RuleSeverity.Block,
+            ["GCI0059"] = RuleSeverity.Block,
 
             // None: disabled by default (duplicate coverage elsewhere)
             ["GCI0054"] = RuleSeverity.None, // duplicate coverage — see GCI0016

--- a/src/GauntletCI.Core/Configuration/ProvenanceConfig.cs
+++ b/src/GauntletCI.Core/Configuration/ProvenanceConfig.cs
@@ -17,5 +17,6 @@ public class ProvenanceConfig
     [
         "GCI0003",
         "GCI0058",
+        "GCI0059",
     ];
 }

--- a/src/GauntletCI.Core/Configuration/SemanticsConfig.cs
+++ b/src/GauntletCI.Core/Configuration/SemanticsConfig.cs
@@ -15,6 +15,7 @@ public class SemanticsConfig
     public string[] BoostRules { get; set; } =
     [
         "GCI0058",
+        "GCI0059",
         "GCI0003",
         "GCI0007",
     ];

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0059_GuardDeletionRemoteUse.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0059_GuardDeletionRemoteUse.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0059, Guard Deletion Remote Use
+/// Detects removed null/validation guards where the guarded symbol is still used in the same method.
+/// </summary>
+public class GCI0059_GuardDeletionRemoteUse : RuleBase
+{
+    public GCI0059_GuardDeletionRemoteUse(IPatternProvider patterns) : base(patterns)
+    {
+    }
+
+    public override string Id => "GCI0059";
+    public override string Name => "Guard Deletion Remote Use";
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        foreach (var file in context.Diff.Files)
+        {
+            if (WellKnownPatterns.IsTestFile(file.NewPath))
+                continue;
+
+            foreach (var (guard, use) in GuardDeletionAnalyzer.FindRemoteUsesAfterGuardDeletion(file))
+            {
+                findings.Add(CreateFinding(
+                    file,
+                    summary: $"Removed guard on '{guard.GuardedSymbol}' but symbol still used in {guard.MethodName}()",
+                    evidence: $"{file.NewPath}:{guard.LineNumber} removed `{guard.GuardText}`; {use.LineNumber} still uses `{use.UseText}`.",
+                    whyItMatters: "Deleting a null or validation guard while retaining downstream use usually reintroduces NullReferenceException or invalid-state paths.",
+                    suggestedAction: $"Restore the guard, add a replacement check before line {use.LineNumber}, or prove {guard.GuardedSymbol} is non-null by construction.",
+                    confidence: Confidence.High,
+                    line: new DiffLine
+                    {
+                        LineNumber = use.LineNumber,
+                        Content = use.UseText,
+                        Kind = use.IsAddedLine ? DiffLineKind.Added : DiffLineKind.Context,
+                    }));
+            }
+        }
+
+        return Task.FromResult(findings);
+    }
+}

--- a/src/GauntletCI.Tests/OrchestratorTests.cs
+++ b/src/GauntletCI.Tests/OrchestratorTests.cs
@@ -22,7 +22,7 @@ public class OrchestratorTests
             +var x = 1;
             """);
         var result = await orchestrator.RunAsync(diff);
-        Assert.Equal(35, result.RulesEvaluated);
+        Assert.Equal(36, result.RulesEvaluated);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class OrchestratorTests
             """);
         var result = await orchestrator.RunAsync(diff);
         Assert.NotNull(result);
-        Assert.Equal(35, result.RulesEvaluated);
+        Assert.Equal(36, result.RulesEvaluated);
     }
 
     [Fact]

--- a/src/GauntletCI.Tests/Phase5IntegrationTests.cs
+++ b/src/GauntletCI.Tests/Phase5IntegrationTests.cs
@@ -39,7 +39,7 @@ public class Phase5IntegrationTests
 
         // Verify that behavioral change detection ran and context signals were evaluated
         Assert.NotNull(result);
-        Assert.Equal(35, result.RulesEvaluated);
+        Assert.Equal(36, result.RulesEvaluated);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class Phase5IntegrationTests
         var result = await orchestrator.RunAsync(diff);
 
         Assert.NotNull(result);
-        Assert.Equal(35, result.RulesEvaluated);
+        Assert.Equal(36, result.RulesEvaluated);
     }
 
     [Fact]
@@ -186,9 +186,9 @@ public class Phase5IntegrationTests
     }
 
     [Fact]
-    public async Task Orchestrator_AllRulesPresent_34EnabledRulesEvaluated()
+    public async Task Orchestrator_AllRulesPresent_36EnabledRulesEvaluated()
     {
-        // 36 rule implementations; GCI0054 and GCI0055 disabled by default (duplicate coverage).
+        // 37 rule implementations; GCI0054 and GCI0055 disabled by default (duplicate coverage).
         var orchestrator = RuleOrchestrator.CreateDefault();
         var cleanDiff = DiffParser.Parse("""
             diff --git a/src/Clean.cs b/src/Clean.cs
@@ -201,6 +201,6 @@ public class Phase5IntegrationTests
             """);
 
         var result = await orchestrator.RunAsync(cleanDiff);
-        Assert.Equal(35, result.RulesEvaluated);
+        Assert.Equal(36, result.RulesEvaluated);
     }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0059Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0059Tests.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Rules.Implementations;
+
+namespace GauntletCI.Tests.Rules;
+
+public sealed class GCI0059Tests
+{
+    private static readonly GCI0059_GuardDeletionRemoteUse Rule = new(new StubPatternProvider());
+
+    [Fact]
+    public async Task RemovedNullGuardWithContinuedUse_ShouldFire()
+    {
+        var raw = """
+            diff --git a/src/OrderService.cs b/src/OrderService.cs
+            index abc..def 100644
+            --- a/src/OrderService.cs
+            +++ b/src/OrderService.cs
+            @@ -10,12 +10,10 @@
+             internal sealed class OrderService
+             {
+                 internal bool TryCharge(Order? order)
+                 {
+            -        if (order == null)
+            -            return false;
+                     return order.Total > 0;
+                 }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal("GCI0059", finding.RuleId);
+        Assert.Contains("order", finding.Evidence, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GuardRemovedButReplaced_ShouldNotFire()
+    {
+        var raw = """
+            diff --git a/src/OrderService.cs b/src/OrderService.cs
+            index abc..def 100644
+            --- a/src/OrderService.cs
+            +++ b/src/OrderService.cs
+            @@ -10,14 +10,14 @@
+             internal sealed class OrderService
+             {
+                 internal bool TryCharge(Order? order)
+                 {
+            -        if (order == null)
+            -            return false;
+            +        if (order is null)
+            +            return false;
+                     return order.Total > 0;
+                 }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task RemovedThrowIfNullWithAddedUse_ShouldFire()
+    {
+        var raw = """
+            diff --git a/src/CacheReader.cs b/src/CacheReader.cs
+            index abc..def 100644
+            --- a/src/CacheReader.cs
+            +++ b/src/CacheReader.cs
+            @@ -20,10 +20,12 @@
+             internal sealed class CacheReader
+             {
+                 internal string Read(string key)
+                 {
+            -        ArgumentNullException.ThrowIfNull(_cache);
+            +        var hit = _cache.TryGetValue(key, out var value);
+            +        return hit ? value : string.Empty;
+                 }
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal("GCI0059", finding.RuleId);
+        Assert.Contains("_cache", finding.Evidence, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **GCI0059 Guard Deletion Remote Use** with `GuardDeletionAnalyzer` to catch removed null/`ThrowIfNull` guards when the guarded symbol is still used in the same method (closes the `guard-deletion-remote-use` FN class).
- Seeds **gold fixture #2** (`guard-deletion-remote-use`) plus `eval/gold-fixture-grid.json` and `scripts/seed-all-gold-fixtures.py` for both gold fixtures.
- Adds **EF Core PR #38024 OSS benchmark** (`run-efcore-benchmark.ps1`, scorecard, CI workflow asserting GCI0004 + delivery cap).
- Fixes `gh api` diff fetch in Redis benchmark script (`Set-Content` instead of invalid `-o`).

## Test plan

- [x] `dotnet test GauntletCI.slnx` — 1556 passed
- [x] GCI0059 unit tests (3 scenarios)
- [x] Corpus run on `guard-deletion-remote-use` — 1 High finding
- [x] Local Redis benchmark — GCI0058 + delivery cap
- [x] Local EF Core benchmark — GCI0004 + 9 findings (cap 25)
- [ ] CI: `efcore-benchmark` and `redis-benchmark` workflows on PR