### PR TITLE
Bump Microsoft.Data.Sqlite from 10.0.6 to 10.0.8

### DIFF
--- a/src/GauntletCI.Cli/GauntletCI.Cli.csproj
+++ b/src/GauntletCI.Cli/GauntletCI.Cli.csproj
@@ -7,7 +7,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.55.2" />

--- a/src/GauntletCI.Corpus/GauntletCI.Corpus.csproj
+++ b/src/GauntletCI.Corpus/GauntletCI.Corpus.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
 

--- a/src/GauntletCI.Llm/GauntletCI.Llm.csproj
+++ b/src/GauntletCI.Llm/GauntletCI.Llm.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.Managed" Version="0.14.1" />
     <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.14.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />


### PR DESCRIPTION
Completes Dependabot #223 (closed without merge during rebase). Patch bump across Cli, Corpus, and Llm.