### PR TITLE
fix(ci): gate main-branch NuGet push behind NUGET_PUSH_ENABLED

### DIFF
--- a/.github/workflows/nuget-build.yml
+++ b/.github/workflows/nuget-build.yml
@@ -33,6 +33,7 @@ jobs:
       run: dotnet pack src/GauntletCI.Cli/GauntletCI.Cli.csproj --no-build --configuration Release --output packaging/
 
     - name: Publish to NuGet.org
+      if: ${{ vars.NUGET_PUSH_ENABLED == 'true' }}
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: dotnet nuget push packaging/*.nupkg -k "$NUGET_API_KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary
- Add `if: vars.NUGET_PUSH_ENABLED == 'true'` guard to the NuGet publish step in `nuget-build.yml`
- Aligns with the tagged `release.yml` workflow: main still builds/tests/packs on every push, but NuGet.org publish requires an explicit repo variable

## Test plan
- [x] Workflow YAML valid
- [x] Build/test/pack steps unchanged; only publish is gated