### PR TITLE
fix(security): block path traversal in StaticAnalysisRunner

### DIFF
--- a/src/GauntletCI.Core/StaticAnalysis/RepoPathResolver.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/RepoPathResolver.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+namespace GauntletCI.Core.StaticAnalysis;
+
+/// <summary>
+/// Resolves repository-relative paths without allowing traversal outside the repo root.
+/// </summary>
+internal static class RepoPathResolver
+{
+    /// <summary>
+    /// Resolves <paramref name="relativePath"/> under <paramref name="repoPath"/> when it stays inside the repo.
+    /// </summary>
+    public static bool TryResolvePathUnderRoot(string repoPath, string relativePath, out string absolutePath)
+    {
+        absolutePath = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(repoPath) || string.IsNullOrWhiteSpace(relativePath))
+            return false;
+
+        if (Path.IsPathRooted(relativePath))
+            return false;
+
+        var fullRoot = Path.GetFullPath(repoPath);
+        var normalizedRelative = relativePath.Replace('/', Path.DirectorySeparatorChar);
+        var candidate = Path.GetFullPath(Path.Combine(fullRoot, normalizedRelative));
+
+        var rootPrefix = fullRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+
+        if (!candidate.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        absolutePath = candidate;
+        return true;
+    }
+}

--- a/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
@@ -50,9 +50,9 @@ public static class StaticAnalysisRunner
         {
             ct.ThrowIfCancellationRequested();
 
-            // Normalize to OS path separator
-            var relativePath = file.NewPath.Replace('/', Path.DirectorySeparatorChar);
-            var absolutePath = Path.Combine(repoPath, relativePath);
+            // Normalize to OS path separator and reject paths outside the repo root
+            if (!RepoPathResolver.TryResolvePathUnderRoot(repoPath, file.NewPath, out var absolutePath))
+                continue;
 
             if (!File.Exists(absolutePath))
                 continue;

--- a/src/GauntletCI.Tests/StaticAnalysisTests.cs
+++ b/src/GauntletCI.Tests/StaticAnalysisTests.cs
@@ -343,4 +343,38 @@ public class StaticAnalysisTests
             Directory.Delete(tempDir, recursive: true);
         }
     }
+
+    [Fact]
+    public async Task StaticAnalysisRunner_PathOutsideRepo_ShouldSkipFile()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"gci_sas_{Guid.NewGuid():N}");
+        var repoDir = Path.Combine(tempRoot, "repo");
+        var outsideDir = Path.Combine(tempRoot, "outside");
+        Directory.CreateDirectory(repoDir);
+        Directory.CreateDirectory(outsideDir);
+
+        var outsideFile = Path.Combine(outsideDir, "Secret.cs");
+        await File.WriteAllTextAsync(outsideFile, "public class Secret { public string Token => \"leaked\"; }");
+
+        try
+        {
+            var raw = """
+                diff --git a/../../outside/Secret.cs b/../../outside/Secret.cs
+                index abc..def 100644
+                --- a/../../outside/Secret.cs
+                +++ b/../../outside/Secret.cs
+                @@ -1,1 +1,1 @@
+                -public class Secret { }
+                +public class Secret { public string Token => "leaked"; }
+                """;
+            var diff = DiffParser.Parse(raw);
+            var result = await StaticAnalysisRunner.RunAsync(diff, repoPath: repoDir);
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `RepoPathResolver` to canonicalize repo-relative paths and reject traversal outside the repo root
- `StaticAnalysisRunner` skips files whose resolved path escapes the repository (prevents reading arbitrary files when analyzing untrusted diffs)
- Add regression test for outside-repo paths

## Test plan
- [x] `dotnet test --filter StaticAnalysisRunner` passes
- [x] Existing valid in-repo analysis test still passes