### PR TITLE
docs: clarify historical corpus metrics and current rule counts

### DIFF
--- a/docs/DEPLOYMENT_v2.2.2.md
+++ b/docs/DEPLOYMENT_v2.2.2.md
@@ -39,7 +39,7 @@
 - ✅ No ambiguity about feature availability by tier
 
 #### Phase 7e-7f: Standardization Complete
-- ✅ Rule counts standardized to "30+" (future-proof for 34 rules)
+- ✅ Rule counts standardized to "30+" at v2.2.2 (current: 37 active rules — see `docs/rules/README.md`)
 - ✅ Model naming consistent: "Phi-4 Mini" (marketing), "phi4-mini" (config)
 - ✅ All site pages using consistent terminology
 

--- a/docs/PHASE_10A_CORPUS_ANALYSIS.md
+++ b/docs/PHASE_10A_CORPUS_ANALYSIS.md
@@ -1,5 +1,7 @@
 # Phase 10A: Corpus Validation Tooling - Analysis Report
 
+> **Historical document.** Metrics and rule counts reflect the May 2026 corpus analysis era (34 rules at Phase 10). For the current rule inventory, see [rules/README.md](rules/README.md).
+
 **Date**: 2026-05-01  
 **Status**: Analysis complete, tooling validated  
 **Objective**: Understand label/detection mismatch; prepare for Phase 10B re-labeling  

--- a/docs/PHASE_10B_SPOTCHECK_ANALYSIS.md
+++ b/docs/PHASE_10B_SPOTCHECK_ANALYSIS.md
@@ -1,5 +1,7 @@
 # Phase 10B: Corpus Re-Labeling Spot-Check Analysis
 
+> **Historical document.** Metrics and rule counts reflect the May 2026 corpus analysis era (34 rules at Phase 10). For the current rule inventory, see [rules/README.md](rules/README.md).
+
 **Date**: 2026-05-01  
 **Status**: Spot-check analysis complete on 3 priority rules  
 **Objective**: Understand FP patterns to guide corpus re-labeling strategy

--- a/docs/PHASE_10C_B_RELABEL_RESULTS.md
+++ b/docs/PHASE_10C_B_RELABEL_RESULTS.md
@@ -1,5 +1,7 @@
 # Phase 10C-B: Selective Re-Labeling Results
 
+> **Historical document.** Metrics and rule counts reflect the May 2026 corpus analysis era (34 rules at Phase 10). For the current rule inventory, see [rules/README.md](rules/README.md).
+
 **Date**: 2026-05-01  
 **Status**: Spot-check complete, categorization done  
 **Rules Reviewed**: GCI0038, GCI0010 (10 samples each)

--- a/docs/PHASE_10C_CATEGORIZATION_RESULTS.md
+++ b/docs/PHASE_10C_CATEGORIZATION_RESULTS.md
@@ -1,5 +1,7 @@
 # Phase 10C: Categorization Results & Decisions
 
+> **Historical document.** Metrics and rule counts reflect the May 2026 corpus analysis era (34 rules at Phase 10). For the current rule inventory, see [rules/README.md](rules/README.md).
+
 **Date**: 2026-05-01  
 **Status**: Spot-check analysis complete, ready for categorization decision
 

--- a/docs/PHASE_10C_RELABEL_PLAN.md
+++ b/docs/PHASE_10C_RELABEL_PLAN.md
@@ -1,5 +1,7 @@
 # Phase 10C: Corpus Re-Labeling Execution Plan
 
+> **Historical document.** Metrics and rule counts reflect the May 2026 corpus analysis era (34 rules at Phase 10). For the current rule inventory, see [rules/README.md](rules/README.md).
+
 **Date**: 2026-05-01  
 **Status**: Starting Phase 10C re-labeling  
 **Backup**: ✅ Created: `data/gauntletci-corpus.db.backup-20260501-124028`

--- a/docs/PHASE_10_POST_LABEL_RULES.md
+++ b/docs/PHASE_10_POST_LABEL_RULES.md
@@ -1,5 +1,7 @@
 # Phase 10: Post-Corpus Rules & Version Skew Analysis
 
+> **Historical document.** Metrics and rule counts reflect the May 2026 corpus analysis era (34 rules at Phase 10). For the current rule inventory, see [rules/README.md](rules/README.md).
+
 **Date**: 2026-05-01  
 **Session**: Phase 10C Corpus Re-Labeling Initiative  
 **Finding**: 8 rules were added after the corpus was labeled (2-3 months ago)

--- a/docs/PHASE_11_GROUND_TRUTH_BASELINE.md
+++ b/docs/PHASE_11_GROUND_TRUTH_BASELINE.md
@@ -1,5 +1,7 @@
 # Phase 11: Ground Truth Building - COMPLETE ✅
 
+> **Historical document.** Metrics and rule counts reflect the May 2026 corpus analysis era (34 rules at Phase 10). For the current rule inventory and Silver benchmark metrics, see [rules/README.md](rules/README.md).
+
 **Date**: 2026-05-01  
 **Session**: Phase 10C-B continuation → Phase 11
 

--- a/docs/PHASE_9_CORPUS_ANALYSIS_DECISION.md
+++ b/docs/PHASE_9_CORPUS_ANALYSIS_DECISION.md
@@ -1,5 +1,7 @@
 # Phase 9B/C Analysis: Corpus-Driven Rule Refinement Decision
 
+> **Historical document.** Metrics and rule counts reflect the May 2026 corpus analysis era (34 rules at Phase 10). For the current rule inventory, see [rules/README.md](rules/README.md).
+
 **Date:** 2026-05-01  
 **Status:** Analysis complete, refinement strategy revised  
 **Decision:** Focus on case study integration (immediate value) vs corpus-based refinements (higher risk)
@@ -150,7 +152,7 @@ The mismatch between corpus labels and actual detections suggests one or more of
 
 ## Conclusion
 
-**Current state**: 34 rules, 1258 passing tests, production-ready.
+**State at time of writing (May 2026)**: 34 rules, 1258 passing tests, production-ready.
 
 **Corpus issue**: Data quality mismatch between labels and implementations. **Not a production risk.** The test suite is a more reliable signal than corpus labels.
 

--- a/docs/features-benefits.md
+++ b/docs/features-benefits.md
@@ -199,10 +199,14 @@ Rules not yet validated from corpus:
 - **GCI0001**: Diff integrity check; disabled in GauntletCI own CI config; no corpus example found
 - **GCI0029**: PII in logs; high FP rate on broad terms like `name`; excluded from showcase
 - **GCI0035**: Layer import violations; requires `ForbiddenImports` config to fire
-- **GCI0048**: Insecure random; newly added; corpus validation pending
-- **GCI0049**: Float equality; newly added; corpus validation pending
-- **GCI0052**: Dependency bot API drift; fires when bot-updated package appears in source without API surface update; corpus validation pending
-- **GCI0053**: Lockfile changed without source; fires when lockfile changes with no corresponding .cs changes; corpus validation pending
+- **GCI0051**: Numeric coercion risk; unit tested; no curated OSS PR showcase example yet
+- **GCI0052**: Dependency bot API drift; **disabled by default** — requires `GITHUB_ACTOR` bot context unavailable in generic diffs
+
+Rules validated via unit tests and case studies (not listed in the corpus showcase table above):
+- **GCI0048**: Insecure random — [case study](case-studies/gci0048-insecure-random.md) and unit tests
+- **GCI0049**: Float/double equality — unit tests and Silver corpus heuristics
+- **GCI0050**: SQL column truncation — [case study](case-studies/gci0050-sql-truncation.md) and unit tests
+- **GCI0053**: Lockfile changed without source — unit tests across supported lockfile formats
 
 Known precision caveats (as of current version):
 - **GCI0029**: `name` term fires on logging context keys and property names, not just PII; use `.gauntletci-ignore` to suppress per path

--- a/docs/project/history.md
+++ b/docs/project/history.md
@@ -23,7 +23,7 @@ the rule).
 With the core engine stable, effort shifted to the marketing site (`site/`, Next.js,
 static export). Work in this phase:
 
-- Rule-as-a-Page: 30+ individual rule detail pages at `/docs/rules/[ruleId]`, each
+- Rule-as-a-Page: 37 individual rule detail pages at `/docs/rules/[ruleId]`, each
   with full rule description, severity rationale, and code examples
 - Contextual loop: articles link to relevant rules, rule pages link back to articles
 - Founder bio and `/about` page for E-E-A-T author trust signals


### PR DESCRIPTION
Add historical disclaimers to Phase 9-11 corpus docs. Update features-benefits validation status, history rule page count to 37, and v2.2.2 deployment note.