### PR TITLE
chore: repo hygiene — gitignore, dependabot, doc sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
 

--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,8 @@ github-app-server/.env
 site/out/
 site/.next/
 site/tsconfig.tsbuildinfo
+site/package-lock.json
+site/.lighthouseci/
 
 # Python bytecode
 **/__pycache__/

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -35,8 +35,8 @@
 
 | Document | Purpose |
 |----------|---------|
-| [/docs/rules.md](/docs/rules.md) | Complete GCI rule reference (50+ rules) |
-| [/docs/rules/](/docs/rules/) | Individual rule pages (GCI0001-GCI0050+) |
+| [/docs/rules.md](/docs/rules.md) | Complete GCI rule reference (37 active rules) |
+| [/docs/rules/](/docs/rules/) | Individual rule pages (GCI0001–GCI0059) |
 | [/docs/best-practices.md](/docs/best-practices.md) | Recommended patterns (BP001-BP030) |
 | [/docs/core-engineering-rules.md](/docs/core-engineering-rules.md) | Engineering invariants & principles |
 

--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-project",
+  "name": "gauntletci-site",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Post-audit hygiene batch: ignore stray site lockfile and Lighthouse CI output, re-enable Dependabot NuGet PRs (limit 5), sync DOCUMENTATION.md rule counts, rename site package to gauntletci-site.