### PR TITLE
fix(security): disable redirects on webhook HTTP client

### DIFF
--- a/src/GauntletCI.Cli/Output/SlackTeamsNotifier.cs
+++ b/src/GauntletCI.Cli/Output/SlackTeamsNotifier.cs
@@ -14,8 +14,7 @@ namespace GauntletCI.Cli.Output;
 /// Soft-fails on missing webhooks or API errors.
 /// 
 /// Thread-Safe: Static HttpClient is thread-safe and managed by HttpClientFactory.
-/// The factory uses Lazy&lt;T&gt; with ExecutionAndPublication semantics, ensuring
-/// single-threaded initialization and safe concurrent access.
+/// Uses GetWebhookClient() which disables automatic redirects (SSRF hardening).
 /// </summary>
 public static class SlackTeamsNotifier
 {
@@ -24,7 +23,7 @@ public static class SlackTeamsNotifier
     /// Thread-safe: managed by HttpClientFactory with lazy initialization.
     /// Do NOT dispose; client is managed by the factory.
     /// </summary>
-    private static readonly HttpClient _http = HttpClientFactory.GetGenericClient();
+    private static readonly HttpClient _http = HttpClientFactory.GetWebhookClient();
 
     /// <summary>
     /// Sends notifications to Slack and/or Teams when Block-severity findings exist.

--- a/src/GauntletCI.Core/HttpClientFactory.cs
+++ b/src/GauntletCI.Core/HttpClientFactory.cs
@@ -22,7 +22,7 @@ public static class HttpClientFactory
     // Generic client: no auth, 30 second default timeout
     private static readonly Lazy<HttpClient> GenericClient = new(() => CreateGenericClient());
 
-    // Anthropic client: API key auth, 120 second timeout for inference calls
+    // Anthropic / webhook client: no redirect, 120 second timeout (webhooks share this pool)
     private static readonly Lazy<HttpClient> AnthropicClientInstance = new(() => CreateAnthropicClient());
 
     // Codecov client: Bearer token auth, 15 second timeout
@@ -55,6 +55,13 @@ public static class HttpClientFactory
     /// Do NOT dispose; client is managed by the factory.
     /// </summary>
     public static HttpClient GetAnthropicClient() => AnthropicClientInstance.Value;
+
+    /// <summary>
+    /// Gets an HTTP client for Slack/Teams incoming webhook POSTs.
+    /// Shares the no-redirect client pool (redirects disabled for SSRF hardening).
+    /// Do NOT dispose; client is managed by the factory.
+    /// </summary>
+    public static HttpClient GetWebhookClient() => AnthropicClientInstance.Value;
 
     /// <summary>
     /// Gets a Codecov API client. Token must be attached per-request via HttpRequestMessage.Headers.

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0039_ExternalServiceSafety.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0039_ExternalServiceSafety.cs
@@ -40,6 +40,9 @@ public class GCI0039_ExternalServiceSafety : RuleBase
         // Skip gRPC files entirely - gRPC Channel initialization IS the timeout mechanism
         if (WellKnownPatterns.IsGrpcRelatedFile(file.NewPath)) return;
 
+        // Central factory is the designated place for HttpClient construction
+        if (WellKnownPatterns.IsCentralHttpClientFactoryFile(file.NewPath)) return;
+
         foreach (var line in file.AddedLines)
         {
             var content = line.Content;
@@ -66,6 +69,8 @@ public class GCI0039_ExternalServiceSafety : RuleBase
 
     private void CheckMissingTimeout(DiffFile file, List<Finding> findings)
     {
+        if (WellKnownPatterns.IsCentralHttpClientFactoryFile(file.NewPath)) return;
+
         var addedLines = file.AddedLines.ToList();
 
         // Only flag files that directly instantiate a new HttpClient; using

--- a/src/GauntletCI.Core/Rules/Patterns/HttpExternalServicePatterns.cs
+++ b/src/GauntletCI.Core/Rules/Patterns/HttpExternalServicePatterns.cs
@@ -30,6 +30,12 @@ internal static class HttpExternalServicePatterns
     }
 
     /// <summary>
+    /// Returns <c>true</c> when the file is the centralized static HttpClient factory.
+    /// </summary>
+    public static bool IsCentralHttpClientFactoryFile(string path) =>
+        path.EndsWith("HttpClientFactory.cs", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Returns <c>true</c> when the added lines indicate HttpClient configuration via IHttpClientFactory.
     /// Factory-managed clients configure timeout at the handler/channel level, not per-client.
     /// </summary>
@@ -65,7 +71,8 @@ internal static class HttpExternalServicePatterns
         var factoryPatterns = new[]
         {
             "IHttpClientFactory", "AddHttpClient", "HttpClientFactoryOptions",
-            "AddPolicyHandler", "AddTransientHttpErrorPolicy", "Polly"
+            "AddPolicyHandler", "AddTransientHttpErrorPolicy", "Polly",
+            "HttpClientFactory.Get",
         };
 
         return addedLines.Any(l =>

--- a/src/GauntletCI.Core/Rules/WellKnownPatterns.cs
+++ b/src/GauntletCI.Core/Rules/WellKnownPatterns.cs
@@ -134,6 +134,12 @@ internal static class WellKnownPatterns
         HttpExternalServicePatterns.IsGrpcRelatedFile(path);
 
     /// <summary>
+    /// Returns <c>true</c> when the file is the centralized static HttpClient factory.
+    /// </summary>
+    public static bool IsCentralHttpClientFactoryFile(string path) =>
+        HttpExternalServicePatterns.IsCentralHttpClientFactoryFile(path);
+
+    /// <summary>
     /// Returns <c>true</c> when the added lines indicate HttpClient configuration via IHttpClientFactory.
     /// Factory-managed clients configure timeout at the handler/channel level, not per-client.
     /// </summary>

--- a/src/GauntletCI.Tests/HttpClientFactoryTests.cs
+++ b/src/GauntletCI.Tests/HttpClientFactoryTests.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net.Http;
+using System.Reflection;
+using GauntletCI.Core;
+
+namespace GauntletCI.Tests;
+
+public class HttpClientFactoryTests
+{
+    [Fact]
+    public void GetWebhookClient_DisablesAutoRedirect()
+    {
+        var client = HttpClientFactory.GetWebhookClient();
+        var handler = FindSocketsHandler(GetRootHandler(client));
+
+        Assert.NotNull(handler);
+        Assert.False(handler!.AllowAutoRedirect);
+    }
+
+    [Fact]
+    public void GetWebhookClient_ReturnsSameInstanceAsAnthropicClient()
+    {
+        Assert.Same(HttpClientFactory.GetAnthropicClient(), HttpClientFactory.GetWebhookClient());
+    }
+
+    [Fact]
+    public void GetWebhookClient_IsDistinctFromGenericClient()
+    {
+        Assert.NotSame(HttpClientFactory.GetWebhookClient(), HttpClientFactory.GetGenericClient());
+    }
+
+    private static HttpMessageHandler GetRootHandler(HttpClient client)
+    {
+        var field = typeof(HttpMessageInvoker).GetField(
+            "_handler",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (HttpMessageHandler)field!.GetValue(client)!;
+    }
+
+    private static SocketsHttpHandler? FindSocketsHandler(HttpMessageHandler handler)
+    {
+        if (handler is SocketsHttpHandler sockets)
+            return sockets;
+
+        if (handler is DelegatingHandler delegating && delegating.InnerHandler is not null)
+            return FindSocketsHandler(delegating.InnerHandler);
+
+        return null;
+    }
+}

--- a/src/GauntletCI.Tests/Rules/GCI0039Tests.cs
+++ b/src/GauntletCI.Tests/Rules/GCI0039Tests.cs
@@ -229,4 +229,25 @@ public class GCI0039Tests
         // Should not flag timeout because GrpcChannelOptions is used
         Assert.DoesNotContain(findings, f => f.Summary.Contains("HttpClient used without explicit timeout"));
     }
+
+    [Fact]
+    public async Task NewHttpClient_InHttpClientFactoryFile_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/GauntletCI.Core/HttpClientFactory.cs b/src/GauntletCI.Core/HttpClientFactory.cs
+            index abc..def 100644
+            --- a/src/GauntletCI.Core/HttpClientFactory.cs
+            +++ b/src/GauntletCI.Core/HttpClientFactory.cs
+            @@ -1,3 +1,5 @@
+             public static class HttpClientFactory {
+            +    var client = new HttpClient(new SocketsHttpHandler { AllowAutoRedirect = false }) { Timeout = TimeSpan.FromSeconds(30) };
+             }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("Direct HttpClient instantiation"));
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("HttpClient used without explicit timeout"));
+    }
 }


### PR DESCRIPTION
## Summary
- Route Slack/Teams notifications through HttpClientFactory.GetWebhookClient (no-redirect pool, shared with Anthropic client)
- Complements #230 webhook URL allowlist — blocked redirects prevent following allowlisted URLs to internal targets
- Exempt centralized HttpClientFactory from GCI0039 instantiation checks
- Recognize HttpClientFactory.Get* as factory-managed in GCI0039

## Test plan
- [x] HttpClientFactoryTests (3 cases)
- [x] GCI0039Tests factory file exemption