### PR TITLE
fix(site): resolve TypeScript errors and enforce build type-checking

### DIFF
--- a/site/app/articles/anglesharp-pr-1159-analysis/page.tsx
+++ b/site/app/articles/anglesharp-pr-1159-analysis/page.tsx
@@ -56,7 +56,7 @@ export default function AngleSharpAnalysisPage() {
   return (
     <main className="min-h-screen flex flex-col">
       <Header />
-      <Breadcrumbs items={[{ label: "Articles", href: "/articles" }, { label: "AngleSharp PR #1159" }]} />
+      <Breadcrumbs />
 
       <article className="flex-1 max-w-3xl mx-auto px-6 py-12">
         <JsonLd data={jsonLd} />

--- a/site/app/articles/case-studies/_components/case-study-layout.tsx
+++ b/site/app/articles/case-studies/_components/case-study-layout.tsx
@@ -40,7 +40,7 @@ export type CaseStudyLayoutProps = {
   sections: CaseStudySection[];
   diffTitle: string;
   diffFile: string;
-  diffLines: CaseStudyDiffLine[];
+  diffLines: readonly CaseStudyDiffLine[];
   findingTitle: string;
   findingBody: string;
   caveats: string[];

--- a/site/app/articles/case-studies/azuread-hardcoded-authority/page.tsx
+++ b/site/app/articles/case-studies/azuread-hardcoded-authority/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { CaseStudyLayout } from "../_components/case-study-layout";
+import { CaseStudyLayout, type CaseStudyDiffLine } from "../_components/case-study-layout";
 
 export const metadata: Metadata = {
   title: "Case Study: Signature Validation Telemetry in IdentityModel | GauntletCI",
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   openGraph: { images: [{ url: "/og/case-studies.png", width: 1200, height: 630 }] },
 };
 
-const diffLines = [
+const diffLines: CaseStudyDiffLine[] = [
   { type: "context", line: "// New telemetry controls and issuer allowlist" },
   { type: "added", line: "public static bool RecordSignatureValidationTelemetry { get; set; }" },
   { type: "added", line: "public static bool EnableIssuerHostCaching { get; set; }" },

--- a/site/app/articles/case-studies/efcore-breaking-api-removal/page.tsx
+++ b/site/app/articles/case-studies/efcore-breaking-api-removal/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { CaseStudyLayout } from "../_components/case-study-layout";
+import { CaseStudyLayout, type CaseStudyDiffLine } from "../_components/case-study-layout";
 
 export const metadata: Metadata = {
   title: "Case Study: Cosmos Serialization Modernization in EF Core | GauntletCI",
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   openGraph: { images: [{ url: "/og/case-studies.png", width: 1200, height: 630 }] },
 };
 
-const diffLines = [
+const diffLines: CaseStudyDiffLine[] = [
   { type: "context", line: "// Public Cosmos option marked obsolete" },
   { type: "added", line: '[Obsolete("Enabling ContentResponseOnWrite currently has no benefit for EF Core.")]' },
   { type: "context", line: "public virtual CosmosDbContextOptionsBuilder ContentResponseOnWriteEnabled(bool enabled = true)" },

--- a/site/app/articles/case-studies/newtonsoft-json-assignment-in-getter/page.tsx
+++ b/site/app/articles/case-studies/newtonsoft-json-assignment-in-getter/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { CaseStudyLayout } from "../_components/case-study-layout";
+import { CaseStudyLayout, type CaseStudyDiffLine } from "../_components/case-study-layout";
 
 export const metadata: Metadata = {
   title: "Case Study: Nullable Migration in Newtonsoft.Json | GauntletCI",
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   openGraph: { images: [{ url: "/og/case-studies.png", width: 1200, height: 630 }] },
 };
 
-const diffLines = [
+const diffLines: CaseStudyDiffLine[] = [
   { type: "context", line: "// JToken.Parent became nullable" },
   { type: "removed", line: "private JContainer _parent;" },
   { type: "added", line: "private JContainer? _parent;" },

--- a/site/app/articles/case-studies/nunit-thread-sleep-async/page.tsx
+++ b/site/app/articles/case-studies/nunit-thread-sleep-async/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { CaseStudyLayout } from "../_components/case-study-layout";
+import { CaseStudyLayout, type CaseStudyDiffLine } from "../_components/case-study-layout";
 
 export const metadata: Metadata = {
   title: "Case Study: Timeout Inheritance Change in NUnit | GauntletCI",
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   openGraph: { images: [{ url: "/og/case-studies.png", width: 1200, height: 630 }] },
 };
 
-const diffLines = [
+const diffLines: CaseStudyDiffLine[] = [
   { type: "context", line: "// CancelAfterAttribute now propagates from base fixtures/classes" },
   { type: "removed", line: '[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited=false)]' },
   { type: "added", line: '[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]' },

--- a/site/app/articles/case-studies/stackexchange-redis-paired-implementation/page.tsx
+++ b/site/app/articles/case-studies/stackexchange-redis-paired-implementation/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { CaseStudyLayout } from "../_components/case-study-layout";
+import { CaseStudyLayout, type CaseStudyDiffLine } from "../_components/case-study-layout";
 
 export const metadata: Metadata = {
   title: "Case Study: Paired Implementation Drift in StackExchange.Redis | GauntletCI",
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   openGraph: { images: [{ url: "/og/case-studies.png", width: 1200, height: 630 }] },
 };
 
-const diffLines = [
+const diffLines: CaseStudyDiffLine[] = [
   { type: "context", line: "// PR #2995: cluster-aware subscription cleanup in Subscription.cs" },
   { type: "context", line: "internal sealed class SingleNodeSubscription : Subscription" },
   { type: "context", line: "{" },
@@ -29,7 +29,7 @@ const diffLines = [
   { type: "added", line: "                scratch[count++] = server.Key;" },
   { type: "context", line: "    }" },
   { type: "context", line: "}" },
-] as const;
+];
 
 const findingBody = [
   "[GCI0058] Paired Implementation Consistency",

--- a/site/app/articles/case-studies/stackexchange-redis-swallowed-exception/page.tsx
+++ b/site/app/articles/case-studies/stackexchange-redis-swallowed-exception/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { CaseStudyLayout } from "../_components/case-study-layout";
+import { CaseStudyLayout, type CaseStudyDiffLine } from "../_components/case-study-layout";
 
 export const metadata: Metadata = {
   title: "Case Study: Swallowed Handler Exceptions in StackExchange.Redis | GauntletCI",
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   openGraph: { images: [{ url: "/og/case-studies.png", width: 1200, height: 630 }] },
 };
 
-const diffLines = [
+const diffLines: CaseStudyDiffLine[] = [
   { type: "context", line: "// PR #2995: ChannelMessageQueue was restructured during keyspace notification work" },
   { type: "context", line: "private void OnMessageSyncImpl(ChannelMessage next, Action<ChannelMessage>? handler)" },
   { type: "context", line: "{" },
@@ -26,7 +26,7 @@ const diffLines = [
   { type: "context", line: "    }" },
   { type: "added", line: "    catch { } // matches MessageCompletable" },
   { type: "context", line: "}" },
-] as const;
+];
 
 const findingBody = [
   "[GCI0007] Error Handling Integrity",

--- a/site/app/articles/google-api-pr-3150-analysis/page.tsx
+++ b/site/app/articles/google-api-pr-3150-analysis/page.tsx
@@ -56,7 +56,7 @@ export default function GoogleAPIAnalysisPage() {
   return (
     <main className="min-h-screen flex flex-col">
       <Header />
-      <Breadcrumbs items={[{ label: "Articles", href: "/articles" }, { label: "Google API PR #3150" }]} />
+      <Breadcrumbs />
 
       <article className="flex-1 max-w-3xl mx-auto px-6 py-12">
         <JsonLd data={jsonLd} />

--- a/site/app/articles/grpc-dotnet-pr-2531/page.tsx
+++ b/site/app/articles/grpc-dotnet-pr-2531/page.tsx
@@ -56,7 +56,7 @@ export default function GrpcAnalysisPage() {
   return (
     <main className="min-h-screen flex flex-col">
       <Header />
-      <Breadcrumbs items={[{ label: "Articles", href: "/articles" }, { label: "gRPC-dotnet PR #2531" }]} />
+      <Breadcrumbs />
 
       <article className="flex-1 max-w-3xl mx-auto px-6 py-12">
         <JsonLd data={jsonLd} />

--- a/site/app/articles/log4net-pr-201-analysis/page.tsx
+++ b/site/app/articles/log4net-pr-201-analysis/page.tsx
@@ -116,7 +116,7 @@ export default function Log4NetAnalysisPage() {
   return (
     <main className="min-h-screen flex flex-col">
       <Header />
-      <Breadcrumbs items={[{ label: "Articles", href: "/articles" }, { label: "log4net PR #201" }]} />
+      <Breadcrumbs />
 
       <article className="flex-1 max-w-3xl mx-auto px-6 py-12">
         <JsonLd data={jsonLd} />

--- a/site/app/articles/p/[page]/page.tsx
+++ b/site/app/articles/p/[page]/page.tsx
@@ -19,8 +19,9 @@ export async function generateStaticParams() {
   }));
 }
 
-export function generateMetadata({ params }: { params: { page: string } }): Metadata {
-  const pageNum = parseInt(params.page, 10) || 1;
+export async function generateMetadata({ params }: { params: Promise<{ page: string }> }): Promise<Metadata> {
+  const { page } = await params;
+  const pageNum = parseInt(page, 10) || 1;
   const canonical = pageNum === 1 ? "/articles" : `/articles/p/${pageNum}`;
   
   return {
@@ -39,8 +40,9 @@ const jsonLd = {
   url: "https://gauntletci.com/articles",
 };
 
-export default function ArticlesPageRoute({ params }: { params: { page: string } }) {
-  const pageParam = parseInt(params.page, 10);
+export default async function ArticlesPageRoute({ params }: { params: Promise<{ page: string }> }) {
+  const { page } = await params;
+  const pageParam = parseInt(page, 10);
   const currentPage = Math.max(1, pageParam || 1);
 
   // Sort: pinned first, then by order

--- a/site/app/articles/stackexchange-redis-pr-3028/page.tsx
+++ b/site/app/articles/stackexchange-redis-pr-3028/page.tsx
@@ -56,7 +56,7 @@ export default function RedisAnalysisPage() {
   return (
     <main className="min-h-screen flex flex-col">
       <Header />
-      <Breadcrumbs items={[{ label: "Articles", href: "/articles" }, { label: "StackExchange.Redis PR #3028" }]} />
+      <Breadcrumbs />
 
       <article className="flex-1 max-w-3xl mx-auto px-6 py-12">
         <JsonLd data={jsonLd} />

--- a/site/app/compare/gauntletci-vs-codeql/page.tsx
+++ b/site/app/compare/gauntletci-vs-codeql/page.tsx
@@ -73,11 +73,16 @@ const featureRows = [
   { label: "Custom rules via code (no query language required)", gauntlet: "yes" as const, codeql: "yes" as const },
 ];
 
-type CellVal = "yes" | "no" | "partial";
+type CellVal = "yes" | "no" | "partial" | "yes (Teams tier)";
 
 function Cell({ value, cyan }: { value: CellVal; cyan?: boolean }) {
-  if (value === "yes")
-    return <Check className={`h-5 w-5 mx-auto ${cyan ? "text-cyan-400" : "text-emerald-500/70"}`} />;
+  if (value === "yes" || value === "yes (Teams tier)")
+    return (
+      <Check
+        className={`h-5 w-5 mx-auto ${cyan ? "text-cyan-400" : "text-emerald-500/70"}`}
+        aria-label={value === "yes (Teams tier)" ? "Yes (Teams tier)" : "Yes"}
+      />
+    );
   if (value === "partial")
     return <AlertCircle className="h-4 w-4 mx-auto text-amber-400/60" />;
   return <Minus className="h-4 w-4 mx-auto text-muted-foreground/30" />;

--- a/site/app/compare/gauntletci-vs-sonarqube/page.tsx
+++ b/site/app/compare/gauntletci-vs-sonarqube/page.tsx
@@ -71,11 +71,16 @@ const featureRows = [
   { label: "Custom rules via code (no YAML required)", gauntlet: "yes" as const, sonar: "yes" as const },
 ];
 
-type CellVal = "yes" | "no" | "partial";
+type CellVal = "yes" | "no" | "partial" | "yes (Teams tier)";
 
 function Cell({ value, cyan }: { value: CellVal; cyan?: boolean }) {
-  if (value === "yes")
-    return <Check className={`h-5 w-5 mx-auto ${cyan ? "text-cyan-400" : "text-emerald-500/70"}`} />;
+  if (value === "yes" || value === "yes (Teams tier)")
+    return (
+      <Check
+        className={`h-5 w-5 mx-auto ${cyan ? "text-cyan-400" : "text-emerald-500/70"}`}
+        aria-label={value === "yes (Teams tier)" ? "Yes (Teams tier)" : "Yes"}
+      />
+    );
   if (value === "partial")
     return <AlertCircle className="h-4 w-4 mx-auto text-amber-400/60" />;
   return <Minus className="h-4 w-4 mx-auto text-muted-foreground/30" />;

--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -2,7 +2,7 @@
 const nextConfig = {
   output: 'export',
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary
- Set ignoreBuildErrors to false in next.config.mjs so the site build fails on type regressions
- Fix Next.js 15 async params on articles pagination page
- Remove invalid Breadcrumbs items prop from 5 article pages
- Type case study diffLines arrays with CaseStudyDiffLine[] (6 files)
- Extend compare page CellVal union for Teams tier values

## Test plan
- [x] npx tsc --noEmit passes in site/
- [ ] CI e2e + lighthouse checks pass