### PR TITLE
Align coverlet.collector 10.0.1 across all test projects

### DIFF
--- a/tests/GauntletCI.Benchmarks/GauntletCI.Benchmarks.csproj
+++ b/tests/GauntletCI.Benchmarks/GauntletCI.Benchmarks.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/GauntletCI.Cli.Tests/GauntletCI.Cli.Tests.csproj
+++ b/tests/GauntletCI.Cli.Tests/GauntletCI.Cli.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/GauntletCI.Core.Tests/GauntletCI.Core.Tests.csproj
+++ b/tests/GauntletCI.Core.Tests/GauntletCI.Core.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />


### PR DESCRIPTION
Finishes Dependabot #222: Cli.Tests, Core.Tests, and Benchmarks were still on 8.0.1 after merge conflict resolution.