### PR TITLE
chore: deduplicate .gitignore markdown exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,9 +93,6 @@ packaging/*.nupkg
 !docs/case-studies/gci0029-pii-exposure.md
 !docs/case-studies/gci0039-thread-exhaustion.md
 !docs/case-studies/README.md
-!docs/case-studies/gci0054-async-void-abuse.md
-!docs/case-studies/gci0055-method-signature-change.md
-!docs/case-studies/README.md
 !docs/PHASE_9_CORPUS_ANALYSIS_DECISION.md
 !docs/PHASE_10A_CORPUS_ANALYSIS.md
 !docs/PHASE_10B_SPOTCHECK_ANALYSIS.md
@@ -129,9 +126,6 @@ packaging/*.nupkg
 !docs/operations/coordination-runbook.md
 !docs/troubleshooting/phase-21-tuning.md
 !docs/DOCUMENTATION.md
-!docs/case-studies/gci0054-async-void-abuse.md
-!docs/case-studies/gci0055-method-signature-change.md
-!docs/case-studies/README.md
 
 # Publish artifacts (self-contained EXE - too large for GitHub)
 publish/


### PR DESCRIPTION
## Summary
- Remove duplicate !docs/case-studies entries (GCI0054, GCI0055, README)

## Test plan
- [x] No functional change; allowlist semantics unchanged