### PR TITLE
Allowlist Slack and Teams webhook URLs

### DIFF
--- a/src/GauntletCI.Cli/Output/SlackTeamsNotifier.cs
+++ b/src/GauntletCI.Cli/Output/SlackTeamsNotifier.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using GauntletCI.Core;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.Rules;
+using GauntletCI.Core.Security;
 
 namespace GauntletCI.Cli.Output;
 
@@ -48,10 +49,20 @@ public static class SlackTeamsNotifier
         var tasks = new List<Task>();
 
         if (slackUrl is not null)
-            tasks.Add(SendSlackNotificationAsync(result, repo, prNumStr, shortSha, slackUrl, ct));
+        {
+            if (WebhookUrlValidator.TryValidateSlack(slackUrl, out var slackError))
+                tasks.Add(SendSlackNotificationAsync(result, repo, prNumStr, shortSha, slackUrl, ct));
+            else
+                Console.Error.WriteLine($"[GauntletCI] Slack webhook rejected: {slackError}");
+        }
 
         if (teamsUrl is not null)
-            tasks.Add(SendTeamsNotificationAsync(result, repo, prNumStr, shortSha, teamsUrl, ct));
+        {
+            if (WebhookUrlValidator.TryValidateTeams(teamsUrl, out var teamsError))
+                tasks.Add(SendTeamsNotificationAsync(result, repo, prNumStr, shortSha, teamsUrl, ct));
+            else
+                Console.Error.WriteLine($"[GauntletCI] Teams webhook rejected: {teamsError}");
+        }
 
         // Send notifications in parallel (both at once if both URLs exist)
         await Task.WhenAll(tasks);

--- a/src/GauntletCI.Core/Security/WebhookUrlValidator.cs
+++ b/src/GauntletCI.Core/Security/WebhookUrlValidator.cs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net;
+
+namespace GauntletCI.Core.Security;
+
+/// <summary>
+/// Validates incoming webhook URLs before outbound POST to reduce SSRF risk from config or env vars.
+/// </summary>
+public static class WebhookUrlValidator
+{
+    private static readonly string[] TeamsHostSuffixes =
+    [
+        ".webhook.office.com",
+        ".logic.azure.com",
+    ];
+
+    /// <summary>
+    /// Returns true when <paramref name="url"/> is a valid Slack incoming webhook URL.
+    /// </summary>
+    public static bool TryValidateSlack(string? url, out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            error = "Webhook URL is empty.";
+            return false;
+        }
+
+        return TryValidate(url, static host => host.Equals("hooks.slack.com", StringComparison.OrdinalIgnoreCase), out error);
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="url"/> is a valid Microsoft Teams incoming webhook URL.
+    /// </summary>
+    public static bool TryValidateTeams(string? url, out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            error = "Webhook URL is empty.";
+            return false;
+        }
+
+        if (!TryValidate(url, IsTeamsHostAllowed, out error))
+            return false;
+
+        if (!Uri.TryCreate(url!.Trim(), UriKind.Absolute, out var uri))
+        {
+            error = "Webhook URL is not a valid absolute URI.";
+            return false;
+        }
+
+        if (uri.Host.Equals("outlook.office.com", StringComparison.OrdinalIgnoreCase)
+            && !uri.AbsolutePath.StartsWith("/webhook", StringComparison.OrdinalIgnoreCase))
+        {
+            error = "Outlook Teams webhook URL must use an /webhook path.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool IsTeamsHostAllowed(string host)
+    {
+        if (host.Equals("outlook.office.com", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        foreach (var suffix in TeamsHostSuffixes)
+        {
+            if (host.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryValidate(
+        string? url,
+        Func<string, bool> hostAllowed,
+        out string? error)
+    {
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            error = "Webhook URL is empty.";
+            return false;
+        }
+
+        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri))
+        {
+            error = "Webhook URL is not a valid absolute URI.";
+            return false;
+        }
+
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            error = "Webhook URL must use HTTPS.";
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            error = "Webhook URL must not contain embedded credentials.";
+            return false;
+        }
+
+        var host = uri.IdnHost.ToLowerInvariant();
+        if (IsBlockedHost(host))
+        {
+            error = "Webhook URL host is not allowed.";
+            return false;
+        }
+
+        if (!hostAllowed(host))
+        {
+            error = "Webhook URL host is not an allowed notification endpoint.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsBlockedHost(string host)
+    {
+        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (host.EndsWith(".local", StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith(".internal", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!IPAddress.TryParse(host, out var ip))
+            return false;
+
+        if (IPAddress.IsLoopback(ip))
+            return true;
+
+        if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+        {
+            var bytes = ip.GetAddressBytes();
+            if (bytes.All(static b => b == 0))
+                return true;
+
+            return bytes[0] switch
+            {
+                10 => true,
+                127 => true,
+                169 when bytes[1] == 254 => true,
+                172 when bytes[1] is >= 16 and <= 31 => true,
+                192 when bytes[1] == 168 => true,
+                _ => false,
+            };
+        }
+
+        return false;
+    }
+}

--- a/src/GauntletCI.Tests/WebhookUrlValidatorTests.cs
+++ b/src/GauntletCI.Tests/WebhookUrlValidatorTests.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Security;
+
+namespace GauntletCI.Tests;
+
+public class WebhookUrlValidatorTests
+{
+    [Theory]
+    [InlineData("https://hooks.slack.com/services/T000/B000/XXXXXXXX")]
+    [InlineData("https://hooks.slack.com/triggers/E000/000/000")]
+    public void TryValidateSlack_AcceptsOfficialHosts(string url)
+    {
+        Assert.True(WebhookUrlValidator.TryValidateSlack(url, out var error));
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData("http://hooks.slack.com/services/T000/B000/XXXXXXXX")]
+    [InlineData("https://evil.com/hooks.slack.com/services/T000/B000/XXXXXXXX")]
+    [InlineData("https://hooks.slack.com.evil.com/services/T000/B000/XXXXXXXX")]
+    [InlineData("https://127.0.0.1/webhook")]
+    [InlineData("https://169.254.169.254/latest/meta-data")]
+    public void TryValidateSlack_RejectsUnsafeUrls(string url)
+    {
+        Assert.False(WebhookUrlValidator.TryValidateSlack(url, out var error));
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    [Theory]
+    [InlineData("https://contoso.webhook.office.com/webhookb2/guid/IncomingWebhook/token/token")]
+    [InlineData("https://prod-12.westus.logic.azure.com:443/workflows/abc/triggers/manual/paths/invoke")]
+    [InlineData("https://outlook.office.com/webhook/guid@guid/IncomingWebhook/token/token")]
+    public void TryValidateTeams_AcceptsOfficialHosts(string url)
+    {
+        Assert.True(WebhookUrlValidator.TryValidateTeams(url, out var error));
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData("https://outlook.office.com/not-a-webhook")]
+    [InlineData("https://evil.com/webhook")]
+    [InlineData("http://contoso.webhook.office.com/webhookb2/guid")]
+    public void TryValidateTeams_RejectsUnsafeUrls(string url)
+    {
+        Assert.False(WebhookUrlValidator.TryValidateTeams(url, out var error));
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+}


### PR DESCRIPTION
## Summary
- Add WebhookUrlValidator with HTTPS-only vendor host allowlists for Slack and Teams
- Block loopback, private, and link-local hosts before notification POSTs
- Reject invalid URLs with stderr message instead of sending

## Test plan
- [x] WebhookUrlValidatorTests (13 cases)