### PR TITLE
Harden git subprocess args against injection

### DIFF
--- a/src/GauntletCI.Cli/Telemetry/TelemetryHasher.cs
+++ b/src/GauntletCI.Cli/Telemetry/TelemetryHasher.cs
@@ -32,14 +32,18 @@ public static class TelemetryHasher
     {
         try
         {
-            var psi = new System.Diagnostics.ProcessStartInfo("git",
-                $"-C \"{repoRoot}\" remote get-url origin")
+            var psi = new System.Diagnostics.ProcessStartInfo("git")
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
+            psi.ArgumentList.Add("-C");
+            psi.ArgumentList.Add(repoRoot);
+            psi.ArgumentList.Add("remote");
+            psi.ArgumentList.Add("get-url");
+            psi.ArgumentList.Add("origin");
             using var proc = System.Diagnostics.Process.Start(psi);
             if (proc is null) return "local";
             var url = await proc.StandardOutput.ReadToEndAsync(ct);

--- a/src/GauntletCI.Core/Diff/DiffParser.cs
+++ b/src/GauntletCI.Core/Diff/DiffParser.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.Text.RegularExpressions;
+using GauntletCI.Core.Git;
 
 namespace GauntletCI.Core.Diff;
 
@@ -180,7 +181,9 @@ public static class DiffParser
     public static async Task<DiffContext> FromStagedAsync(
         string repoPath, int contextLines = 10, CancellationToken ct = default)
     {
-        var diff = await RunProcessAsync("git", $"-C \"{repoPath}\" diff --cached -U{contextLines}", ct).ConfigureAwait(false);
+        var diff = await RunGitAsync(
+            ["-C", repoPath, "diff", "--cached", $"-U{contextLines}"],
+            ct).ConfigureAwait(false);
         return Parse(diff, commitSha: "staged");
     }
 
@@ -188,7 +191,9 @@ public static class DiffParser
     public static async Task<DiffContext> FromUnstagedAsync(
         string repoPath, int contextLines = 10, CancellationToken ct = default)
     {
-        var diff = await RunProcessAsync("git", $"-C \"{repoPath}\" diff -U{contextLines}", ct).ConfigureAwait(false);
+        var diff = await RunGitAsync(
+            ["-C", repoPath, "diff", $"-U{contextLines}"],
+            ct).ConfigureAwait(false);
         return Parse(diff, commitSha: "unstaged");
     }
 
@@ -196,7 +201,9 @@ public static class DiffParser
     public static async Task<DiffContext> FromAllChangesAsync(
         string repoPath, int contextLines = 10, CancellationToken ct = default)
     {
-        var diff = await RunProcessAsync("git", $"-C \"{repoPath}\" diff HEAD -U{contextLines}", ct).ConfigureAwait(false);
+        var diff = await RunGitAsync(
+            ["-C", repoPath, "diff", $"-U{contextLines}", "HEAD"],
+            ct).ConfigureAwait(false);
         return Parse(diff, commitSha: "all-changes");
     }
 
@@ -220,33 +227,45 @@ public static class DiffParser
     private static async Task<(string diff, string? message)> RunGitAsync(
         string repoPath, string commitRef, int contextLines, CancellationToken ct)
     {
+        GitRefValidator.ValidateRef(commitRef);
+
         // Get commit message
         string? message = null;
         try
         {
-            var msgResult = await RunProcessAsync("git", $"-C \"{repoPath}\" log -1 --format=%s {commitRef}", ct).ConfigureAwait(false);
+            var msgResult = await RunGitAsync(
+                ["-C", repoPath, "log", "-1", "--format=%s", "--", commitRef],
+                ct).ConfigureAwait(false);
             message = msgResult.Trim();
         }
         catch { /* non-fatal */ }
 
         // Get diff: for a single commit use commit^..commit; for a range pass as-is
-        var diffArg = commitRef.Contains("..") ? commitRef : $"{commitRef}^..{commitRef}";
-        var diff = await RunProcessAsync("git", $"-C \"{repoPath}\" diff -U{contextLines} {diffArg}", ct).ConfigureAwait(false);
+        var diffArg = commitRef.Contains("..", StringComparison.Ordinal) ? commitRef : $"{commitRef}^..{commitRef}";
+        var diff = await RunGitAsync(
+            ["-C", repoPath, "diff", $"-U{contextLines}", "--", diffArg],
+            ct).ConfigureAwait(false);
         return (diff, message);
     }
 
-    private static async Task<string> RunProcessAsync(string executable, string arguments, CancellationToken ct)
+    private static Task<string> RunGitAsync(IReadOnlyList<string> args, CancellationToken ct) =>
+        RunProcessAsync("git", args, ct);
+
+    private static async Task<string> RunProcessAsync(
+        string executable, IReadOnlyList<string> arguments, CancellationToken ct)
     {
         using var process = new System.Diagnostics.Process();
         process.StartInfo = new System.Diagnostics.ProcessStartInfo
         {
             FileName = executable,
-            Arguments = arguments,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true
         };
+
+        foreach (var arg in arguments)
+            process.StartInfo.ArgumentList.Add(arg);
 
         process.Start();
 
@@ -288,7 +307,7 @@ public static class DiffParser
         }
 
         if (process.ExitCode != 0)
-            throw new GitProcessException($"{executable} {arguments}", process.ExitCode, stderr);
+            throw new GitProcessException($"{executable} {string.Join(' ', arguments)}", process.ExitCode, stderr);
 
         return output;
     }

--- a/src/GauntletCI.Core/Git/GitRefValidator.cs
+++ b/src/GauntletCI.Core/Git/GitRefValidator.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Text.RegularExpressions;
+
+namespace GauntletCI.Core.Git;
+
+/// <summary>
+/// Validates git ref strings before passing them as subprocess arguments.
+/// Rejects option-like values and characters outside the git ref alphabet.
+/// </summary>
+public static class GitRefValidator
+{
+    private static readonly Regex RefPartPattern = new(
+        @"^[a-zA-Z0-9._~/^:@{}+-]+$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Throws <see cref="ArgumentException"/> when <paramref name="commitRef"/> is not a safe git ref or range.
+    /// </summary>
+    public static void ValidateRef(string commitRef)
+    {
+        if (string.IsNullOrWhiteSpace(commitRef))
+            throw new ArgumentException("Commit reference must not be empty.", nameof(commitRef));
+
+        if (commitRef.StartsWith('-'))
+            throw new ArgumentException($"Invalid git ref: {commitRef}", nameof(commitRef));
+
+        if (commitRef.Contains("..", StringComparison.Ordinal))
+        {
+            var parts = commitRef.Split("..", 2, StringSplitOptions.None);
+            ValidateRefPart(parts[0]);
+            ValidateRefPart(parts[1]);
+            return;
+        }
+
+        ValidateRefPart(commitRef);
+    }
+
+    private static void ValidateRefPart(string part)
+    {
+        if (part.Length == 0)
+            throw new ArgumentException("Invalid git ref range.", nameof(part));
+
+        if (!RefPartPattern.IsMatch(part))
+            throw new ArgumentException($"Invalid git ref: {part}", nameof(part));
+    }
+}

--- a/src/GauntletCI.Tests/GitRefValidatorTests.cs
+++ b/src/GauntletCI.Tests/GitRefValidatorTests.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Git;
+
+namespace GauntletCI.Tests;
+
+public class GitRefValidatorTests
+{
+    [Theory]
+    [InlineData("HEAD")]
+    [InlineData("main")]
+    [InlineData("abc123def456")]
+    [InlineData("origin/main")]
+    [InlineData("HEAD~1")]
+    [InlineData("v1.2.3")]
+    [InlineData("refs/heads/main")]
+    [InlineData("abc123..def456")]
+    public void ValidateRef_AcceptsCommonRefs(string commitRef)
+    {
+        GitRefValidator.ValidateRef(commitRef);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("--output=evil")]
+    [InlineData("-n")]
+    [InlineData("HEAD;calc")]
+    [InlineData("HEAD --output=evil")]
+    [InlineData("..main")]
+    [InlineData("main..")]
+    public void ValidateRef_RejectsUnsafeRefs(string commitRef)
+    {
+        Assert.Throws<ArgumentException>(() => GitRefValidator.ValidateRef(commitRef));
+    }
+}


### PR DESCRIPTION
## Summary
- Use ProcessStartInfo.ArgumentList instead of concatenated argument strings for git invocations
- Validate commit refs before passing them to git (reject option-like values)
- Insert -- before revspec arguments in DiffParser log/diff commands
- Apply same ArgumentList pattern in TelemetryHasher

## Test plan
- [x] GitRefValidatorTests (14 cases)
- [x] DiffParserTests pass locally