### PR TITLE
fix(docs): qualify remaining 100% local marketing claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Detection is fully deterministic. Same diff, same findings, every time. No LLM e
 | Behavioral change detection | ✅ | Partial | Partial | ❌ |
 | Test coverage gap detection | ✅ | ❌ | ❌ | ❌ |
 | Runs pre-commit (local) | ✅ | ❌ | ❌ | ❌ |
-| 100% local / no data egress | ✅ | ❌ | ❌ | ✅ |
+| Core analysis local / no data egress by default | ✅ | ❌ | ❌ | ✅ |
 | .NET-native | ✅ | ❌ | ❌ | ✅ |
 | AI explanations available | ✅ opt-in | ✅ | ✅ | ❌ |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ To understand why GauntletCI is fast and private, it helps to see how it works f
 | **Execution Trigger** | Push to remote branch / PR creation. | Local `git commit` hook or manual CLI invocation. |
 | **Analysis Scope** | Whole-project compilation and full test-suite execution. | Staged Git diff isolation via localized Roslyn AST parsing. |
 | **Feedback Loop** | 5 to 20+ minutes (Context switch required). | **Sub-second (<0.5s)** (Immediate local feedback). |
-| **Data Privacy** | Code is transmitted to third-party cloud runners. | **100% Local.** No external API calls, zero data exfiltration. |
+| **Data Privacy** | Code is transmitted to third-party cloud runners. | **Core analysis runs locally by default.** No external API calls required for rule detection; optional telemetry and integrations are opt-in. |
 | **Target Risk** | Functional regressions (via unit/integration tests). | **Behavioral Change Risk (BCR)** (Silent exception paths, unverified logic). |
 
 ## The Diff-Isolation Engine

--- a/site/app/articles/jellyfin-pr-16062-post-mortem/page.tsx
+++ b/site/app/articles/jellyfin-pr-16062-post-mortem/page.tsx
@@ -339,7 +339,7 @@ gauntletci analyze --staged`}</code>
               </pre>
               <ul className="space-y-2">
                 <li>Works locally in <strong className="text-foreground">under 1 second</strong></li>
-                <li>No code leaves your machine</li>
+                <li>By default, no code leaves your machine</li>
                 <li>Free for personal and internal use</li>
                 <li>Pro/Teams plans for advanced team features</li>
               </ul>

--- a/site/app/compare/gauntletci-vs-ai-code-review/page.tsx
+++ b/site/app/compare/gauntletci-vs-ai-code-review/page.tsx
@@ -329,7 +329,7 @@ export default function AiCodeReviewComparePage() {
               {[
                 "You want to catch behavioral regressions before the commit is created",
                 "Your team needs deterministic, repeatable findings with no LLM variance",
-                "You require 100% local execution -- no code uploads, no API cost",
+                "You require core analysis to run locally by default -- no code uploads, no API cost",
                 "You work in .NET / C# and want diff-aware behavioral detection",
                 "Pre-commit speed matters -- results in under one second",
               ].map((item) => (

--- a/site/app/compare/gauntletci-vs-codeclimate/page.tsx
+++ b/site/app/compare/gauntletci-vs-codeclimate/page.tsx
@@ -213,7 +213,7 @@ export default function CodeClimateComparePage() {
             <ul className="space-y-2 text-sm text-muted-foreground">
               {[
                 "You want to catch behavioral regressions before the commit is created",
-                "Your team needs 100% local execution -- no code uploads, no SaaS account",
+                "Your team needs core analysis to run locally by default -- no code uploads, no SaaS account",
                 "You want findings scoped to what changed, not the whole codebase",
                 "You work in .NET / C# and want diff-aware behavioral detection",
                 "Pre-commit speed is required -- under one second on every save",

--- a/site/app/compare/gauntletci-vs-codeql/page.tsx
+++ b/site/app/compare/gauntletci-vs-codeql/page.tsx
@@ -195,8 +195,8 @@ export default function VsCodeQLPage() {
                 body: "CodeQL's power comes with complexity. GauntletCI's 37 built-in C#/.NET rules cover the most common behavioral regression classes with zero configuration required to start.",
               },
               {
-                title: "100% local, always",
-                body: "CodeQL results are uploaded to GitHub. GauntletCI never sends code anywhere. No GitHub Advanced Security subscription required. Works in air-gapped environments and private networks.",
+                title: "Local by default",
+                body: "CodeQL results are uploaded to GitHub. GauntletCI core analysis never sends code anywhere by default. No GitHub Advanced Security subscription required. Works in air-gapped environments and private networks.",
               },
             ].map((card) => (
               <div key={card.title} className="rounded-lg border border-border bg-card/50 p-5">

--- a/site/app/compare/gauntletci-vs-ndepend/page.tsx
+++ b/site/app/compare/gauntletci-vs-ndepend/page.tsx
@@ -57,7 +57,7 @@ const tableRows = [
 
 const featureRows = [
   { label: "Diff-scoped analysis (changed lines only)", gauntlet: "yes" as const, ndepend: "no" as const },
-  { label: "100% local execution, no code upload", gauntlet: "yes" as const, ndepend: "yes" as const },
+  { label: "Core analysis runs locally by default, no code upload", gauntlet: "yes" as const, ndepend: "yes" as const },
   { label: "Pre-commit (before push) feedback", gauntlet: "yes" as const, ndepend: "no" as const },
   { label: "Air-gap / data residency friendly", gauntlet: "yes" as const, ndepend: "yes" as const },
   { label: "Free tier with full rule set", gauntlet: "yes" as const, ndepend: "no" as const },
@@ -158,7 +158,7 @@ export default function VsNDependPage() {
                 "CQLinq - a LINQ-based query language for writing custom metric-based rules",
                 "Technical debt time estimates with trend charts across builds",
                 "Cyclomatic complexity, coupling, cohesion, and other structural metrics",
-                "Runs 100% locally - no code upload, no SaaS dependency",
+                "Core analysis runs locally by default -- no code upload, no SaaS dependency",
                 "Deep Visual Studio and CI/CD integration for .NET teams",
               ].map((item) => (
                 <li key={item} className="flex items-start gap-2">

--- a/site/app/compare/gauntletci-vs-semgrep/page.tsx
+++ b/site/app/compare/gauntletci-vs-semgrep/page.tsx
@@ -198,7 +198,7 @@ export default function SemgrepComparePage() {
                 "You want zero-config detection of behavioral and structural risk",
                 "You need pre-commit speed - under one second on every commit",
                 "You want findings only on what changed, not the entire codebase",
-                "You need 100% local execution with no account or network dependency",
+                "You need core analysis to run locally by default with no account or network dependency",
                 "You work in a .NET / C# codebase and want diff-aware coverage from day one",
               ].map((item) => (
                 <li key={item} className="flex gap-2">

--- a/site/app/compare/gauntletci-vs-snyk/page.tsx
+++ b/site/app/compare/gauntletci-vs-snyk/page.tsx
@@ -34,7 +34,7 @@ const jsonLd = {
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "GauntletCI vs Snyk: Behavioral Risk Detection vs Vulnerability Scanning",
-  "description": "Snyk scans dependencies and code for known vulnerabilities. GauntletCI detects behavioral regressions in the lines you changed -- pre-commit, 100% local, zero false positives on pre-existing code.",
+  "description": "Snyk scans dependencies and code for known vulnerabilities. GauntletCI detects behavioral regressions in the lines you changed -- pre-commit, core analysis runs locally by default, zero false positives on pre-existing code.",
   "url": "https://gauntletci.com/compare/gauntletci-vs-snyk",
   "publisher": { "@type": "Organization", "name": "GauntletCI", "url": "https://gauntletci.com" },
 };
@@ -108,8 +108,8 @@ export default function SnykComparePage() {
             <p className="text-sm text-muted-foreground leading-relaxed">
               GauntletCI runs entirely on your machine. It reads the git diff, applies
               deterministic behavioral rules to the changed lines, and reports risk introduced
-              by this specific change -- before the commit is created. No code leaves the
-              machine. No account required. No network call.
+              by this specific change -- before the commit is created. By default, no code leaves the
+              machine. No account required. No network call for core analysis.
             </p>
             <p className="text-sm text-muted-foreground leading-relaxed">
               GauntletCI answers: "Did this change remove a guard clause?", "Did it alter a
@@ -233,7 +233,7 @@ export default function SnykComparePage() {
             <ul className="space-y-2 text-sm text-muted-foreground">
               {[
                 "You want pre-commit detection of behavioral regressions before code review",
-                "Your team needs 100% local execution with no data leaving the machine",
+                "Your team needs core analysis to run locally by default with no data leaving the machine",
                 "You work in a .NET / C# codebase and want diff-aware behavioral rules",
                 "You operate in an air-gapped or strict data residency environment",
                 "You want findings scoped only to what changed -- zero noise from pre-existing issues",

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -58,7 +58,7 @@ const faqSchema = {
       "name": "How does GauntletCI compare to Snyk?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Snyk is primarily a dependency and container vulnerability scanner that requires cloud connectivity and a Snyk account. GauntletCI detects behavioral, structural, and security risks in first-party code changes, not dependency vulnerabilities, and runs 100% locally with no data transmitted. GauntletCI is suitable for air-gapped environments and organizations with strict data residency requirements; Snyk is not."
+        "text": "Snyk is primarily a dependency and container vulnerability scanner that requires cloud connectivity and a Snyk account. GauntletCI detects behavioral, structural, and security risks in first-party code changes, not dependency vulnerabilities, and runs core analysis locally by default with no data transmitted unless optional integrations are enabled. GauntletCI is suitable for air-gapped environments and organizations with strict data residency requirements; Snyk is not."
       }
     },
     {
@@ -74,7 +74,7 @@ const faqSchema = {
       "name": "How does GauntletCI compare to Code Climate?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Code Climate is a SaaS platform that analyzes full repositories for maintainability and test coverage trends over time. It requires uploading code to a cloud service. GauntletCI is fully local, diff-scoped, and focused on change risk rather than codebase health metrics. GauntletCI does not require a cloud account, never transmits code, and produces results in under one second, making it a complement to, not a replacement for, Code Climate's longitudinal reporting."
+        "text": "Code Climate is a SaaS platform that analyzes full repositories for maintainability and test coverage trends over time. It requires uploading code to a cloud service. GauntletCI is diff-scoped and focused on change risk rather than codebase health metrics, with core analysis running locally by default. GauntletCI does not require a cloud account, does not transmit code by default, and produces results in under one second, making it a complement to, not a replacement for, Code Climate's longitudinal reporting."
       }
     },
     {

--- a/site/components/features-benefits.tsx
+++ b/site/components/features-benefits.tsx
@@ -36,9 +36,9 @@ const items = [
   },
   {
     icon: Lock,
-    feature: "100% Local Execution & Privacy",
-    what: "All analysis runs entirely on the machine where the command runs. No diff, no finding, no file path is ever transmitted. Evidence strings for PII and secrets are auto-redacted in output.",
-    benefit: "Works in air-gapped environments, on proprietary codebases, and in organizations with strict data residency requirements, no policy exceptions needed. Local execution is the default and requires no configuration.",
+    feature: "Core Analysis Runs Locally by Default",
+    what: "Deterministic rule evaluation runs entirely on the machine where the command runs. By default, no diff, finding, or file path is transmitted. Optional telemetry and network integrations are opt-in. Evidence strings for PII and secrets are auto-redacted in output.",
+    benefit: "Works in air-gapped environments, on proprietary codebases, and in organizations with strict data residency requirements. Local execution is the default and requires no configuration.",
   },
   {
     icon: BrainCircuit,

--- a/site/components/pricing.tsx
+++ b/site/components/pricing.tsx
@@ -19,7 +19,7 @@ const features: FeatureRow[] = [
   { label: "Deterministic Change-Risk Detection", community: "check", pro: "check", teams: "check", enterprise: "check" },
   { label: "Sub-Second Pre-Commit Hook",           community: "check", pro: "check", teams: "check", enterprise: "check" },
   { label: "Per-Repo Configuration (.gauntletci.json)", community: "check", pro: "check", teams: "check", enterprise: "check" },
-  { label: "100% Local Execution & Privacy",       community: "check", pro: "check", teams: "check", enterprise: "check" },
+  { label: "Core Analysis Runs Locally by Default", community: "check", pro: "check", teams: "check", enterprise: "check" },
   { label: "Evidence String Redaction (PII / Secrets)", community: "check", pro: "check", teams: "check", enterprise: "check" },
 
   // Pro


### PR DESCRIPTION
## Summary
- Replace unqualified ''100% local'' and ''never transmits code'' language with ''core analysis runs locally by default''
- Update pricing table, features-benefits, compare pages, FAQ JSON-LD, README, and architecture docs
- Aligns with /docs/privacy-modes and prior Phase 7 messaging audit

## Test plan
- [x] Copy review only — no runtime changes