### PR TITLE
fix(core): GCI0019, semantic witnesses, default analyze to staged

### DIFF
--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -32,7 +32,7 @@ public static class AnalyzeCommand
         var stagedFlag = new Option<bool>("--staged", "Analyse staged changes (git diff --cached)");
         var unstagedFlag = new Option<bool>("--unstaged", "Analyse unstaged changes (git diff)");
         var allChangesFlag = new Option<bool>("--all-changes", "Analyse all local changes: staged + unstaged (git diff HEAD)");
-        var codebaseOption = new Option<DirectoryInfo?>("--codebase", "Full codebase scan: analyse all C# files in directory (e.g., ./src). Treats all code as new for rule evaluation. This is the default when no other source is specified.");
+        var codebaseOption = new Option<DirectoryInfo?>("--codebase", "Full codebase scan: analyse all C# files in directory (e.g., ./src). Treats all code as new for rule evaluation.");
         var repoOption = new Option<DirectoryInfo>(
             "--repo",
             () => new DirectoryInfo(Directory.GetCurrentDirectory()),
@@ -140,11 +140,11 @@ public static class AnalyzeCommand
                 output = Path.GetExtension(output).TrimStart('.').ToLowerInvariant();
             }
 
-            // Default to full codebase scan if no explicit source is provided and stdin is not redirected
+            // Default to staged changes when no explicit source is provided and stdin is not redirected
             if (diffFile is null && commit is null && !staged && !unstaged && !allChanges &&
                 codebase is null && !Console.IsInputRedirected)
             {
-                codebase = repo;
+                staged = true;
             }
 
             // Enforce single diff source

--- a/src/GauntletCI.Core/Analysis/AnalysisContext.cs
+++ b/src/GauntletCI.Core/Analysis/AnalysisContext.cs
@@ -28,6 +28,9 @@ public sealed class AnalysisContext
     /// </summary>
     public DiffContext Diff { get; init; } = new();
 
+    /// <summary>All changed files from the original diff, including skipped paths.</summary>
+    public IReadOnlyList<DiffFile> AllFiles { get; init; } = Array.Empty<DiffFile>();
+
     /// <summary>Optional static analysis results for the diff.</summary>
     public AnalyzerResult? StaticAnalysis { get; init; }
 

--- a/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
+++ b/src/GauntletCI.Core/Configuration/DefaultSeverities.cs
@@ -20,6 +20,7 @@ internal static class DefaultSeverities
             ["GCI0012"] = RuleSeverity.Block,
             ["GCI0015"] = RuleSeverity.Block,
             ["GCI0016"] = RuleSeverity.Block,
+            ["GCI0019"] = RuleSeverity.Info,
             ["GCI0020"] = RuleSeverity.Block,
             ["GCI0021"] = RuleSeverity.Block,
             ["GCI0036"] = RuleSeverity.Block,

--- a/src/GauntletCI.Core/Rules/Delivery/SemanticFindingProcessor.cs
+++ b/src/GauntletCI.Core/Rules/Delivery/SemanticFindingProcessor.cs
@@ -66,7 +66,8 @@ public static class SemanticFindingProcessor
                 continue;
             }
 
-            var witness = counterfactuals.All.FirstOrDefault();
+            var line = finding.Line!.Value;
+            var witness = FindWitness(counterfactuals, finding.FilePath, line);
             var note = witness is null
                 ? $"Semantic witness: {operation.Description}"
                 : $"Counterfactual: {witness.Description} — {operation.Description}";
@@ -99,6 +100,19 @@ public static class SemanticFindingProcessor
             : source.CoverageNote + " | " + counterfactualNote,
         TicketContext = source.TicketContext,
     };
+
+    private static PatchCounterfactual? FindWitness(
+        PatchCounterfactualCollection counterfactuals,
+        string? filePath,
+        int line)
+    {
+        var normalized = NormalizePath(filePath);
+        return counterfactuals.All.FirstOrDefault(c =>
+                   c.PrimaryLineNumber == line &&
+                   string.Equals(NormalizePath(c.FilePath), normalized, StringComparison.OrdinalIgnoreCase))
+               ?? counterfactuals.All.FirstOrDefault(c =>
+                   string.Equals(NormalizePath(c.FilePath), normalized, StringComparison.OrdinalIgnoreCase));
+    }
 
     private static string Key(string? filePath, int? line) =>
         $"{NormalizePath(filePath)}|{line ?? 0}";

--- a/src/GauntletCI.Core/Rules/IPostProcessor.cs
+++ b/src/GauntletCI.Core/Rules/IPostProcessor.cs
@@ -11,5 +11,9 @@ namespace GauntletCI.Core.Rules;
 /// </summary>
 public interface IPostProcessor
 {
-    Finding? PostProcess(DiffContext context);
+    /// <summary>
+    /// Runs after all rules have evaluated. Returns an optional synthetic finding
+    /// based on aggregate diff properties and prior rule output.
+    /// </summary>
+    Finding? PostProcess(DiffContext context, IReadOnlyList<Finding> findings);
 }

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0019_ConfidenceAndEvidence.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0019_ConfidenceAndEvidence.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+
+namespace GauntletCI.Core.Rules.Implementations;
+
+/// <summary>
+/// GCI0019, Confidence and Evidence
+/// Flags binary files that cannot be text-scanned and warns when large diffs produce no other findings.
+/// </summary>
+public class GCI0019_ConfidenceAndEvidence : RuleBase, IPostProcessor
+{
+    private const int LargeDiffLineThreshold = 200;
+    private const int LargeDiffMaxFindings = 1;
+
+    private static readonly HashSet<string> BinaryExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".bmp", ".svg",
+        ".pdf", ".zip", ".7z", ".gz", ".tar", ".dll", ".exe", ".so", ".dylib",
+        ".woff", ".woff2", ".ttf", ".eot", ".otf",
+    };
+
+    public GCI0019_ConfidenceAndEvidence(IPatternProvider patterns) : base(patterns)
+    {
+    }
+
+    public override string Id => "GCI0019";
+    public override string Name => "Confidence and Evidence";
+
+    public override Task<List<Finding>> EvaluateAsync(
+        AnalysisContext context, CancellationToken ct = default)
+    {
+        var findings = new List<Finding>();
+
+        foreach (var file in context.AllFiles.Where(f => !f.IsDeleted && IsBinaryFile(f)))
+        {
+            findings.Add(CreateFinding(
+                file,
+                summary: $"Binary file changed: {Path.GetFileName(file.NewPath)}",
+                evidence: file.NewPath,
+                whyItMatters: "Binary files cannot be scanned for credentials, logic errors, or security issues using text-based analysis.",
+                suggestedAction: "Review binary files manually and consider storing large binaries in Git LFS.",
+                confidence: Confidence.Low));
+        }
+
+        return Task.FromResult(findings);
+    }
+
+    public Finding? PostProcess(DiffContext context, IReadOnlyList<Finding> findings)
+    {
+        var totalLines = context.AllAddedLines.Count() + context.AllRemovedLines.Count();
+        var otherFindings = findings.Count(f => !string.Equals(f.RuleId, Id, StringComparison.OrdinalIgnoreCase));
+        if (totalLines <= LargeDiffLineThreshold || otherFindings > LargeDiffMaxFindings)
+            return null;
+
+        return CreateFinding(
+            summary: $"Large diff ({totalLines} lines changed) produced no rule findings",
+            evidence: $"{totalLines} total added/removed lines across {context.Files.Count} eligible file(s)",
+            whyItMatters: "Large diffs with no findings may be clean, but subtle behavioral risks can evade deterministic checks.",
+            suggestedAction: "Consider a manual deep review or enable LLM-assisted analysis for this change.",
+            confidence: Confidence.Low);
+    }
+
+    private static bool IsBinaryFile(DiffFile file)
+    {
+        if (file.Hunks.Count == 0)
+            return true;
+
+        var extension = Path.GetExtension(file.NewPath);
+        return !string.IsNullOrEmpty(extension) && BinaryExtensions.Contains(extension);
+    }
+}

--- a/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
+++ b/src/GauntletCI.Core/Rules/RuleOrchestrator.cs
@@ -172,6 +172,7 @@ public class RuleOrchestrator
             SkippedFiles = skippedRecords,
             FileStatistics = fileStatistics,
             Diff = filteredDiff,
+            AllFiles = diff.Files,
             StaticAnalysis = staticAnalysis,
             Syntax = staticAnalysis?.Syntax,
             TargetFramework = staticAnalysis?.TargetFramework,
@@ -240,7 +241,7 @@ public class RuleOrchestrator
         }
 
         ApplyIgnoreList(allFindings, ignoreList);
-        PostProcess(filteredDiff, allFindings);
+        PostProcess(diff, allFindings);
 
         var provenanceIndex = DiffProvenanceAnalyzer.Build(filteredDiff);
         var provenance = ProvenanceFindingProcessor.Apply(allFindings, provenanceIndex, _config.Provenance);
@@ -298,7 +299,7 @@ public class RuleOrchestrator
         {
             foreach (var processor in _rules.OfType<IPostProcessor>())
             {
-                var finding = processor.PostProcess(diff);
+                var finding = processor.PostProcess(diff, allFindings);
                 if (finding != null) allFindings.Add(finding);
             }
         }

--- a/src/GauntletCI.Core/Semantics/PatchCounterfactualGenerator.cs
+++ b/src/GauntletCI.Core/Semantics/PatchCounterfactualGenerator.cs
@@ -41,7 +41,10 @@ public static class PatchCounterfactualGenerator
             switch (op.Kind)
             {
                 case PatchOperationKind.ConditionalModified:
-                    counterfactuals.Add(PatchCounterfactualFactory.BoundaryValue("Test boundary where condition changed"));
+                    counterfactuals.Add(PatchCounterfactualFactory.BoundaryValue(
+                        "Test boundary where condition changed",
+                        op.FilePath,
+                        op.NewLineNumber));
                     break;
 
                 case PatchOperationKind.ConditionalRemoved:

--- a/src/GauntletCI.Tests/OrchestratorTests.cs
+++ b/src/GauntletCI.Tests/OrchestratorTests.cs
@@ -22,7 +22,7 @@ public class OrchestratorTests
             +var x = 1;
             """);
         var result = await orchestrator.RunAsync(diff);
-        Assert.Equal(36, result.RulesEvaluated);
+        Assert.Equal(37, result.RulesEvaluated);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class OrchestratorTests
             """);
         var result = await orchestrator.RunAsync(diff);
         Assert.NotNull(result);
-        Assert.Equal(36, result.RulesEvaluated);
+        Assert.Equal(37, result.RulesEvaluated);
     }
 
     [Fact]
@@ -194,9 +194,8 @@ public class OrchestratorTests
         var diff = DiffParser.Parse(raw);
         var orchestrator = RuleOrchestrator.CreateDefault();
         var result = await orchestrator.RunAsync(diff);
-        // The GCI0019 large-diff warning is added if totalLines > 200 and findings < 2
-        // We just verify RunAsync completes without error
-        Assert.NotNull(result);
+        Assert.Contains(result.Findings, f => f.RuleId == "GCI0019");
+        Assert.Contains(result.Findings, f => f.Summary.Contains("Large diff", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/GauntletCI.Tests/Phase5IntegrationTests.cs
+++ b/src/GauntletCI.Tests/Phase5IntegrationTests.cs
@@ -39,7 +39,7 @@ public class Phase5IntegrationTests
 
         // Verify that behavioral change detection ran and context signals were evaluated
         Assert.NotNull(result);
-        Assert.Equal(36, result.RulesEvaluated);
+        Assert.Equal(37, result.RulesEvaluated);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class Phase5IntegrationTests
         var result = await orchestrator.RunAsync(diff);
 
         Assert.NotNull(result);
-        Assert.Equal(36, result.RulesEvaluated);
+        Assert.Equal(37, result.RulesEvaluated);
     }
 
     [Fact]
@@ -186,9 +186,9 @@ public class Phase5IntegrationTests
     }
 
     [Fact]
-    public async Task Orchestrator_AllRulesPresent_36EnabledRulesEvaluated()
+    public async Task Orchestrator_AllRulesPresent_37EnabledRulesEvaluated()
     {
-        // 38 rule implementations; GCI0054 and GCI0055 disabled by default (duplicate coverage).
+        // 39 rule implementations; GCI0054 and GCI0055 disabled by default (duplicate coverage).
         var orchestrator = RuleOrchestrator.CreateDefault();
         var cleanDiff = DiffParser.Parse("""
             diff --git a/src/Clean.cs b/src/Clean.cs
@@ -201,6 +201,6 @@ public class Phase5IntegrationTests
             """);
 
         var result = await orchestrator.RunAsync(cleanDiff);
-        Assert.Equal(36, result.RulesEvaluated);
+        Assert.Equal(37, result.RulesEvaluated);
     }
 }

--- a/src/GauntletCI.Tests/Rules/GCI0019Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0019Tests.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Model;
+using GauntletCI.Core.Rules;
+using GauntletCI.Core.Rules.Implementations;
+
+namespace GauntletCI.Tests.Rules;
+
+public sealed class GCI0019Tests
+{
+    [Fact]
+    public async Task EvaluateAsync_BinaryFileDiff_ProducesFinding()
+    {
+        var diff = DiffParser.Parse("""
+            diff --git a/assets/logo.png b/assets/logo.png
+            index abc1234..def5678 100644
+            Binary files a/assets/logo.png and b/assets/logo.png differ
+            """);
+
+        var rule = new GCI0019_ConfidenceAndEvidence(new DefaultPatternProvider());
+        var context = new GauntletCI.Core.Analysis.AnalysisContext
+        {
+            AllFiles = diff.Files,
+            Diff = diff,
+        };
+
+        var findings = await rule.EvaluateAsync(context);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal("GCI0019", finding.RuleId);
+        Assert.Equal("assets/logo.png", finding.FilePath);
+    }
+
+    [Fact]
+    public void PostProcess_LargeDiffWithNoOtherFindings_ProducesWarning()
+    {
+        var addedLines = string.Join("\n", Enumerable.Range(1, 210).Select(i => $"+    var x{i} = {i};"));
+        var raw = $"""
+            diff --git a/src/CleanService.cs b/src/CleanService.cs
+            index abc..def 100644
+            --- a/src/CleanService.cs
+            +++ b/src/CleanService.cs
+            @@ -1,1 +1,211 @@
+             // service
+            {addedLines}
+            """;
+        var diff = DiffParser.Parse(raw);
+        var rule = new GCI0019_ConfidenceAndEvidence(new DefaultPatternProvider());
+
+        var finding = rule.PostProcess(diff, Array.Empty<Finding>());
+
+        Assert.NotNull(finding);
+        Assert.Equal("GCI0019", finding!.RuleId);
+        Assert.Contains("Large diff", finding.Summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PostProcess_LargeDiffWithMultipleOtherFindings_ReturnsNull()
+    {
+        var addedLines = string.Join("\n", Enumerable.Range(1, 210).Select(i => $"+    var x{i} = {i};"));
+        var raw = $"""
+            diff --git a/src/CleanService.cs b/src/CleanService.cs
+            index abc..def 100644
+            --- a/src/CleanService.cs
+            +++ b/src/CleanService.cs
+            @@ -1,1 +1,211 @@
+             // service
+            {addedLines}
+            """;
+        var diff = DiffParser.Parse(raw);
+        var rule = new GCI0019_ConfidenceAndEvidence(new DefaultPatternProvider());
+        var prior = new List<Finding>
+        {
+            new() { RuleId = "GCI0003", RuleName = "A", Summary = "a", Evidence = "e", WhyItMatters = "w", SuggestedAction = "s" },
+            new() { RuleId = "GCI0004", RuleName = "B", Summary = "b", Evidence = "e", WhyItMatters = "w", SuggestedAction = "s" },
+        };
+
+        Assert.Null(rule.PostProcess(diff, prior));
+    }
+}


### PR DESCRIPTION
## Summary
- **GCI0019**: binary file detection + large-diff warning when >200 lines and no other findings
- **SemanticFindingProcessor**: match counterfactual witnesses by file/line instead of always using the first
- **Analyze CLI**: default bare \gauntletci analyze\ to \--staged\ (matches README quick start)
- **IPostProcessor**: extended to receive prior findings; PostProcess uses full diff (not filtered)

## Test plan
- [x] \dotnet test GauntletCI.slnx\ — 1844 tests pass
- [x] New GCI0019Tests + updated OrchestratorTests assert large-diff warning
