### PR TITLE
chore: centralize package version in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Version>2.8.0-alpha1</Version>
+  </PropertyGroup>
+</Project>

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
   gauntletci-version:
     description: "The GauntletCI NuGet tool version to install."
     required: false
-    default: "2.7.1"
+    default: "2.8.0-alpha1"
 
 outputs:
   findings-count:

--- a/src/GauntletCI.Cli/GauntletCI.Cli.csproj
+++ b/src/GauntletCI.Cli/GauntletCI.Cli.csproj
@@ -44,7 +44,6 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>gauntletci</ToolCommandName>
     <PackageId>GauntletCI</PackageId>
-    <Version>2.8.0-alpha1</Version>
     <Authors>Eric Cogen</Authors>
     <Description>GauntletCI is a .NET pre-commit and PR integration gate that evaluates diffs against 36+ behavioral-change rules: catching unvalidated changes, missing tests, async deadlock risk, security risks, and resource lifecycle violations before code is committed or merged. Optional local LLM enrichment via Ollama. Built-in MCP server for AI assistant integration. Core analysis runs locally by default. Source-available CodeRabbit alternative (Elastic License 2.0) with deterministic, auditable findings.</Description>
     <PackageTags>pre-commit;code-review;llm;static-analysis;behavioral-analysis;diff-analysis;git-hooks;ci;dotnet;csharp;mcp;pr-review;risk-detection;behavioral-testing;security-risk;async-safety;ollama;ai-code-review</PackageTags>


### PR DESCRIPTION
## Summary
- Add root Directory.Build.props with Version 2.8.0-alpha1
- Remove duplicate Version from GauntletCI.Cli.csproj
- Sync action.yml gauntletci-version default

## Test plan
- [x] Build-only metadata change