### PR TITLE
fix(security): dedicated webhook HttpClient + repo-first pre-commit

### DIFF
--- a/src/GauntletCI.Cli/Hooks/gauntletci-hook.ps1
+++ b/src/GauntletCI.Cli/Hooks/gauntletci-hook.ps1
@@ -55,6 +55,14 @@ function Get-RepoCliProjectPath {
 }
 
 function Resolve-GauntletCiInvocation {
+    $repoProject = Get-RepoCliProjectPath
+    if ($null -ne $repoProject) {
+        return @{
+            Command = "dotnet"
+            PrefixArgs = @("run", "--project", $repoProject, "--")
+        }
+    }
+
     if (Get-Command gauntletci -ErrorAction SilentlyContinue) {
         return @{
             Command = "gauntletci"
@@ -77,14 +85,6 @@ function Resolve-GauntletCiInvocation {
                 Command = $toolShim
                 PrefixArgs = @()
             }
-        }
-    }
-
-    $repoProject = Get-RepoCliProjectPath
-    if ($null -ne $repoProject) {
-        return @{
-            Command = "dotnet"
-            PrefixArgs = @("run", "--project", $repoProject, "--")
         }
     }
 

--- a/src/GauntletCI.Cli/Hooks/gauntletci-hook.sh
+++ b/src/GauntletCI.Cli/Hooks/gauntletci-hook.sh
@@ -5,6 +5,17 @@
 set -e
 
 resolve_gauntletci() {
+    local current
+    current="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    while [ -n "$current" ] && [ "$current" != "/" ]; do
+        if [ -f "$current/src/GauntletCI.Cli/GauntletCI.Cli.csproj" ]; then
+            GAUNTLETCI_MODE="repo"
+            GAUNTLETCI_REPO_ROOT="$current"
+            return 0
+        fi
+        current="$(dirname "$current")"
+    done
+
     if command -v gauntletci &> /dev/null; then
         GAUNTLETCI_MODE="shim"
         GAUNTLETCI_CMD="gauntletci"
@@ -31,17 +42,6 @@ resolve_gauntletci() {
             GAUNTLETCI_CMD="$dir/gauntletci.exe"
             return 0
         fi
-    done
-
-    local current
-    current="$(pwd)"
-    while [ -n "$current" ] && [ "$current" != "/" ]; do
-        if [ -f "$current/src/GauntletCI.Cli/GauntletCI.Cli.csproj" ]; then
-            GAUNTLETCI_MODE="repo"
-            GAUNTLETCI_REPO_ROOT="$current"
-            return 0
-        fi
-        current="$(dirname "$current")"
     done
 
     return 1

--- a/src/GauntletCI.Core/HttpClientFactory.cs
+++ b/src/GauntletCI.Core/HttpClientFactory.cs
@@ -22,8 +22,11 @@ public static class HttpClientFactory
     // Generic client: no auth, 30 second default timeout
     private static readonly Lazy<HttpClient> GenericClient = new(() => CreateGenericClient());
 
-    // Anthropic / webhook client: no redirect, 120 second timeout (webhooks share this pool)
+    // Anthropic client: API key auth, 120 second timeout, no redirect
     private static readonly Lazy<HttpClient> AnthropicClientInstance = new(() => CreateAnthropicClient());
+
+    // Webhook client: Slack/Teams incoming webhooks, 30 second timeout, no redirect
+    private static readonly Lazy<HttpClient> WebhookClientInstance = new(() => CreateWebhookClient());
 
     // Codecov client: Bearer token auth, 15 second timeout
     private static readonly Lazy<HttpClient> CodecovClientInstance = new(() => CreateCodecovClient());
@@ -58,10 +61,10 @@ public static class HttpClientFactory
 
     /// <summary>
     /// Gets an HTTP client for Slack/Teams incoming webhook POSTs.
-    /// Shares the no-redirect client pool (redirects disabled for SSRF hardening).
+    /// Disables automatic redirects to prevent allowlisted URLs from being followed to internal targets.
     /// Do NOT dispose; client is managed by the factory.
     /// </summary>
-    public static HttpClient GetWebhookClient() => AnthropicClientInstance.Value;
+    public static HttpClient GetWebhookClient() => WebhookClientInstance.Value;
 
     /// <summary>
     /// Gets a Codecov API client. Token must be attached per-request via HttpRequestMessage.Headers.
@@ -157,6 +160,27 @@ public static class HttpClientFactory
 
         client.DefaultRequestHeaders.Accept.Add(
             new MediaTypeWithQualityHeaderValue("application/json"));
+
+        return client;
+    }
+
+    /// <summary>
+    /// Creates a webhook HTTP client with redirects disabled (SSRF hardening for incoming webhooks).
+    /// </summary>
+    private static HttpClient CreateWebhookClient()
+    {
+        var handler = new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            AllowAutoRedirect = false,
+        };
+
+        var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+
+        client.DefaultRequestHeaders.Add("User-Agent", "GauntletCI/2.0");
 
         return client;
     }

--- a/src/GauntletCI.Tests/HttpClientFactoryTests.cs
+++ b/src/GauntletCI.Tests/HttpClientFactoryTests.cs
@@ -18,15 +18,22 @@ public class HttpClientFactoryTests
     }
 
     [Fact]
-    public void GetWebhookClient_ReturnsSameInstanceAsAnthropicClient()
+    public void GetWebhookClient_ReturnsSameInstanceOnRepeatCalls()
     {
-        Assert.Same(HttpClientFactory.GetAnthropicClient(), HttpClientFactory.GetWebhookClient());
+        Assert.Same(HttpClientFactory.GetWebhookClient(), HttpClientFactory.GetWebhookClient());
     }
 
     [Fact]
-    public void GetWebhookClient_IsDistinctFromGenericClient()
+    public void GetWebhookClient_IsDistinctFromAnthropicAndGenericClients()
     {
+        Assert.NotSame(HttpClientFactory.GetWebhookClient(), HttpClientFactory.GetAnthropicClient());
         Assert.NotSame(HttpClientFactory.GetWebhookClient(), HttpClientFactory.GetGenericClient());
+    }
+
+    [Fact]
+    public void GetWebhookClient_UsesThirtySecondTimeout()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(30), HttpClientFactory.GetWebhookClient().Timeout);
     }
 
     private static HttpMessageHandler GetRootHandler(HttpClient client)


### PR DESCRIPTION
## Summary
- Add dedicated GetWebhookClient pool (30s timeout, AllowAutoRedirect=false) separate from Anthropic
- Pre-commit hooks now prefer `dotnet run` from this repo when GauntletCI.Cli.csproj is present
- Enables dogfooding current GCI0039 HttpClientFactory exemption during development

## Test plan
- [x] HttpClientFactoryTests (4 cases)
- [x] Pre-commit passes with repo-built CLI