### PR TITLE
fix(licensing): reject non-JWT legacy license bypass

### DIFF
--- a/src/GauntletCI.Core/Licensing/LicenseService.cs
+++ b/src/GauntletCI.Core/Licensing/LicenseService.cs
@@ -72,9 +72,8 @@ public static class LicenseService
         var parts = token.Split('.');
         if (parts.Length != 3)
         {
-            // Legacy non-JWT token: backward-compat with the old "any non-empty env var" stub.
-            return new LicenseInfo(LicenseTier.Pro, null, null, true,
-                "Legacy license key format. Re-issue a signed token at gauntletci.com.");
+            return LicenseInfo.Invalid(
+                "License token is not a valid signed JWT. Re-issue a token at https://gauntletci.com/pricing");
         }
 
         try

--- a/src/GauntletCI.Tests/LicenseServiceTests.cs
+++ b/src/GauntletCI.Tests/LicenseServiceTests.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Licensing;
+
+namespace GauntletCI.Tests;
+
+public class LicenseServiceTests
+{
+    [Fact]
+    public void Load_NonJwtToken_IsRejected()
+    {
+        const string envVar = "GAUNTLETCI_LICENSE_TEST_NONJWT";
+        try
+        {
+            Environment.SetEnvironmentVariable(envVar, "not-a-jwt-token");
+            var license = LicenseService.Load(envVar);
+
+            Assert.False(license.IsValid);
+            Assert.False(license.IsLicensed);
+            Assert.Equal(LicenseTier.Community, license.Tier);
+            Assert.Contains("not a valid signed JWT", license.Error, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVar, null);
+        }
+    }
+
+    [Fact]
+    public void Load_MissingToken_ReturnsCommunity()
+    {
+        const string envVar = "GAUNTLETCI_LICENSE_TEST_MISSING";
+        Environment.SetEnvironmentVariable(envVar, null);
+
+        var license = LicenseService.Load(envVar);
+
+        Assert.True(license.IsValid);
+        Assert.False(license.IsLicensed);
+        Assert.Equal(LicenseTier.Community, license.Tier);
+    }
+}


### PR DESCRIPTION
## Summary
- Remove legacy path that granted Pro tier for any non-JWT env var value
- Non-JWT tokens now return Invalid with a clear re-issue message
- Add LicenseServiceTests covering rejection and missing-token community baseline

## Test plan
- [x] dotnet test --filter LicenseServiceTests