### PR TITLE
Authenticate local LLM daemon pipe clients

### DIFF
--- a/src/GauntletCI.Cli/LlmDaemon/DaemonProtocol.cs
+++ b/src/GauntletCI.Cli/LlmDaemon/DaemonProtocol.cs
@@ -5,6 +5,7 @@ namespace GauntletCI.Cli.LlmDaemon;
 
 internal sealed record DaemonRequest(
     [property: JsonPropertyName("op")] string Op,
+    [property: JsonPropertyName("token")] string? Token = null,
     [property: JsonPropertyName("ruleId")] string? RuleId = null,
     [property: JsonPropertyName("ruleName")] string? RuleName = null,
     [property: JsonPropertyName("summary")] string? Summary = null,

--- a/src/GauntletCI.Cli/LlmDaemon/LlmDaemonAuth.cs
+++ b/src/GauntletCI.Cli/LlmDaemon/LlmDaemonAuth.cs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.IO.Pipes;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text;
+
+namespace GauntletCI.Cli.LlmDaemon;
+
+/// <summary>
+/// Session token and pipe ACL helpers for the local LLM daemon.
+/// </summary>
+internal static class LlmDaemonAuth
+{
+    internal static string TokenFilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".gauntletci", "llm-daemon.token");
+
+    internal static string GenerateToken()
+    {
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes);
+    }
+
+    internal static async Task PersistTokenAsync(string token, CancellationToken ct = default)
+    {
+        var path = TokenFilePath;
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        await File.WriteAllTextAsync(path, token, ct).ConfigureAwait(false);
+        TryRestrictTokenFile(path);
+    }
+
+    internal static void DeleteTokenFile()
+    {
+        try { File.Delete(TokenFilePath); }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"LlmDaemonAuth: Failed to delete token file: {ex.Message}");
+        }
+    }
+
+    internal static string? TryReadPersistedToken()
+    {
+        try
+        {
+            if (!File.Exists(TokenFilePath))
+                return null;
+
+            var token = File.ReadAllText(TokenFilePath).Trim();
+            return string.IsNullOrEmpty(token) ? null : token;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static bool IsValidToken(string? expected, string? provided)
+    {
+        if (string.IsNullOrEmpty(expected) || string.IsNullOrEmpty(provided))
+            return false;
+
+        var expectedBytes = Encoding.UTF8.GetBytes(expected);
+        var providedBytes = Encoding.UTF8.GetBytes(provided);
+        return expectedBytes.Length == providedBytes.Length
+            && CryptographicOperations.FixedTimeEquals(expectedBytes, providedBytes);
+    }
+
+    internal static NamedPipeServerStream CreateServerStream(string pipeName)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var security = CreateCurrentUserPipeSecurity();
+            return NamedPipeServerStreamAcl.Create(
+                pipeName,
+                PipeDirection.InOut,
+                maxNumberOfServerInstances: 1,
+                PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous,
+                inBufferSize: 0,
+                outBufferSize: 0,
+                pipeSecurity: security);
+        }
+
+        return new NamedPipeServerStream(
+            pipeName,
+            PipeDirection.InOut,
+            maxNumberOfServerInstances: 1,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static PipeSecurity CreateCurrentUserPipeSecurity()
+    {
+        var security = new PipeSecurity();
+        var user = WindowsIdentity.GetCurrent().User
+            ?? throw new InvalidOperationException("Current Windows identity has no user SID.");
+
+        security.AddAccessRule(new PipeAccessRule(
+            user,
+            PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance,
+            AccessControlType.Allow));
+        security.SetOwner(user);
+        return security;
+    }
+
+    private static void TryRestrictTokenFile(string path)
+    {
+        try
+        {
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            {
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+                return;
+            }
+
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            var info = new FileInfo(path);
+            var acl = info.GetAccessControl();
+            acl.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+            acl.AddAccessRule(new FileSystemAccessRule(
+                WindowsIdentity.GetCurrent().User!,
+                FileSystemRights.FullControl,
+                AccessControlType.Allow));
+            info.SetAccessControl(acl);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"LlmDaemonAuth: Failed to restrict token file permissions: {ex.Message}");
+        }
+    }
+}

--- a/src/GauntletCI.Cli/LlmDaemon/LlmDaemonClient.cs
+++ b/src/GauntletCI.Cli/LlmDaemon/LlmDaemonClient.cs
@@ -21,13 +21,19 @@ internal sealed class LlmDaemonClient : ILlmEngine
     private readonly NamedPipeClientStream _pipe;
     private readonly StreamReader _reader;
     private readonly StreamWriter _writer;
+    private readonly string _sessionToken;
     private bool _disposed;
 
-    private LlmDaemonClient(NamedPipeClientStream pipe, StreamReader reader, StreamWriter writer)
+    private LlmDaemonClient(
+        NamedPipeClientStream pipe,
+        StreamReader reader,
+        StreamWriter writer,
+        string sessionToken)
     {
         _pipe = pipe;
         _reader = reader;
         _writer = writer;
+        _sessionToken = sessionToken;
     }
 
     public bool IsAvailable => _pipe.IsConnected && !_disposed;
@@ -93,8 +99,15 @@ internal sealed class LlmDaemonClient : ILlmEngine
             var reader = new StreamReader(pipe, leaveOpen: true);
             var writer = new StreamWriter(pipe, leaveOpen: true) { AutoFlush = true };
 
+            var sessionToken = LlmDaemonAuth.TryReadPersistedToken();
+            if (sessionToken is null)
+            {
+                pipe.Dispose();
+                return null;
+            }
+
             // Ping to confirm the server is ready
-            await writer.WriteLineAsync(JsonSerializer.Serialize(new DaemonRequest("ping")));
+            await writer.WriteLineAsync(JsonSerializer.Serialize(new DaemonRequest("ping", Token: sessionToken)));
             var raw = await reader.ReadLineAsync(ct);
             if (raw is null) { pipe.Dispose(); return null; }
 
@@ -103,7 +116,7 @@ internal sealed class LlmDaemonClient : ILlmEngine
 
             pipe = null; // ownership transferred to client
             return new LlmDaemonClient(
-                (NamedPipeClientStream)reader.BaseStream, reader, writer);
+                (NamedPipeClientStream)reader.BaseStream, reader, writer, sessionToken);
         }
         catch (OperationCanceledException)
         {
@@ -151,6 +164,7 @@ internal sealed class LlmDaemonClient : ILlmEngine
     public async Task<string> EnrichFindingAsync(Finding finding, CancellationToken ct = default)
     {
         var req = new DaemonRequest("enrich",
+            Token: _sessionToken,
             RuleId: finding.RuleId,
             RuleName: finding.RuleName,
             Summary: finding.Summary,

--- a/src/GauntletCI.Cli/LlmDaemon/LlmDaemonServer.cs
+++ b/src/GauntletCI.Cli/LlmDaemon/LlmDaemonServer.cs
@@ -32,6 +32,9 @@ internal static class LlmDaemonServer
         Directory.CreateDirectory(Path.GetDirectoryName(pidPath)!);
         await File.WriteAllTextAsync(pidPath, Environment.ProcessId.ToString(), ct);
 
+        var sessionToken = LlmDaemonAuth.GenerateToken();
+        await LlmDaemonAuth.PersistTokenAsync(sessionToken, ct);
+
         using ILlmEngine engine = new LocalLlmEngine();
         var lastActivity = DateTime.UtcNow;
 
@@ -39,12 +42,7 @@ internal static class LlmDaemonServer
         {
             while (!ct.IsCancellationRequested && DateTime.UtcNow - lastActivity < IdleTimeout)
             {
-                using var pipe = new NamedPipeServerStream(
-                    PipeName,
-                    PipeDirection.InOut,
-                    maxNumberOfServerInstances: 1,
-                    PipeTransmissionMode.Byte,
-                    PipeOptions.Asynchronous);
+                using var pipe = LlmDaemonAuth.CreateServerStream(PipeName);
 
                 // Wait for a client with a rolling poll window so we can re-check idle time
                 using var pollCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -60,13 +58,14 @@ internal static class LlmDaemonServer
                 }
 
                 lastActivity = DateTime.UtcNow;
-                await HandleClientAsync(engine, pipe, ct);
+                await HandleClientAsync(engine, pipe, sessionToken, ct);
                 lastActivity = DateTime.UtcNow;
             }
         }
         catch (OperationCanceledException) { }
         finally
         {
+            LlmDaemonAuth.DeleteTokenFile();
             try { File.Delete(pidPath); }
             catch (Exception ex)
             {
@@ -76,7 +75,8 @@ internal static class LlmDaemonServer
         }
     }
 
-    private static async Task HandleClientAsync(ILlmEngine engine, NamedPipeServerStream pipe, CancellationToken ct)
+    private static async Task HandleClientAsync(
+        ILlmEngine engine, NamedPipeServerStream pipe, string sessionToken, CancellationToken ct)
     {
         using var reader = new StreamReader(pipe, leaveOpen: true);
         using var writer = new StreamWriter(pipe, leaveOpen: true) { AutoFlush = true };
@@ -109,6 +109,10 @@ internal static class LlmDaemonServer
                 if (req is null)
                 {
                     resp = new DaemonResponse(false, "Deserialization resulted in null");
+                }
+                else if (!LlmDaemonAuth.IsValidToken(sessionToken, req.Token))
+                {
+                    resp = new DaemonResponse(false, "Unauthorized");
                 }
                 else
                 {

--- a/src/GauntletCI.Tests/LlmDaemonAuthTests.cs
+++ b/src/GauntletCI.Tests/LlmDaemonAuthTests.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Cli.LlmDaemon;
+
+namespace GauntletCI.Tests;
+
+public class LlmDaemonAuthTests
+{
+    [Fact]
+    public void IsValidToken_AcceptsMatchingToken()
+    {
+        const string token = "abc123";
+        Assert.True(LlmDaemonAuth.IsValidToken(token, token));
+    }
+
+    [Theory]
+    [InlineData(null, "abc")]
+    [InlineData("abc", null)]
+    [InlineData("", "abc")]
+    [InlineData("abc", "abcd")]
+    [InlineData("abc", "abd")]
+    public void IsValidToken_RejectsMissingOrMismatchedTokens(string? expected, string? provided)
+    {
+        Assert.False(LlmDaemonAuth.IsValidToken(expected, provided));
+    }
+
+    [Fact]
+    public void GenerateToken_ProducesDistinctValues()
+    {
+        var first = LlmDaemonAuth.GenerateToken();
+        var second = LlmDaemonAuth.GenerateToken();
+
+        Assert.NotEqual(first, second);
+        Assert.True(first.Length >= 32);
+    }
+}


### PR DESCRIPTION
## Summary
- Issue a random session token in ~/.gauntletci/llm-daemon.token on daemon start
- Require token on every daemon request (ping and enrich)
- Restrict Windows named pipe ACL to the current user
- Set user-only permissions on the token file

## Test plan
- [x] LlmDaemonAuthTests (7 cases)