### PR TITLE
fix(GCI0056): scan repo for test framework evidence

### DIFF
--- a/src/GauntletCI.Core/Rules/Implementations/GCI0056_MissingTestFramework.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0056_MissingTestFramework.cs
@@ -3,14 +3,14 @@ using System.Text.RegularExpressions;
 using GauntletCI.Core.Analysis;
 using GauntletCI.Core.FileAnalysis;
 using GauntletCI.Core.Model;
+using GauntletCI.Core.StaticAnalysis;
 
 namespace GauntletCI.Core.Rules.Implementations;
 
 /// <summary>
 /// GCI0056, Missing Test Framework Detection
 /// Detects repositories that appear to lack test infrastructure by scanning for
-/// test framework references in project files (xunit, NUnit, MSTest, etc.) and
-/// test file patterns. Flags when production code exists but no test framework evidence.
+/// test framework references in project files and test file patterns.
 /// </summary>
 public class GCI0056_MissingTestFramework : RuleBase
 {
@@ -21,38 +21,23 @@ public class GCI0056_MissingTestFramework : RuleBase
     public override string Id => "GCI0056";
     public override string Name => "Missing Test Framework";
 
-    private static readonly string[] TestFrameworkPackages = new[]
-    {
-        // C# test frameworks
-        "xunit", "NUnit", "MSTest", "Microsoft.NET.Test.Sdk",
-        "nsubstitute", "moq", "autofixture", "Verify", "Shouldly",
-        // JavaScript test frameworks
-        "jest", "mocha", "vitest", "chai", "jasmine",
-        // Python test frameworks
-        "pytest", "unittest",
-        // General test utilities
-        "test", "testing"
-    };
+    private static readonly string[] ProjectFilePatterns =
+    [
+        ".csproj", ".vbproj", "package.json", "pyproject.toml", "Cargo.toml", ".gradle",
+    ];
 
-    private static readonly string[] ProjectFilePatterns = new[]
-    {
-        ".csproj", ".vbproj", "package.json", "pyproject.toml", "Cargo.toml", ".gradle"
-    };
-
-    private static readonly string[] ExemptDirectoryPatterns = new[]
-    {
-        "/samples/", "/sample/", "/examples/", "/example/", "/docs/", "/tools/", "/.github/"
-    };
+    private static readonly string[] ExemptDirectoryPatterns =
+    [
+        "/samples/", "/sample/", "/examples/", "/example/", "/docs/", "/tools/", "/.github/",
+    ];
 
     public override Task<List<Finding>> EvaluateAsync(
         AnalysisContext context, CancellationToken ct = default)
     {
         var findings = new List<Finding>();
 
-        // Collect all files (eligible and skipped)
         var allFiles = context.EligibleFiles.Concat(context.SkippedFiles).ToList();
 
-        // Check if repository appears to have production code
         var productionFiles = allFiles
             .Where(f => !WellKnownPatterns.IsTestFile(f.FilePath))
             .Where(f => !IsDocumentationFile(f.FilePath))
@@ -60,32 +45,18 @@ public class GCI0056_MissingTestFramework : RuleBase
             .Where(f => IsSourceCodeFile(f.FilePath))
             .ToList();
 
-        // If fewer than 3 production files, too small to require tests
         if (productionFiles.Count < 3)
             return Task.FromResult(findings);
 
-        // Check for project files that indicate a buildable repository
         var hasProjectFile = allFiles.Any(f =>
             ProjectFilePatterns.Any(p => f.FilePath.EndsWith(p, StringComparison.OrdinalIgnoreCase)));
 
         if (!hasProjectFile)
             return Task.FromResult(findings);
 
-        // Check for test files (excluding benchmarks for this rule)
-        var testFiles = allFiles
-            .Where(f => WellKnownPatterns.IsTestFile(f.FilePath))
-            .Where(f => !f.FilePath.EndsWith("Benchmark.cs", StringComparison.OrdinalIgnoreCase))
-            .Where(f => !f.FilePath.EndsWith("Benchmarks.cs", StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        // Check for test framework references in project files
-        var hasTestFramework = CheckForTestFrameworkPackages(allFiles);
-
-        // If tests exist OR test framework packages are referenced, no finding
-        if (testFiles.Count > 0 || hasTestFramework)
+        if (HasTestInfrastructureEvidence(allFiles))
             return Task.FromResult(findings);
 
-        // No tests and no test framework detected
         findings.Add(CreateFinding(
             summary: "Repository has no test framework detected",
             evidence: $"Repository contains {productionFiles.Count} production files but no test files or test framework packages found",
@@ -94,6 +65,20 @@ public class GCI0056_MissingTestFramework : RuleBase
             confidence: Confidence.Medium));
 
         return Task.FromResult(findings);
+    }
+
+    private static bool HasTestInfrastructureEvidence(IReadOnlyList<ChangedFileAnalysisRecord> allFiles)
+    {
+        var testFiles = allFiles
+            .Where(f => WellKnownPatterns.IsTestFile(f.FilePath))
+            .Where(f => !f.FilePath.EndsWith("Benchmark.cs", StringComparison.OrdinalIgnoreCase))
+            .Where(f => !f.FilePath.EndsWith("Benchmarks.cs", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (testFiles.Count > 0)
+            return true;
+
+        return TestFrameworkDetector.HasTestInfrastructure(Directory.GetCurrentDirectory());
     }
 
     private static bool IsSourceCodeFile(string filePath)
@@ -113,23 +98,5 @@ public class GCI0056_MissingTestFramework : RuleBase
         var normalized = filePath.Replace('\\', '/');
         return ExemptDirectoryPatterns.Any(p =>
             normalized.Contains(p, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static bool CheckForTestFrameworkPackages(IReadOnlyList<ChangedFileAnalysisRecord> allFiles)
-    {
-        // Look for .csproj, package.json, etc. and check for test framework references
-        var projectFiles = allFiles
-            .Where(f => f.FilePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
-                        f.FilePath.EndsWith("package.json", StringComparison.OrdinalIgnoreCase) ||
-                        f.FilePath.EndsWith("pyproject.toml", StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        // Without access to file contents in AnalysisContext, we rely on
-        // a future enhancement that would parse project files.
-        // For now, if a project file exists but we can't parse it,
-        // conservatively assume test framework may exist.
-        // TODO: Parse project files when file content access is available
-
-        return false; // Defer to test file detection until file parsing is available
     }
 }

--- a/src/GauntletCI.Core/StaticAnalysis/TestFrameworkDetector.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/TestFrameworkDetector.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Rules;
+
+namespace GauntletCI.Core.StaticAnalysis;
+
+/// <summary>
+/// Detects test infrastructure in a repository by scanning project manifests and test file paths.
+/// </summary>
+public static class TestFrameworkDetector
+{
+    private static readonly string[] TestFrameworkTokens =
+    [
+        "xunit", "nunit", "mstest", "microsoft.net.test.sdk",
+        "nsubstitute", "moq", "autofixture", "verify", "shouldly",
+        "jest", "mocha", "vitest", "chai", "jasmine",
+        "pytest",
+    ];
+
+    private static readonly string[] ProjectManifestNames =
+    [
+        ".csproj", "package.json", "pyproject.toml",
+    ];
+
+    private static readonly string[] SkipDirectoryNames =
+    [
+        "bin", "obj", "node_modules", ".git", ".github",
+    ];
+
+    /// <summary>
+    /// Returns true when the repository under <paramref name="repoPath"/> has test files
+    /// or project manifests referencing known test frameworks.
+    /// </summary>
+    public static bool HasTestInfrastructure(string? repoPath)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(repoPath))
+            return false;
+
+        try
+        {
+            if (HasTestFiles(repoPath))
+                return true;
+
+            return HasTestFrameworkReferences(repoPath);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool HasTestFiles(string repoPath)
+    {
+        foreach (var file in Directory.EnumerateFiles(repoPath, "*.*", SearchOption.AllDirectories))
+        {
+            if (ShouldSkipPath(file))
+                continue;
+
+            var relative = Path.GetRelativePath(repoPath, file).Replace('\\', '/');
+            if (WellKnownPatterns.IsTestFile(relative))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasTestFrameworkReferences(string repoPath)
+    {
+        foreach (var file in Directory.EnumerateFiles(repoPath, "*.*", SearchOption.AllDirectories))
+        {
+            if (ShouldSkipPath(file))
+                continue;
+
+            if (!IsProjectManifest(file))
+                continue;
+
+            string content;
+            try { content = File.ReadAllText(file); }
+            catch (IOException) { continue; }
+
+            if (ContainsTestFrameworkToken(content))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsProjectManifest(string filePath)
+    {
+        var fileName = Path.GetFileName(filePath);
+        return ProjectManifestNames.Any(name =>
+            fileName.EndsWith(name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool ContainsTestFrameworkToken(string content)
+    {
+        foreach (var token in TestFrameworkTokens)
+        {
+            if (content.Contains(token, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ShouldSkipPath(string absolutePath)
+    {
+        var parts = absolutePath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return parts.Any(part =>
+            SkipDirectoryNames.Contains(part, StringComparer.OrdinalIgnoreCase));
+    }
+}

--- a/tests/GauntletCI.Core.Tests/Rules/GCI0056_MissingTestFrameworkTests.cs
+++ b/tests/GauntletCI.Core.Tests/Rules/GCI0056_MissingTestFrameworkTests.cs
@@ -8,13 +8,20 @@ using GauntletCI.Core.Rules.Implementations;
 
 namespace GauntletCI.Core.Tests.Rules;
 
-public class GCI0056_MissingTestFrameworkTests
+public class GCI0056_MissingTestFrameworkTests : IDisposable
 {
-    private GCI0056_MissingTestFramework _rule;
+    private readonly GCI0056_MissingTestFramework _rule;
+    private readonly string _originalDirectory;
 
     public GCI0056_MissingTestFrameworkTests()
     {
         _rule = new GCI0056_MissingTestFramework(new DefaultPatternProvider());
+        _originalDirectory = Directory.GetCurrentDirectory();
+    }
+
+    public void Dispose()
+    {
+        Directory.SetCurrentDirectory(_originalDirectory);
     }
 
     private AnalysisContext CreateContext(params ChangedFileAnalysisRecord[] files)
@@ -28,62 +35,166 @@ public class GCI0056_MissingTestFrameworkTests
         };
     }
 
+    private static string CreateTempRepo(Action<string> setup)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "gci0056-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        setup(tempDir);
+        Directory.SetCurrentDirectory(tempDir);
+        return tempDir;
+    }
+
     [Fact]
     public async Task NoFinding_WhenProjectHasTests()
     {
-        var files = new[]
+        var tempDir = CreateTempRepo(dir =>
         {
-            new ChangedFileAnalysisRecord { FilePath = "src/MyClass.cs", IsEligible = true },
-            new ChangedFileAnalysisRecord { FilePath = "src/Service.cs", IsEligible = true },
-            new ChangedFileAnalysisRecord { FilePath = "src/Util.cs", IsEligible = true },
-            new ChangedFileAnalysisRecord { FilePath = "tests/MyClassTests.cs", IsEligible = true },
-            new ChangedFileAnalysisRecord { FilePath = "MyProject.csproj", IsEligible = true }
-        };
+            Directory.CreateDirectory(Path.Combine(dir, "src"));
+            Directory.CreateDirectory(Path.Combine(dir, "tests"));
+            File.WriteAllText(Path.Combine(dir, "src", "MyClass.cs"), "class MyClass {}");
+            File.WriteAllText(Path.Combine(dir, "src", "Service.cs"), "class Service {}");
+            File.WriteAllText(Path.Combine(dir, "src", "Util.cs"), "class Util {}");
+            File.WriteAllText(Path.Combine(dir, "tests", "MyClassTests.cs"), "class MyClassTests {}");
+            File.WriteAllText(Path.Combine(dir, "MyProject.csproj"), "<Project />");
+        });
 
-        var context = CreateContext(files);
-        var findings = await _rule.EvaluateAsync(context);
+        try
+        {
+            var files = new[]
+            {
+                new ChangedFileAnalysisRecord { FilePath = "src/MyClass.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "src/Service.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "src/Util.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "tests/MyClassTests.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "MyProject.csproj", IsEligible = true }
+            };
 
-        Assert.Empty(findings);
+            var findings = await _rule.EvaluateAsync(CreateContext(files));
+            Assert.Empty(findings);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(_originalDirectory);
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task NoFinding_WhenProjectReferencesTestFramework()
+    {
+        var tempDir = CreateTempRepo(dir =>
+        {
+            Directory.CreateDirectory(Path.Combine(dir, "src"));
+            File.WriteAllText(Path.Combine(dir, "src", "MyClass.cs"), "class MyClass {}");
+            File.WriteAllText(Path.Combine(dir, "src", "Service.cs"), "class Service {}");
+            File.WriteAllText(Path.Combine(dir, "src", "Util.cs"), "class Util {}");
+            File.WriteAllText(
+                Path.Combine(dir, "MyProject.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <ItemGroup>
+                    <PackageReference Include="xunit" Version="2.9.3" />
+                  </ItemGroup>
+                </Project>
+                """);
+        });
+
+        try
+        {
+            var files = new[]
+            {
+                new ChangedFileAnalysisRecord { FilePath = "src/MyClass.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "src/Service.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "src/Util.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "MyProject.csproj", IsEligible = true }
+            };
+
+            var findings = await _rule.EvaluateAsync(CreateContext(files));
+            Assert.Empty(findings);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(_originalDirectory);
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task Finding_WhenNoTestsAndMultipleSources()
     {
-        var files = new[]
+        var tempDir = CreateTempRepo(dir =>
         {
-            new ChangedFileAnalysisRecord { FilePath = "src/MyClass.cs", IsEligible = true },
-            new ChangedFileAnalysisRecord { FilePath = "src/Service.cs", IsEligible = true },
-            new ChangedFileAnalysisRecord { FilePath = "src/Util.cs", IsEligible = true },
-            new ChangedFileAnalysisRecord { FilePath = "MyProject.csproj", IsEligible = true }
-        };
+            Directory.CreateDirectory(Path.Combine(dir, "src"));
+            File.WriteAllText(Path.Combine(dir, "src", "MyClass.cs"), "class MyClass {}");
+            File.WriteAllText(Path.Combine(dir, "src", "Service.cs"), "class Service {}");
+            File.WriteAllText(Path.Combine(dir, "src", "Util.cs"), "class Util {}");
+            File.WriteAllText(Path.Combine(dir, "MyProject.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        });
 
-        var context = CreateContext(files);
-        var findings = await _rule.EvaluateAsync(context);
+        try
+        {
+            var files = new[]
+            {
+                new ChangedFileAnalysisRecord { FilePath = "src/MyClass.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "src/Service.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "src/Util.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "MyProject.csproj", IsEligible = true }
+            };
 
-        Assert.NotEmpty(findings);
-        Assert.Single(findings);
-        Assert.Equal(Confidence.Medium, findings[0].Confidence);
+            var findings = await _rule.EvaluateAsync(CreateContext(files));
+
+            Assert.NotEmpty(findings);
+            Assert.Single(findings);
+            Assert.Equal(Confidence.Medium, findings[0].Confidence);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(_originalDirectory);
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task NoFinding_WhenTooFewSources()
     {
-        var files = new[]
+        var tempDir = CreateTempRepo(dir =>
         {
-            new ChangedFileAnalysisRecord { FilePath = "src/MyClass.cs", IsEligible = true },
-            new ChangedFileAnalysisRecord { FilePath = "src/Service.cs", IsEligible = true },
-            new ChangedFileAnalysisRecord { FilePath = "MyProject.csproj", IsEligible = true }
-        };
+            Directory.CreateDirectory(Path.Combine(dir, "src"));
+            File.WriteAllText(Path.Combine(dir, "src", "MyClass.cs"), "class MyClass {}");
+            File.WriteAllText(Path.Combine(dir, "src", "Service.cs"), "class Service {}");
+            File.WriteAllText(Path.Combine(dir, "MyProject.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        });
 
-        var context = CreateContext(files);
-        var findings = await _rule.EvaluateAsync(context);
+        try
+        {
+            var files = new[]
+            {
+                new ChangedFileAnalysisRecord { FilePath = "src/MyClass.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "src/Service.cs", IsEligible = true },
+                new ChangedFileAnalysisRecord { FilePath = "MyProject.csproj", IsEligible = true }
+            };
 
-        Assert.Empty(findings);
+            var findings = await _rule.EvaluateAsync(CreateContext(files));
+            Assert.Empty(findings);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(_originalDirectory);
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task NoFinding_WhenNoProjectFile()
     {
+        CreateTempRepo(dir =>
+        {
+            Directory.CreateDirectory(Path.Combine(dir, "src"));
+            File.WriteAllText(Path.Combine(dir, "src", "MyClass.cs"), "class MyClass {}");
+            File.WriteAllText(Path.Combine(dir, "src", "Service.cs"), "class Service {}");
+            File.WriteAllText(Path.Combine(dir, "src", "Util.cs"), "class Util {}");
+        });
+
         var files = new[]
         {
             new ChangedFileAnalysisRecord { FilePath = "src/MyClass.cs", IsEligible = true },
@@ -91,15 +202,15 @@ public class GCI0056_MissingTestFrameworkTests
             new ChangedFileAnalysisRecord { FilePath = "src/Util.cs", IsEligible = true }
         };
 
-        var context = CreateContext(files);
-        var findings = await _rule.EvaluateAsync(context);
-
+        var findings = await _rule.EvaluateAsync(CreateContext(files));
         Assert.Empty(findings);
     }
 
     [Fact]
     public async Task NoFinding_WhenSampleProject()
     {
+        CreateTempRepo(_ => { });
+
         var files = new[]
         {
             new ChangedFileAnalysisRecord { FilePath = "samples/Example.cs", IsEligible = true },
@@ -108,9 +219,7 @@ public class GCI0056_MissingTestFrameworkTests
             new ChangedFileAnalysisRecord { FilePath = "samples/Sample.csproj", IsEligible = true }
         };
 
-        var context = CreateContext(files);
-        var findings = await _rule.EvaluateAsync(context);
-
+        var findings = await _rule.EvaluateAsync(CreateContext(files));
         Assert.Empty(findings);
     }
 }


### PR DESCRIPTION
## Summary
- Add TestFrameworkDetector to scan project manifests and test file paths on disk
- Replace stub CheckForTestFrameworkPackages that always returned false
- Update tests to use isolated temp directories

## Test plan
- [x] dotnet test --filter GCI0056 (6 tests pass)