### PR TITLE
fix(licensing): allow runtime RSA public key override

### DIFF
--- a/src/GauntletCI.Core/Licensing/LicenseService.cs
+++ b/src/GauntletCI.Core/Licensing/LicenseService.cs
@@ -11,7 +11,8 @@ namespace GauntletCI.Core.Licensing;
 /// </summary>
 public static class LicenseService
 {
-    // DEV/PLACEHOLDER key -- replace with your production key pair before issuing live licenses.
+    // DEV/PLACEHOLDER key -- replace with your production key pair before issuing live licenses,
+    // or set GAUNTLETCI_LICENSE_PUBLIC_KEY / GAUNTLETCI_LICENSE_PUBLIC_KEY_FILE at runtime.
     // The matching private key is stored securely in your license issuance service and never committed.
     private static readonly string EmbeddedPublicKey = string.Join("\n",
         "-----BEGIN RSA PUBLIC KEY-----",
@@ -82,7 +83,7 @@ public static class LicenseService
             var signature = Base64UrlDecode(parts[2]);
 
             using var rsa = RSA.Create();
-            rsa.ImportFromPem(EmbeddedPublicKey);
+            rsa.ImportFromPem(ResolvePublicKeyPem());
 
             if (!rsa.VerifyData(dataToVerify, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1))
                 return LicenseInfo.Invalid(
@@ -120,6 +121,23 @@ public static class LicenseService
         {
             return LicenseInfo.Invalid($"License could not be parsed: {ex.Message}");
         }
+    }
+
+    private static string ResolvePublicKeyPem()
+    {
+        var inline = Environment.GetEnvironmentVariable("GAUNTLETCI_LICENSE_PUBLIC_KEY");
+        if (!string.IsNullOrWhiteSpace(inline))
+            return inline.Replace("\\n", "\n", StringComparison.Ordinal).Trim();
+
+        var keyFile = Environment.GetEnvironmentVariable("GAUNTLETCI_LICENSE_PUBLIC_KEY_FILE");
+        if (!string.IsNullOrWhiteSpace(keyFile) && File.Exists(keyFile))
+        {
+            var pem = File.ReadAllText(keyFile).Trim();
+            if (!string.IsNullOrWhiteSpace(pem))
+                return pem;
+        }
+
+        return EmbeddedPublicKey;
     }
 
     private static byte[] Base64UrlDecode(string input)

--- a/src/GauntletCI.Tests/LicenseServiceTests.cs
+++ b/src/GauntletCI.Tests/LicenseServiceTests.cs
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using GauntletCI.Core.Licensing;
 
 namespace GauntletCI.Tests;
@@ -37,4 +40,78 @@ public class LicenseServiceTests
         Assert.False(license.IsLicensed);
         Assert.Equal(LicenseTier.Community, license.Tier);
     }
+
+    [Fact]
+    public void Load_ValidToken_WithPublicKeyEnvOverride_AcceptsProTier()
+    {
+        const string licenseEnv = "GAUNTLETCI_LICENSE_TEST_OVERRIDE";
+        const string publicKeyEnv = "GAUNTLETCI_LICENSE_PUBLIC_KEY";
+        using var rsa = RSA.Create(2048);
+        var publicPem = rsa.ExportRSAPublicKeyPem();
+        var token = SignTestJwt(rsa, new { iss = "gauntletci.com", tier = "pro", exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds() });
+
+        try
+        {
+            Environment.SetEnvironmentVariable(publicKeyEnv, publicPem);
+            Environment.SetEnvironmentVariable(licenseEnv, token);
+
+            var license = LicenseService.Load(licenseEnv);
+
+            Assert.True(license.IsValid);
+            Assert.True(license.IsLicensed);
+            Assert.Equal(LicenseTier.Pro, license.Tier);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(licenseEnv, null);
+            Environment.SetEnvironmentVariable(publicKeyEnv, null);
+        }
+    }
+
+    [Fact]
+    public void Load_ValidToken_WithPublicKeyFileOverride_AcceptsProTier()
+    {
+        const string licenseEnv = "GAUNTLETCI_LICENSE_TEST_FILE";
+        const string publicKeyFileEnv = "GAUNTLETCI_LICENSE_PUBLIC_KEY_FILE";
+        using var rsa = RSA.Create(2048);
+        var publicPem = rsa.ExportRSAPublicKeyPem();
+        var token = SignTestJwt(rsa, new { iss = "gauntletci.com", tier = "pro", exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds() });
+        var keyPath = Path.Combine(Path.GetTempPath(), $"gauntletci-test-{Guid.NewGuid():N}.pem");
+        File.WriteAllText(keyPath, publicPem);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(publicKeyFileEnv, keyPath);
+            Environment.SetEnvironmentVariable(licenseEnv, token);
+
+            var license = LicenseService.Load(licenseEnv);
+
+            Assert.True(license.IsValid);
+            Assert.True(license.IsLicensed);
+            Assert.Equal(LicenseTier.Pro, license.Tier);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(licenseEnv, null);
+            Environment.SetEnvironmentVariable(publicKeyFileEnv, null);
+            if (File.Exists(keyPath))
+                File.Delete(keyPath);
+        }
+    }
+
+    private static string SignTestJwt(RSA rsa, object payload)
+    {
+        var header = Base64UrlEncode("""{"alg":"RS256","typ":"JWT"}""");
+        var payloadJson = JsonSerializer.Serialize(payload);
+        var payloadPart = Base64UrlEncode(payloadJson);
+        var signingInput = Encoding.ASCII.GetBytes($"{header}.{payloadPart}");
+        var signature = rsa.SignData(signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return $"{header}.{payloadPart}.{Base64UrlEncode(signature)}";
+    }
+
+    private static string Base64UrlEncode(string value) =>
+        Base64UrlEncode(Encoding.UTF8.GetBytes(value));
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
 }


### PR DESCRIPTION
## Summary
- Add `GAUNTLETCI_LICENSE_PUBLIC_KEY` (inline PEM) and `GAUNTLETCI_LICENSE_PUBLIC_KEY_FILE` env vars for license verification
- Falls back to embedded DEV placeholder key when unset
- Adds tests that sign JWTs with a temp key pair and verify Pro tier via env override

## Why
Production deployments should not need a rebuild to swap the DEV placeholder RSA public key before issuing live licenses.

## Test plan
- [x] `dotnet test --filter LicenseServiceTests` (4/4 pass)
- [ ] CI build-and-test (ubuntu + windows)