### PR TITLE
fix(ci): include GauntletCI.Cli.Tests in solution

### DIFF
--- a/GauntletCI.slnx
+++ b/GauntletCI.slnx
@@ -8,6 +8,7 @@
     <Project Path="src/GauntletCI.BenchmarkReporter/GauntletCI.BenchmarkReporter.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/GauntletCI.Cli.Tests/GauntletCI.Cli.Tests.csproj" />
     <Project Path="tests/GauntletCI.Core.Tests/GauntletCI.Core.Tests.csproj" />
     <Project Path="tests/GauntletCI.Benchmarks/GauntletCI.Benchmarks.csproj" />
   </Folder>


### PR DESCRIPTION
## Summary
- Add \	ests/GauntletCI.Cli.Tests\ to \GauntletCI.slnx\ so CI executes 82 CLI tests previously excluded from \dotnet test GauntletCI.slnx\

## Test plan
- [x] \dotnet test GauntletCI.slnx\ includes Cli.Tests (82 passed)