### PR TITLE
fix(licensing): tighten network validation fail-open behavior

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -303,6 +303,19 @@ GauntletCI supports two LLM enrichment paths:
 - API key read from the environment variable named by `ciApiKeyEnv`: never stored in config.
 - Requires a GauntletCI license key in the environment variable named by `licenseKeyEnv`.
 
+### License subscription check
+
+Paid-tier features trigger a remote subscription check against the GauntletCI license worker. Behavior:
+
+| Condition | Result |
+| --- | --- |
+| Fresh cache (< 24 h, same token) | Uses cached active/inactive status |
+| Network error + stale cache | Reuses last known status (revoked licenses stay blocked) |
+| Network error + no cache | Fails open, prints a warning; set `GAUNTLETCI_OFFLINE=1` for intentional air-gap |
+| `GAUNTLETCI_OFFLINE=1` | Skips network check entirely |
+
+Run `gauntletci license status` to inspect JWT validity and subscription state.
+
 In both cases, enrichment applies only to `High`-confidence findings and appends a `LlmExplanation` string to each.
 
 ---

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -234,15 +234,22 @@ public static class AnalyzeCommand
                     var rawToken = LicenseService.ReadRawToken(envVar);
                     if (rawToken is not null)
                     {
-                        var (netValid, netReason) = await Licensing.NetworkLicenseValidator
+                        var netResult = await Licensing.NetworkLicenseValidator
                             .ValidateAsync(rawToken, ct);
-                        if (!netValid)
+                        if (!netResult.Valid)
                         {
                             Console.Error.WriteLine(
-                                $"[GauntletCI] License subscription is no longer active ({netReason ?? "cancelled"}). " +
+                                $"[GauntletCI] License subscription is no longer active ({netResult.Reason ?? "cancelled"}). " +
                                 "Renew at https://gauntletci.com/pricing or run: gauntletci license renew");
                             ctx.ExitCode = 1;
                             return;
+                        }
+
+                        if (netResult.SkippedNetworkCheck)
+                        {
+                            Console.Error.WriteLine(
+                                "[GauntletCI] Warning: Could not verify license subscription online. " +
+                                "Using offline mode. Set GAUNTLETCI_OFFLINE=1 to suppress this warning.");
                         }
                     }
                 }

--- a/src/GauntletCI.Cli/Commands/LicenseCommand.cs
+++ b/src/GauntletCI.Cli/Commands/LicenseCommand.cs
@@ -66,13 +66,17 @@ public static class LicenseCommand
             if (license.IsValid && license.Tier > LicenseTier.Community && rawToken is not null)
             {
                 AnsiConsole.WriteLine();
-                var (netValid, reason) = await NetworkLicenseValidator.ValidateAsync(
+                var netResult = await NetworkLicenseValidator.ValidateAsync(
                     rawToken, ctx.GetCancellationToken());
 
-                if (netValid)
+                if (netResult.Valid && !netResult.SkippedNetworkCheck)
                     AnsiConsole.MarkupLine("  Subscription: [green]Active[/]");
+                else if (netResult.Valid && netResult.SkippedNetworkCheck)
+                    AnsiConsole.MarkupLine(
+                        "  Subscription: [yellow]Not verified[/] (offline — set GAUNTLETCI_OFFLINE=1 or check network)");
                 else
-                    AnsiConsole.MarkupLine($"  Subscription: [red]Inactive[/] ({Markup.Escape(reason ?? "cancelled")})");
+                    AnsiConsole.MarkupLine(
+                        $"  Subscription: [red]Inactive[/] ({Markup.Escape(netResult.Reason ?? "cancelled")})");
             }
 
             AnsiConsole.WriteLine();

--- a/src/GauntletCI.Cli/Licensing/NetworkLicenseValidator.cs
+++ b/src/GauntletCI.Cli/Licensing/NetworkLicenseValidator.cs
@@ -9,8 +9,9 @@ namespace GauntletCI.Cli.Licensing;
 /// <summary>
 /// Validates an active GauntletCI license against the remote status endpoint.
 /// Caches the result for 24 hours to avoid latency on every run.
-/// Fails open (returns valid) if the network is unreachable, so air-gapped
-/// or locked-down CI environments are unaffected.
+/// On network errors, reuses a stale cache entry when one exists for the same token.
+/// When no cache exists and the network is unreachable, fails open but flags
+/// <see cref="NetworkLicenseValidationResult.SkippedNetworkCheck"/> so callers can warn.
 /// Set GAUNTLETCI_OFFLINE=1 to skip the network check entirely (Enterprise/air-gap).
 /// </summary>
 public static class NetworkLicenseValidator
@@ -18,35 +19,39 @@ public static class NetworkLicenseValidator
     private const string StatusEndpoint = "https://gauntletci-license-worker.patient-water-71dd.workers.dev/license/status";
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
 
-    private static readonly string CachePath = Path.Combine(
+    private static readonly string DefaultCachePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         ".gauntletci", "license-status-cache.json");
 
+    /// <summary>Test hook: override cache file path.</summary>
+    internal static string? TestCachePathOverride { get; set; }
+
+    /// <summary>Test hook: override status endpoint (use unreachable URL to simulate network failure).</summary>
+    internal static string? TestStatusEndpointOverride { get; set; }
+
+    private static string CachePath => TestCachePathOverride ?? DefaultCachePath;
+
     /// <summary>
     /// Validates the token against the remote endpoint.
-    /// Returns (Valid: true, Reason: null) when the subscription is active.
-    /// Returns (Valid: false, Reason: string) when cancelled or revoked.
-    /// Returns (Valid: true, Reason: null) when the network is unreachable (fail-open).
-    /// Returns (Valid: true, Reason: null) when GAUNTLETCI_OFFLINE=1 is set.
     /// </summary>
-    public static async Task<(bool Valid, string? Reason)> ValidateAsync(
+    public static async Task<NetworkLicenseValidationResult> ValidateAsync(
         string token,
         CancellationToken ct = default)
     {
         if (IsOfflineMode())
-            return (true, null);
+            return new NetworkLicenseValidationResult(true, null, SkippedNetworkCheck: true);
 
-        // Check cache first -- skip network if cache is fresh and token matches.
-        var cached = TryReadCache(token);
+        var cached = TryReadCache(token, ignoreTtl: false);
         if (cached.HasValue)
-            return cached.Value;
+            return new NetworkLicenseValidationResult(cached.Value.Valid, cached.Value.Reason);
 
         try
         {
+            var endpoint = TestStatusEndpointOverride ?? StatusEndpoint;
             var http = HttpClientFactory.GetGenericClient();
             // Do not dispose: HttpClientFactory owns this shared, process-wide client.
 
-            using var request = new HttpRequestMessage(HttpMethod.Get, StatusEndpoint);
+            using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
 
             using var response = await http.SendAsync(request, ct);
@@ -57,13 +62,20 @@ public static class NetworkLicenseValidator
             var reason = root.TryGetProperty("reason", out var r) ? r.GetString() : null;
 
             WriteCache(token, valid, reason);
-            return (valid, reason);
+            return new NetworkLicenseValidationResult(valid, reason);
         }
-        catch (OperationCanceledException) { /* caller cancelled */ throw; }
-        catch
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
         {
-            // Network unavailable -- fail open and do not update the cache.
-            return (true, null);
+            System.Diagnostics.Debug.WriteLine(
+                $"[NetworkLicenseValidator] Network check failed: {ex.Message}");
+
+            var stale = TryReadCache(token, ignoreTtl: true);
+            if (stale.HasValue)
+                return new NetworkLicenseValidationResult(stale.Value.Valid, stale.Value.Reason);
+
+            // No prior validation record -- allow air-gapped first run, but flag it.
+            return new NetworkLicenseValidationResult(true, null, SkippedNetworkCheck: true);
         }
     }
 
@@ -72,7 +84,7 @@ public static class NetworkLicenseValidator
     private static bool IsOfflineMode() =>
         !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GAUNTLETCI_OFFLINE"));
 
-    private static (bool Valid, string? Reason)? TryReadCache(string token)
+    internal static (bool Valid, string? Reason)? TryReadCache(string token, bool ignoreTtl)
     {
         try
         {
@@ -83,15 +95,17 @@ public static class NetworkLicenseValidator
             using var doc = JsonDocument.Parse(stream);
             var root = doc.RootElement;
 
-            // Invalidate if the token has changed since the cache was written.
             var cachedHash = root.TryGetProperty("tokenHash", out var h) ? h.GetString() : null;
             if (cachedHash != TokenHash(token))
                 return null;
 
-            var cachedAt = DateTimeOffset.FromUnixTimeSeconds(
-                root.GetProperty("cachedAt").GetInt64());
-            if (DateTimeOffset.UtcNow - cachedAt > CacheTtl)
-                return null;
+            if (!ignoreTtl)
+            {
+                var cachedAt = DateTimeOffset.FromUnixTimeSeconds(
+                    root.GetProperty("cachedAt").GetInt64());
+                if (DateTimeOffset.UtcNow - cachedAt > CacheTtl)
+                    return null;
+            }
 
             var valid = root.GetProperty("valid").GetBoolean();
             var reason = root.TryGetProperty("reason", out var rv) ? rv.GetString() : null;
@@ -103,7 +117,7 @@ public static class NetworkLicenseValidator
         }
     }
 
-    private static void WriteCache(string token, bool valid, string? reason)
+    internal static void WriteCache(string token, bool valid, string? reason)
     {
         try
         {
@@ -119,8 +133,8 @@ public static class NetworkLicenseValidator
         }
         catch (Exception ex)
         {
-            // Cache write failure is non-critical but should be logged
-            System.Diagnostics.Debug.WriteLine($"[NetworkLicenseValidator] Warning: Failed to write license cache: {ex.Message}");
+            System.Diagnostics.Debug.WriteLine(
+                $"[NetworkLicenseValidator] Warning: Failed to write license cache: {ex.Message}");
         }
     }
 
@@ -130,3 +144,8 @@ public static class NetworkLicenseValidator
         return Convert.ToHexString(bytes)[..16];
     }
 }
+
+public readonly record struct NetworkLicenseValidationResult(
+    bool Valid,
+    string? Reason,
+    bool SkippedNetworkCheck = false);

--- a/src/GauntletCI.Tests/NetworkLicenseValidatorTests.cs
+++ b/src/GauntletCI.Tests/NetworkLicenseValidatorTests.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Cli.Licensing;
+
+namespace GauntletCI.Tests;
+
+public class NetworkLicenseValidatorTests : IDisposable
+{
+    private readonly string _cacheDir;
+    private readonly string _cachePath;
+
+    public NetworkLicenseValidatorTests()
+    {
+        _cacheDir = Path.Combine(Path.GetTempPath(), "gauntletci-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_cacheDir);
+        _cachePath = Path.Combine(_cacheDir, "license-status-cache.json");
+        NetworkLicenseValidator.TestCachePathOverride = _cachePath;
+    }
+
+    public void Dispose()
+    {
+        NetworkLicenseValidator.TestCachePathOverride = null;
+        NetworkLicenseValidator.TestStatusEndpointOverride = null;
+        if (Directory.Exists(_cacheDir))
+            Directory.Delete(_cacheDir, recursive: true);
+    }
+
+    private void SimulateNetworkFailure() =>
+        NetworkLicenseValidator.TestStatusEndpointOverride = "http://127.0.0.1:1/unreachable";
+
+    [Fact]
+    public async Task ValidateAsync_UsesFreshCacheWithoutNetworkCall()
+    {
+        const string token = "test-token-fresh-cache";
+        NetworkLicenseValidator.WriteCache(token, valid: true, reason: null);
+
+        SimulateNetworkFailure();
+        var result = await NetworkLicenseValidator.ValidateAsync(token);
+
+        Assert.True(result.Valid);
+        Assert.False(result.SkippedNetworkCheck);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_UsesStaleCacheWhenNetworkFails()
+    {
+        const string token = "test-token-stale-cache";
+        WriteStaleCache(token, valid: false, reason: "cancelled", age: TimeSpan.FromDays(2));
+
+        SimulateNetworkFailure();
+        var result = await NetworkLicenseValidator.ValidateAsync(token);
+
+        Assert.False(result.Valid);
+        Assert.Equal("cancelled", result.Reason);
+        Assert.False(result.SkippedNetworkCheck);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_FailsOpenWhenNoCacheAndNetworkFails()
+    {
+        const string token = "test-token-no-cache";
+        SimulateNetworkFailure();
+
+        var result = await NetworkLicenseValidator.ValidateAsync(token);
+
+        Assert.True(result.Valid);
+        Assert.True(result.SkippedNetworkCheck);
+    }
+
+    [Fact]
+    public void TryReadCache_IgnoresTtlWhenRequested()
+    {
+        const string token = "test-token-ttl";
+        WriteStaleCache(token, valid: true, reason: null, age: TimeSpan.FromDays(2));
+
+        Assert.Null(NetworkLicenseValidator.TryReadCache(token, ignoreTtl: false));
+        Assert.NotNull(NetworkLicenseValidator.TryReadCache(token, ignoreTtl: true));
+    }
+
+    private void WriteStaleCache(string token, bool valid, string? reason, TimeSpan age)
+    {
+        NetworkLicenseValidator.WriteCache(token, valid, reason);
+        var cachedAt = DateTimeOffset.UtcNow.Subtract(age).ToUnixTimeSeconds();
+        using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(_cachePath));
+        var tokenHash = doc.RootElement.GetProperty("tokenHash").GetString();
+        var payload = new
+        {
+            tokenHash,
+            valid,
+            reason,
+            cachedAt,
+        };
+        File.WriteAllText(_cachePath, System.Text.Json.JsonSerializer.Serialize(payload));
+    }
+}


### PR DESCRIPTION
## Summary
- Reuse stale cache on network errors so revoked licenses stay blocked after cache expiry
- Add SkippedNetworkCheck flag when verification is skipped (offline mode or no cache + network down)
- Warn in analyze and license status commands when subscription could not be verified
- Document behavior in architecture.md

## Test plan
- [x] NetworkLicenseValidatorTests (4 cases)