### PR TITLE
fix(docs): sync rule count copy from 30+ to 37 active rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Five minutes from install to first finding. No configuration required.
 
 ## What GauntletCI Detects
 
-30+ deterministic rules across production risk tiers:
+37 deterministic rules across production risk tiers:
 
 | Tier | Category | Example |
 |---|---|---|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ Instead of executing a heavy build-and-scan pass, GauntletCI intercepts the inne
 
 1. **Extraction:** The engine queries the local Git index to isolate modified lines and files.
 2. **Targeted Parsing:** Only the affected source files are loaded into syntax trees, omitting unchanged projects or assemblies.
-3. **Rule Application:** 30+ deterministic rules (e.g., `GCI0003` for guard clause removal, `GCI0007` for swallowed exceptions) evaluate the structural delta between the pre-image and post-image of the code.
+3. **Rule Application:** 37 deterministic rules (e.g., `GCI0003` for guard clause removal, `GCI0007` for swallowed exceptions) evaluate the structural delta between the pre-image and post-image of the code.
 
 This approach means GauntletCI runs before you push, gives instant feedback, and never sees your code outside your machine.
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -10,7 +10,19 @@ A finding is not a claim that the code is definitely broken. A finding is eviden
 - **Beta**: useful but still being tuned
 - **Experimental**: may produce more false positives
 
-## Rules
+## Active rules (37)
+
+GauntletCI ships **37 active deterministic rules** today. The canonical reference with confidence levels, detection logic, and configuration notes is **[docs/rules.md](../rules.md)**.
+
+| Category | Count | Rule IDs |
+|----------|------:|----------|
+| **Active** (emit findings by default) | 37 | GCI0001, GCI0003–GCI0007, GCI0010, GCI0012, GCI0015–GCI0016, GCI0019, GCI0020–GCI0022, GCI0024, GCI0029, GCI0032, GCI0035–GCI0036, GCI0038–GCI0039, GCI0041–GCI0049, GCI0050–GCI0053, GCI0056–GCI0059 |
+| **Implemented, disabled by default** | 2 | GCI0054 (async void — use GCI0016), GCI0055 (regex signatures — use GCI0003) |
+| **Reserved / consolidated** | 3 | GCI0028 (unassigned), GCI0030 (→ GCI0024), GCI0033 (→ GCI0016) |
+
+## Deep-dive rule pages
+
+These pages expand on a subset of high-traffic rules. See [docs/rules.md](../rules.md) for the full catalog.
 
 | Rule | Name | Category | Status |
 | --- | --- | --- | --- |
@@ -19,8 +31,6 @@ A finding is not a claim that the code is definitely broken. A finding is eviden
 | [GCI0006](GCI0006-edge-case-handling.md) | Edge Case Handling | Behavior and Contracts | Stable |
 | [GCI0007](GCI0007-error-handling-integrity.md) | Error Handling Integrity | Observability and Failure Handling | Stable |
 | [GCI0010](GCI0010-hardcoding-and-configuration.md) | Hardcoding and Configuration | Security and Configuration | Stable |
-
-For the full evolving rule reference, see [docs/rules.md](../rules.md).
 
 ## Best Practices Guide
 

--- a/nuget-readme.md
+++ b/nuget-readme.md
@@ -18,7 +18,7 @@ Neither validates what your change actually does.
 - ⚡ Sub-second analysis: no compilation, no AST, no network
 - 🔒 Runs locally: no code leaves your machine
 - 🎯 Up to 3 high-signal findings per run, no noise
-- 🔢 Fully deterministic: 30+ rules, no LLM required
+- 🔢 Fully deterministic: 37 rules, no LLM required
 
 ---
 
@@ -142,7 +142,7 @@ Baseline delta mode means you get signal on what you're changing today, not nois
 | | |
 |--|--|
 | [Getting Started](https://gauntletci.com/docs) | Install, first run, pre-commit hook |
-| [Rule Library](https://gauntletci.com/docs/rules) | All 30+ detection rules with examples |
+| [Rule Library](https://gauntletci.com/docs/rules) | All 37 detection rules with examples |
 | [CLI Reference](https://gauntletci.com/docs/cli-reference) | All commands and flags |
 | [Configuration](https://gauntletci.com/docs/configuration) | `.gauntletci.json` reference |
 | [Local LLM Setup](https://gauntletci.com/docs/local-llm) | Optional explanation layer via Ollama |

--- a/site/app/about/page.tsx
+++ b/site/app/about/page.tsx
@@ -105,7 +105,7 @@ export default function AboutPage() {
                   href="/docs/rules"
                   className="text-cyan-400 hover:underline font-semibold flex items-center gap-2"
                 >
-                  Browse the 30+ deterministic rules
+                  Browse the 37 deterministic rules
                   <ArrowRight className="h-3.5 w-3.5" />
                 </Link>
                 <p className="text-muted-foreground text-xs mt-1">

--- a/site/app/compare/gauntletci-vs-codeql/page.tsx
+++ b/site/app/compare/gauntletci-vs-codeql/page.tsx
@@ -192,7 +192,7 @@ export default function VsCodeQLPage() {
               },
               {
                 title: "No QL required",
-                body: "CodeQL's power comes with complexity. GauntletCI's 30+ built-in C#/.NET rules cover the most common behavioral regression classes with zero configuration required to start.",
+                body: "CodeQL's power comes with complexity. GauntletCI's 37 built-in C#/.NET rules cover the most common behavioral regression classes with zero configuration required to start.",
               },
               {
                 title: "100% local, always",

--- a/site/app/compare/gauntletci-vs-semgrep/page.tsx
+++ b/site/app/compare/gauntletci-vs-semgrep/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 
 const table = [
   { feature: "Analysis scope",         gauntlet: "Changed diff lines only",           semgrep: "Full file or full repo scan" },
-  { feature: "Rule authoring",         gauntlet: "30+ built-in, zero config",          semgrep: "Custom YAML patterns required" },
+  { feature: "Rule authoring",         gauntlet: "37 built-in, zero config",          semgrep: "Custom YAML patterns required" },
   { feature: "Behavioral drift detection", gauntlet: "Yes - removed logic, API contract changes", semgrep: "Limited - pattern matches only" },
   { feature: "Pre-commit speed",       gauntlet: "Under 1 second",                     semgrep: "Seconds to minutes (file-scoped)" },
   { feature: "False positives on unchanged code", gauntlet: "None - diff-scoped by design", semgrep: "Yes - scans pre-existing issues too" },
@@ -23,7 +23,7 @@ const table = [
   { feature: "LLM enrichment",         gauntlet: "Built-in ONNX, fully offline",       semgrep: "No" },
   { feature: "Baseline delta mode",    gauntlet: "Yes - suppress pre-existing issues", semgrep: "No" },
   { feature: "CI gate + inline comments", gauntlet: "Yes (Teams tier)",                semgrep: "Yes (paid)" },
-  { feature: "Free tier",              gauntlet: "All 30+ rules, no account",          semgrep: "Limited free, account required" },
+  { feature: "Free tier",              gauntlet: "All 37 rules, no account",          semgrep: "Limited free, account required" },
   { feature: "MCP server",             gauntlet: "Yes (Pro tier) -- AI assistants call GauntletCI directly", semgrep: "No" },
   { feature: "Custom rules",           gauntlet: "Yes -- implement IRule in C#, no YAML", semgrep: "Yes -- YAML patterns (required for all rules)" },
 ];
@@ -107,7 +107,7 @@ export default function SemgrepComparePage() {
               Zero false positives on pre-existing issues.
             </p>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              No YAML to write. 30+ built-in rules cover behavioral drift, security, async safety,
+              No YAML to write. 37 built-in rules cover behavioral drift, security, async safety,
               data integrity, and architecture violations - all running in under one second with
               no account or network call required.
             </p>

--- a/site/app/docs/configuration/page.tsx
+++ b/site/app/docs/configuration/page.tsx
@@ -21,7 +21,7 @@ const jsonLd = {
 const faqSchema = buildFaqSchema([
   {
     q: "Is GauntletCI zero-config?",
-    a: "Yes. GauntletCI works out of the box with no configuration file required. All 30+ rules are enabled by default. Place a .gauntletci.json file at your repository root to customize behavior.",
+    a: "Yes. GauntletCI works out of the box with no configuration file required. All 37 rules are enabled by default. Place a .gauntletci.json file at your repository root to customize behavior.",
   },
   {
     q: "How do I disable a specific rule?",

--- a/site/app/docs/custom-rules/page.tsx
+++ b/site/app/docs/custom-rules/page.tsx
@@ -394,7 +394,7 @@ CreateFinding(file, summary, evidence, whyItMatters, suggestedAction, confidence
           <h2 className="text-2xl font-semibold mb-4">Next steps</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {[
-              { href: "/docs/rules", label: "Rule Library", desc: "Browse all 30+ built-in detection rules" },
+              { href: "/docs/rules", label: "Rule Library", desc: "Browse all 37 built-in detection rules" },
               { href: "/docs/configuration", label: "Configuration", desc: "Engineering policy and .gauntletci.json options" },
               { href: "/docs/cli-reference", label: "CLI Reference", desc: "All commands, flags, and exit codes" },
             ].map((link) => (

--- a/site/app/docs/page.tsx
+++ b/site/app/docs/page.tsx
@@ -38,7 +38,7 @@ const faqSchema = buildFaqSchema([
   },
   {
     q: "What does GauntletCI analyze?",
-    a: "GauntletCI reads the exact lines added and removed in your diff and evaluates them against 30+ deterministic rules. It flags behavior changes without test updates, breaking API changes, new exception paths, removed null guards, and hardcoded secrets.",
+    a: "GauntletCI reads the exact lines added and removed in your diff and evaluates them against 37 deterministic rules. It flags behavior changes without test updates, breaking API changes, new exception paths, removed null guards, and hardcoded secrets.",
   },
 ]);
 
@@ -120,7 +120,7 @@ export default function DocsPage() {
       <section>
         <h2 className="text-2xl font-semibold mb-4">What it analyzes</h2>
         <p className="text-muted-foreground mb-4">
-          GauntletCI reads the exact lines added and removed in your diff and evaluates them against 30+ deterministic rules. It flags:
+          GauntletCI reads the exact lines added and removed in your diff and evaluates them against 37 deterministic rules. It flags:
         </p>
         <ul className="space-y-2 text-sm text-muted-foreground list-none">
           {[

--- a/site/app/docs/privacy-modes/page.tsx
+++ b/site/app/docs/privacy-modes/page.tsx
@@ -51,7 +51,7 @@ export default function PrivacyModesPage() {
                 <div>
                   <p className="font-semibold text-foreground mb-1">✓ What's enabled:</p>
                   <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-                    <li>30+ built-in deterministic rules (GCI0001-GCI0037)</li>
+                    <li>37 built-in deterministic rules (GCI0001-GCI0037)</li>
                     <li>Diff-based change detection</li>
                     <li>Local AST analysis (Roslyn syntax trees)</li>
                     <li>Pre-commit hook integration</li>
@@ -324,7 +324,7 @@ integrations:
           <div className="rounded-lg border border-cyan-500/30 bg-cyan-500/5 p-4 mb-4">
             <p className="text-sm font-semibold text-cyan-400 mb-2">📋 Rule Types</p>
             <p className="text-sm text-muted-foreground mb-2">
-              <strong>Built-in rules (30+ deterministic):</strong> Run without any LLM. Results are identical across runs. Always enabled.
+              <strong>Built-in rules (37 deterministic):</strong> Run without any LLM. Results are identical across runs. Always enabled.
             </p>
             <p className="text-sm text-muted-foreground">
               <strong>Experimental policy rules (optional):</strong> Defined in markdown, evaluated via LLM. Opt-in via <code className="bg-muted px-1 rounded text-xs">experimental.engineeringPolicy</code>.

--- a/site/components/detection-rules.tsx
+++ b/site/components/detection-rules.tsx
@@ -44,7 +44,7 @@ export function DetectionRules() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-3xl sm:text-4xl font-bold tracking-tight text-balance">
-            30+ built-in detection rules
+            37 built-in detection rules
           </h2>
           <p className="mt-4 text-lg text-muted-foreground max-w-2xl mx-auto text-pretty">
             Comprehensive coverage across behavioral risk categories.

--- a/site/components/faq.tsx
+++ b/site/components/faq.tsx
@@ -186,8 +186,8 @@ const faqs = [
     myth: "AI finds the bugs.",
     reality: (
       <>
-        The <strong>detection engine is 100% deterministic Roslyn analysis</strong>. It uses a fixed set of 30+
-        rules to identify changes. The AI (which runs 100% offline, locally) is only used to <em>explain</em> the
+        The <strong>detection engine is 100% deterministic Roslyn analysis</strong>. It uses a fixed set of 37
+        built-in rules to identify changes. The AI (which runs 100% offline, locally) is only used to <em>explain</em> the
         finding in plain English so juniors do not have to Google the error code.
       </>
     ),

--- a/site/components/features-benefits.tsx
+++ b/site/components/features-benefits.tsx
@@ -13,7 +13,7 @@ const items = [
   {
     icon: ShieldAlert,
     feature: "Deterministic Change-Risk Detection",
-    what: "30+ rules analyze the exact lines added or removed in a diff, not the whole file. Each rule targets a specific class of risk: removed logic without tests, breaking API changes, hardcoded secrets, unsafe casts, missing null guards, and more.",
+    what: "37 rules analyze the exact lines added or removed in a diff, not the whole file. Each rule targets a specific class of risk: removed logic without tests, breaking API changes, hardcoded secrets, unsafe casts, missing null guards, and more.",
     benefit: "A second opinion on every commit that focuses entirely on what changed and why it might fail in production, catching the things that look fine in review but break at runtime.",
   },
   {

--- a/site/components/terminal-block.tsx
+++ b/site/components/terminal-block.tsx
@@ -10,7 +10,7 @@ interface OutputLine {
 const lines: OutputLine[] = [
   { type: "cmd",      text: "$ gauntletci analyze --staged" },
   { type: "blank",    text: "" },
-  { type: "dim",      text: "  GauntletCI v2.1.0, 30+ rules, diff-scoped" },
+  { type: "dim",      text: "  GauntletCI v2.1.0, 37 rules, diff-scoped" },
   { type: "blank",    text: "" },
   { type: "critical", text: "  [BLOCK]  GCI0004  Breaking change in public API", annotation: 1 },
   { type: "dim",      text: "           OrderService.cs:142: ProcessPayment(decimal amount, string currency)" },


### PR DESCRIPTION
## Summary
- Update README, NuGet readme, architecture doc, and 11 site pages from stale 30+ to 37 active rules
- Refresh docs/rules/README.md with full active-rule table and pointer to docs/rules.md

## Test plan
- [x] Grep confirms no remaining user-facing 30+ rule counts (SonarQube language count unchanged)
- [ ] CI e2e + lighthouse pass