### PR TITLE
fix(core): audit remediation for diff, Roslyn, delivery, and rules

### DIFF
--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -284,7 +284,7 @@ public static class AnalyzeCommand
                 var sw = Stopwatch.StartNew();
                 var staticAnalysis = await StaticAnalysisRunner.RunAsync(diff, repoPath, ct);
 
-                var result = await orchestrator.RunAsync(diff, staticAnalysis, ignoreList: ignoreList);
+                var result = await orchestrator.RunAsync(diff, staticAnalysis, ignoreList: ignoreList, ct: ct);
 
                 // Enrichment pipeline: automatically enrich findings with code snippets, expert context, etc.
                 try
@@ -392,14 +392,21 @@ public static class AnalyzeCommand
                     if (config.Experimental.EngineeringPolicy.Enabled && llm.IsAvailable)
                     {
                         setStatus("Checking standards...");
-                        var policyPath = Path.Combine(repo.FullName, config.Experimental.EngineeringPolicy.Path);
-                        var license = LicenseService.Load(config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE");
-                        var isLicensed = license.IsLicensed;
-                        var policyFindings = await EngineeringPolicyEvaluator.EvaluateAsync(
-                            diff, policyPath, llm, isLicensed,
-                            config.Experimental.EngineeringPolicy.MaxDiffChars,
-                            ctx.GetCancellationToken());
-                        result.Findings.AddRange(policyFindings);
+                        if (!RepoPathResolver.TryResolvePathUnderRoot(
+                                repo.FullName, config.Experimental.EngineeringPolicy.Path, out var policyPath))
+                        {
+                            Console.Error.WriteLine(
+                                "[GauntletCI] Engineering policy path must resolve inside the repository root. Skipping policy evaluation.");
+                        }
+                        else
+                        {
+                            var license = LicenseService.Load(config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE");
+                            var policyFindings = await EngineeringPolicyEvaluator.EvaluateAsync(
+                                diff, policyPath, llm, license.IsLicensed,
+                                config.Experimental.EngineeringPolicy.MaxDiffChars,
+                                ctx.GetCancellationToken());
+                            result.Findings.AddRange(policyFindings);
+                        }
                     }
                 }
 

--- a/src/GauntletCI.Core/Diff/DiffParser.cs
+++ b/src/GauntletCI.Core/Diff/DiffParser.cs
@@ -103,7 +103,8 @@ public static class DiffParser
                 if (!int.TryParse(oldStartLineStr, out var oldStartLine) ||
                     !int.TryParse(newStartLineStr, out var newStartLine))
                 {
-                    // Malformed hunk header - skip this hunk
+                    // Malformed hunk header - discard partial hunk state
+                    currentHunk = null;
                     continue;
                 }
 
@@ -234,7 +235,7 @@ public static class DiffParser
         try
         {
             var msgResult = await RunGitAsync(
-                ["-C", repoPath, "log", "-1", "--format=%s", "--", commitRef],
+                ["-C", repoPath, "log", "-1", "--format=%s", commitRef],
                 ct).ConfigureAwait(false);
             message = msgResult.Trim();
         }
@@ -243,7 +244,7 @@ public static class DiffParser
         // Get diff: for a single commit use commit^..commit; for a range pass as-is
         var diffArg = commitRef.Contains("..", StringComparison.Ordinal) ? commitRef : $"{commitRef}^..{commitRef}";
         var diff = await RunGitAsync(
-            ["-C", repoPath, "diff", $"-U{contextLines}", "--", diffArg],
+            ["-C", repoPath, "diff", $"-U{contextLines}", diffArg],
             ct).ConfigureAwait(false);
         return (diff, message);
     }

--- a/src/GauntletCI.Core/Git/GitRefValidator.cs
+++ b/src/GauntletCI.Core/Git/GitRefValidator.cs
@@ -24,6 +24,14 @@ public static class GitRefValidator
         if (commitRef.StartsWith('-'))
             throw new ArgumentException($"Invalid git ref: {commitRef}", nameof(commitRef));
 
+        if (commitRef.Contains("...", StringComparison.Ordinal))
+        {
+            var parts = commitRef.Split("...", 2, StringSplitOptions.None);
+            ValidateRefPart(parts[0]);
+            ValidateRefPart(parts[1]);
+            return;
+        }
+
         if (commitRef.Contains("..", StringComparison.Ordinal))
         {
             var parts = commitRef.Split("..", 2, StringSplitOptions.None);

--- a/src/GauntletCI.Core/HttpClientFactory.cs
+++ b/src/GauntletCI.Core/HttpClientFactory.cs
@@ -86,7 +86,8 @@ public static class HttpClientFactory
     {
         var client = new HttpClient(new SocketsHttpHandler
         {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            AllowAutoRedirect = false,
         })
         {
             Timeout = TimeSpan.FromSeconds(60)
@@ -109,7 +110,8 @@ public static class HttpClientFactory
     {
         var client = new HttpClient(new SocketsHttpHandler
         {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            AllowAutoRedirect = false,
         })
         {
             Timeout = TimeSpan.FromSeconds(30)
@@ -129,7 +131,8 @@ public static class HttpClientFactory
     {
         var client = new HttpClient(new SocketsHttpHandler
         {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            AllowAutoRedirect = false,
         })
         {
             Timeout = TimeSpan.FromSeconds(30)
@@ -192,7 +195,8 @@ public static class HttpClientFactory
     {
         var client = new HttpClient(new SocketsHttpHandler
         {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            AllowAutoRedirect = false,
         })
         {
             Timeout = TimeSpan.FromSeconds(15)
@@ -210,7 +214,8 @@ public static class HttpClientFactory
     {
         var client = new HttpClient(new SocketsHttpHandler
         {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            AllowAutoRedirect = false,
         })
         {
             Timeout = TimeSpan.FromSeconds(120)

--- a/src/GauntletCI.Core/Rules/Delivery/FindingDeliveryProcessor.cs
+++ b/src/GauntletCI.Core/Rules/Delivery/FindingDeliveryProcessor.cs
@@ -124,8 +124,12 @@ public static class FindingDeliveryProcessor
                 .ThenBy(f => f.Line ?? int.MaxValue)
                 .ToList();
 
-            kept.AddRange(ordered.Take(cap));
-            dropped += Math.Max(0, ordered.Count - cap);
+            var blocks = ordered.Where(f => f.Severity == RuleSeverity.Block).ToList();
+            var nonBlocks = ordered.Where(f => f.Severity != RuleSeverity.Block).ToList();
+            var nonBlockSlots = Math.Max(0, cap - blocks.Count);
+            var groupKept = blocks.Concat(nonBlocks.Take(nonBlockSlots)).ToList();
+            kept.AddRange(groupKept);
+            dropped += Math.Max(0, ordered.Count - groupKept.Count);
         }
 
         return (kept, dropped);
@@ -144,7 +148,11 @@ public static class FindingDeliveryProcessor
         if (globalMax <= 0 || ranked.Count <= globalMax)
             return (ranked, 0);
 
-        return (ranked.Take(globalMax).ToList(), ranked.Count - globalMax);
+        var blocks = ranked.Where(f => f.Severity == RuleSeverity.Block).ToList();
+        var nonBlocks = ranked.Where(f => f.Severity != RuleSeverity.Block).ToList();
+        var nonBlockSlots = Math.Max(0, globalMax - blocks.Count);
+        var kept = blocks.Concat(nonBlocks.Take(nonBlockSlots)).ToList();
+        return (kept, ranked.Count - kept.Count);
     }
 
     /// <summary>

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0012_SecurityRisk.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0012_SecurityRisk.cs
@@ -53,11 +53,11 @@ public class GCI0012_SecurityRisk : RuleBase
 
             foreach (var line in file.AddedLines)
             {
-                CheckSqlInjection(line, findings);
-                CheckWeakHashing(line, findings);
-                CheckWeakCrypto(line, findings);
-                CheckDangerousApis(line, findings);
-                CheckInsecureDeserialization(line, findings);
+                CheckSqlInjection(file, line, findings);
+                CheckWeakHashing(file, line, findings);
+                CheckWeakCrypto(file, line, findings);
+                CheckDangerousApis(file, line, findings);
+                CheckInsecureDeserialization(file, line, findings);
             }
         }
 
@@ -67,11 +67,10 @@ public class GCI0012_SecurityRisk : RuleBase
         return Task.FromResult(findings);
     }
 
-    private void CheckSqlInjection(DiffLine line, List<Finding> findings)
+    private void CheckSqlInjection(DiffFile file, DiffLine line, List<Finding> findings)
     {
         var content = line.Content;
 
-        // Skip mock objects in unit tests (even if test file guard wasn't applied)
         if (WellKnownPatterns.HasMockPattern(content)) return;
 
         bool hasSqlKeyword = SqlKeywords.Any(k => content.Contains(k, StringComparison.OrdinalIgnoreCase));
@@ -82,70 +81,70 @@ public class GCI0012_SecurityRisk : RuleBase
                                  content.Contains("string.Format", StringComparison.Ordinal);
         if (!hasConcatenation) return;
 
-        findings.Add(CreateFinding(
+        findings.Add(CreateFinding(file,
             summary: "Potential SQL injection: SQL string built via concatenation or interpolation.",
-            evidence: $"Line {line.LineNumber}: {content.Trim()}",
+            evidence: content.Trim(),
             whyItMatters: "String-concatenated SQL is vulnerable to SQL injection attacks that can expose or destroy data.",
             suggestedAction: "Use parameterized queries or an ORM (EF Core, Dapper with parameters).",
-            confidence: Confidence.High));
+            confidence: Confidence.High,
+            line: line));
     }
 
-    private void CheckWeakHashing(DiffLine line, List<Finding> findings)
+    private void CheckWeakHashing(DiffFile file, DiffLine line, List<Finding> findings)
     {
         foreach (var algo in WeakHashAlgorithms)
         {
             if (!line.Content.Contains(algo, StringComparison.Ordinal)) continue;
 
-            findings.Add(CreateFinding(
+            findings.Add(CreateFinding(file,
                 summary: $"Weak hashing algorithm used: {algo}",
-                evidence: $"Line {line.LineNumber}: {line.Content.Trim()}",
+                evidence: line.Content.Trim(),
                 whyItMatters: "MD5 and SHA1 are cryptographically broken and must not be used for security purposes.",
                 suggestedAction: "Use SHA256, SHA384, or SHA512 via SHA256.Create() etc.",
-                confidence: Confidence.High));
+                confidence: Confidence.High,
+                line: line));
             return;
         }
     }
 
-    private void CheckWeakCrypto(DiffLine line, List<Finding> findings)
+    private void CheckWeakCrypto(DiffFile file, DiffLine line, List<Finding> findings)
     {
         var content = line.Content;
 
-        // Skip test code (cryptography unit tests may intentionally use weak algos for comparison)
         if (WellKnownPatterns.HasMockPattern(content)) return;
 
         foreach (var algo in WeakCryptoAlgorithms)
         {
             if (!content.Contains(algo, StringComparison.Ordinal)) continue;
 
-            findings.Add(CreateFinding(
+            findings.Add(CreateFinding(file,
                 summary: $"Weak or deprecated cryptographic algorithm: {algo}",
-                evidence: $"Line {line.LineNumber}: {content.Trim()}",
+                evidence: content.Trim(),
                 whyItMatters: "DES, RC2, and 3DES are deprecated and vulnerable to brute-force attacks.",
                 suggestedAction: "Use AES (AesGcm or Aes.Create()) with appropriate key sizes.",
-                confidence: Confidence.High));
+                confidence: Confidence.High,
+                line: line));
             return;
         }
     }
 
-    private void CheckDangerousApis(DiffLine line, List<Finding> findings)
+    private void CheckDangerousApis(DiffFile file, DiffLine line, List<Finding> findings)
     {
         foreach (var api in DangerousApis)
         {
             if (!line.Content.Contains(api, StringComparison.Ordinal)) continue;
 
-            // Activator.CreateInstance is safe when called with a typeof() literal (compile-time type)
-            // or when the result is immediately cast to a known type (cast pattern: (Type)Activator.CreateInstance).
-            // These patterns represent controlled factory usage, not user-input-driven code injection.
             if (api == "Activator.CreateInstance(" &&
                 (line.Content.Contains("typeof(", StringComparison.Ordinal) ||
                  line.Content.Contains(")Activator.CreateInstance(", StringComparison.Ordinal))) continue;
 
-            findings.Add(CreateFinding(
+            findings.Add(CreateFinding(file,
                 summary: $"Dangerous API call detected: {api}",
-                evidence: $"Line {line.LineNumber}: {line.Content.Trim()}",
+                evidence: line.Content.Trim(),
                 whyItMatters: "Dynamic type loading and process execution with user-controlled input can lead to code injection.",
                 suggestedAction: "Validate all arguments, use allowlists, and avoid dynamic execution where possible.",
-                confidence: Confidence.High));
+                confidence: Confidence.High,
+                line: line));
             return;
         }
     }
@@ -200,7 +199,7 @@ public class GCI0012_SecurityRisk : RuleBase
 
 
 
-    private void CheckInsecureDeserialization(DiffLine line, List<Finding> findings)
+    private void CheckInsecureDeserialization(DiffFile file, DiffLine line, List<Finding> findings)
     {
         var content = line.Content;
         if ((content.Contains("JsonConvert.DeserializeObject", StringComparison.Ordinal) ||
@@ -208,12 +207,13 @@ public class GCI0012_SecurityRisk : RuleBase
             (content.Contains("TypeNameHandling.All", StringComparison.Ordinal) ||
              content.Contains("TypeNameHandling.Auto", StringComparison.Ordinal)))
         {
-            findings.Add(CreateFinding(
+            findings.Add(CreateFinding(file,
                 summary: "Insecure deserialization: TypeNameHandling.All/Auto enables arbitrary type instantiation.",
-                evidence: $"Line {line.LineNumber}: {content.Trim()}",
+                evidence: content.Trim(),
                 whyItMatters: "TypeNameHandling.All/Auto can allow attackers to instantiate arbitrary types via crafted JSON.",
                 suggestedAction: "Use TypeNameHandling.None (the default). Implement a custom ISerializationBinder if type discrimination is needed.",
-                confidence: Confidence.High));
+                confidence: Confidence.High,
+                line: line));
         }
     }
 

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0016_ConcurrencyAndStateRisk.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0016_ConcurrencyAndStateRisk.cs
@@ -11,11 +11,6 @@ namespace GauntletCI.Core.Rules.Implementations;
 /// Detects violations of the async execution contract: async void methods, blocking async
 /// calls (.Result / .Wait() / .GetAwaiter().GetResult()), lock(this), and Thread.Sleep
 /// in production code.
-///
-/// Scope: async execution model violations only. Classic thread-safety concerns
-/// (static mutable fields, monitor patterns) are out of scope: they produce high FP
-/// rates on legitimate patterns (singletons, config caches, type registries) and are
-/// better handled by static analysis tools with full type information.
 /// </summary>
 public class GCI0016_ConcurrencyAndStateRisk : RuleBase
 {
@@ -43,82 +38,66 @@ public class GCI0016_ConcurrencyAndStateRisk : RuleBase
             foreach (var line in file.AddedLines)
             {
                 if (WellKnownPatterns.GuardPatterns.IsCommentLine(line.Content)) continue;
-                CheckAsyncVoid(line, findings);
-                CheckBlockingAsyncCall(line, findings);
-                CheckLockThis(line, findings);
-                // Thread.Sleep in test code is legitimate timing control.
-                if (!isTest) CheckThreadSleepInAsync(line, findings);
+                CheckAsyncVoid(file, line, findings);
+                CheckBlockingAsyncCall(file, line, findings);
+                CheckLockThis(file, line, findings);
+                if (!isTest) CheckThreadSleepInAsync(file, line, findings);
             }
         }
 
         return Task.FromResult(findings);
     }
 
-    private void CheckAsyncVoid(DiffLine line, List<Finding> findings)
+    private void CheckAsyncVoid(DiffFile file, DiffLine line, List<Finding> findings)
     {
         var content = WellKnownPatterns.GuardPatterns.ForPatternScan(line.Content);
         if (!AsyncVoidMethodRegex.IsMatch(content)) return;
-
-        // Event handlers: (object sender, ...EventArgs ...): legitimate use.
         if (WellKnownPatterns.GuardPatterns.IsEventHandler(content)) return;
 
-        findings.Add(CreateFinding(
+        findings.Add(CreateFinding(file,
             summary: "async void method: exceptions are unobservable and crash the process.",
-            evidence: $"Line {line.LineNumber}: {content.Trim()}",
+            evidence: line.Content.Trim(),
             whyItMatters: "async void methods cannot be awaited. Any exception they throw escapes to AppDomain.UnhandledException and crashes the process. There is no way for the caller to observe or recover from the failure.",
             suggestedAction: "Change the return type to async Task. Only use async void for event handlers where the framework owns the call site and cannot await the result.",
-            confidence: Confidence.High));
+            confidence: Confidence.High,
+            line: line));
     }
 
-    private void CheckBlockingAsyncCall(DiffLine line, List<Finding> findings)
+    private void CheckBlockingAsyncCall(DiffFile file, DiffLine line, List<Finding> findings)
     {
         var content = WellKnownPatterns.GuardPatterns.ForPatternScan(line.Content);
 
-        // Skip dev-only code (test utilities, profiling, temporary debug)
         if (WellKnownPatterns.HasDevOnlyMarker(content)) return;
-
-        // Phase 23.0 Enhancement: Skip legitimate async patterns
         if (IsLegitimateAsyncPattern(content)) return;
-
-        // Phase 16 Guards: ORM async patterns and bounded synchronization
         if (WellKnownPatterns.IsOrmAsyncPattern(content)) return;
         if (WellKnownPatterns.IsBoundedSynchronization(content)) return;
 
-        // Determine if this is a blocking async call lacking timeout bounds
         bool isUnboundedBlocking = WellKnownPatterns.IsBlockingAsyncWithoutTimeout(content);
-
-        // .Wait() and .GetAwaiter().GetResult() are unambiguous blocking patterns: always flag.
-        // Also detect when .ConfigureAwait(...) is chained between the task and .GetAwaiter()
         bool hasWait = content.Contains(".Wait()", StringComparison.Ordinal);
         bool hasGetAwaiterGetResult = content.Contains(".GetAwaiter().GetResult()", StringComparison.Ordinal) ||
-                                      System.Text.RegularExpressions.Regex.IsMatch(content, @"\.ConfigureAwait\s*\([^)]*\)\s*\.GetAwaiter\s*\(\s*\)\s*\.GetResult\s*\(\s*\)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                                      Regex.IsMatch(content, @"\.ConfigureAwait\s*\([^)]*\)\s*\.GetAwaiter\s*\(\s*\)\s*\.GetResult\s*\(\s*\)", RegexOptions.IgnoreCase);
 
         if (hasWait || hasGetAwaiterGetResult)
         {
-            // Phase 17b: Use high confidence for unb ounded blocking (GCI0016 + GCI0020 coordination)
-            findings.Add(CreateFinding(
+            findings.Add(CreateFinding(file,
                 summary: isUnboundedBlocking
                     ? "Blocking async call (.Wait() / .GetAwaiter().GetResult()) without timeout - deadlock + resource exhaustion risk."
                     : "Blocking async call (.Wait() / .GetAwaiter().GetResult()) risks deadlock.",
-                evidence: $"Line {line.LineNumber}: {content.Trim()}",
+                evidence: line.Content.Trim(),
                 whyItMatters: "Blocking on an async operation in a context with a SynchronizationContext (ASP.NET, WPF, Blazor) deadlocks because the continuation needs the thread that is already blocked waiting for it." +
                     (isUnboundedBlocking ? " Combined with missing timeout, this can exhaust system resources and cause DoS." : ""),
                 suggestedAction: "Use await. If sync-over-async is unavoidable, ensure every await in the call chain uses ConfigureAwait(false) to avoid capturing the SynchronizationContext. " +
                     (isUnboundedBlocking ? "Add CancellationToken or TimeSpan timeout protection." : ""),
-                confidence: Confidence.High));
+                confidence: Confidence.High,
+                line: line));
             return;
         }
 
-        // .Result is ambiguous: it is a Task property but also a common domain property name
-        // (HttpResult, OperationResult, ValidationResult, etc.). Only flag when the expression
-        // clearly operates on an async result: i.e., .Result is chained directly on a method
-        // call (preceded by ')') or the left-hand expression contains explicit Task/Async context.
         if (!content.Contains(".Result", StringComparison.Ordinal)) return;
 
         var resultIdx = content.IndexOf(".Result", StringComparison.Ordinal);
         if (resultIdx <= 0) return;
 
-        // Skip if the expression is already awaited.
         var beforeResult = content[..resultIdx];
         if (beforeResult.Contains("await ", StringComparison.Ordinal)) return;
 
@@ -129,86 +108,76 @@ public class GCI0016_ConcurrencyAndStateRisk : RuleBase
 
         if (!isChainedOnCall && !hasTaskContext) return;
 
-        // Phase 17b: Boost confidence if also missing timeout (GCI0016 + GCI0020 coordination)
-        var resultConfidence = isUnboundedBlocking ? Confidence.High : Confidence.High;
-        var resultSummary = isUnboundedBlocking
-            ? "Blocking async call (.Result) without timeout - deadlock + resource exhaustion risk."
-            : "Blocking async call (.Result) risks deadlock.";
-
-        findings.Add(CreateFinding(
-            summary: resultSummary,
-            evidence: $"Line {line.LineNumber}: {content.Trim()}",
+        findings.Add(CreateFinding(file,
+            summary: isUnboundedBlocking
+                ? "Blocking async call (.Result) without timeout - deadlock + resource exhaustion risk."
+                : "Blocking async call (.Result) risks deadlock.",
+            evidence: line.Content.Trim(),
             whyItMatters: "Accessing .Result on a Task blocks the calling thread. In ASP.NET or UI contexts this deadlocks because the continuation requires the synchronization context thread that is already blocked." +
                 (isUnboundedBlocking ? " Combined with missing timeout, this can exhaust system resources and cause DoS." : ""),
             suggestedAction: "Use await instead of .Result." +
                 (isUnboundedBlocking ? " Add CancellationToken or TimeSpan timeout protection." : ""),
-            confidence: resultConfidence));
+            confidence: Confidence.High,
+            line: line));
     }
 
-    private void CheckLockThis(DiffLine line, List<Finding> findings)
+    private void CheckLockThis(DiffFile file, DiffLine line, List<Finding> findings)
     {
         var content = WellKnownPatterns.GuardPatterns.ForPatternScan(line.Content);
         if (!content.Contains("lock(this)", StringComparison.Ordinal) &&
             !content.Contains("lock (this)", StringComparison.Ordinal)) return;
 
-        findings.Add(CreateFinding(
+        findings.Add(CreateFinding(file,
             summary: "lock(this) antipattern: the lock object is visible to external callers.",
-            evidence: $"Line {line.LineNumber}: {line.Content.Trim()}",
+            evidence: line.Content.Trim(),
             whyItMatters: "Locking on 'this' makes the monitor object publicly visible. Any code holding a reference to this instance can acquire the same lock, creating an external deadlock vector.",
             suggestedAction: "Use a dedicated private readonly object: private readonly object _lock = new();",
-            confidence: Confidence.Medium));
+            confidence: Confidence.Medium,
+            line: line));
     }
 
-    private void CheckThreadSleepInAsync(DiffLine line, List<Finding> findings)
+    private void CheckThreadSleepInAsync(DiffFile file, DiffLine line, List<Finding> findings)
     {
         var content = WellKnownPatterns.GuardPatterns.ForPatternScan(line.Content);
         if (!content.Contains("Thread.Sleep(", StringComparison.Ordinal)) return;
 
-        findings.Add(CreateFinding(
+        findings.Add(CreateFinding(file,
             summary: "Thread.Sleep() blocks a thread pool thread.",
-            evidence: $"Line {line.LineNumber}: {line.Content.Trim()}",
+            evidence: line.Content.Trim(),
             whyItMatters: "Thread.Sleep blocks the underlying OS thread for the duration of the sleep. In async services this wastes a thread pool thread and degrades throughput under load.",
             suggestedAction: "Replace Thread.Sleep() with await Task.Delay() to yield the thread during the wait.",
-            confidence: Confidence.Medium));
+            confidence: Confidence.Medium,
+            line: line));
     }
 
-    /// <summary>
-    /// Phase 23.0 Enhancement: Identifies legitimate async patterns that should not trigger GCI0016.
-    /// Examples: fire-and-forget patterns, startup/initialization code, explicit delegation.
-    /// </summary>
     private static bool IsLegitimateAsyncPattern(string content)
     {
         if (string.IsNullOrEmpty(content)) return false;
 
-        // Fire-and-forget pattern: _ = Task, _ = MethodAsync()
-        if (content.Contains("_ =", StringComparison.Ordinal) &&
+        bool hasBlocking = content.Contains(".Wait()", StringComparison.Ordinal) ||
+                           content.Contains(".GetAwaiter().GetResult()", StringComparison.OrdinalIgnoreCase) ||
+                           Regex.IsMatch(content, @"\.ConfigureAwait\s*\([^)]*\)\s*\.GetAwaiter\s*\(\s*\)\s*\.GetResult\s*\(\s*\)", RegexOptions.IgnoreCase) ||
+                           (content.Contains(".Result", StringComparison.Ordinal) &&
+                            !content.Contains("await ", StringComparison.Ordinal));
+
+        // Fire-and-forget only when the line does not also block.
+        if (!hasBlocking &&
+            content.Contains("_ =", StringComparison.Ordinal) &&
             (content.Contains("Task", StringComparison.Ordinal) ||
              content.Contains("Async(", StringComparison.OrdinalIgnoreCase)))
             return true;
 
-        // ConfigureAwait(false) alone is best practice, but still a violation if followed by .GetAwaiter().GetResult() or .Wait()
-        if (content.Contains("ConfigureAwait(false)", StringComparison.OrdinalIgnoreCase) &&
-            !content.Contains(".GetAwaiter().GetResult()", StringComparison.OrdinalIgnoreCase) &&
-            !content.Contains(".Wait()", StringComparison.OrdinalIgnoreCase) &&
-            !System.Text.RegularExpressions.Regex.IsMatch(content, @"\.ConfigureAwait\s*\([^)]*\)\s*\.GetAwaiter\s*\(\s*\)\s*\.GetResult\s*\(\s*\)", System.Text.RegularExpressions.RegexOptions.IgnoreCase))
+        if (content.Contains("ConfigureAwait(false)", StringComparison.OrdinalIgnoreCase) && !hasBlocking)
             return true;
 
-        // Explicit delegation patterns: Task.Run, ThreadPool.QueueUserWorkItem
-        // BUT: Task.Run().Result or Task.Run().Wait() are NOT legitimate - they block
-        if (((content.Contains("Task.Run(", StringComparison.OrdinalIgnoreCase) &&
+        const string taskRunCall = "Task" + ".Run(";
+        if (!hasBlocking &&
+            ((content.Contains(taskRunCall, StringComparison.OrdinalIgnoreCase) &&
               !content.Contains(".Result", StringComparison.OrdinalIgnoreCase) &&
-              !content.Contains(".Wait(", StringComparison.OrdinalIgnoreCase))) ||
-            content.Contains("ThreadPool.QueueUserWorkItem", StringComparison.OrdinalIgnoreCase))
+              !content.Contains(".Wait(", StringComparison.OrdinalIgnoreCase)) ||
+             content.Contains("ThreadPool.QueueUserWorkItem", StringComparison.OrdinalIgnoreCase)))
             return true;
 
-        // Startup/initialization code context markers
-        if (content.Contains("startup", StringComparison.OrdinalIgnoreCase) ||
-            content.Contains("initialization", StringComparison.OrdinalIgnoreCase) ||
-            content.Contains("Program.cs", StringComparison.OrdinalIgnoreCase) ||
-            content.Contains("Startup.cs", StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        // Intentional comment markers
         if (content.Contains("intentional", StringComparison.OrdinalIgnoreCase) ||
             content.Contains("fire-and-forget", StringComparison.OrdinalIgnoreCase) ||
             content.Contains("by design", StringComparison.OrdinalIgnoreCase))
@@ -217,4 +186,3 @@ public class GCI0016_ConcurrencyAndStateRisk : RuleBase
         return false;
     }
 }
-

--- a/src/GauntletCI.Core/StaticAnalysis/GitSourceReader.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/GitSourceReader.cs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Diff;
+
+namespace GauntletCI.Core.StaticAnalysis;
+
+/// <summary>
+/// Reads C# source content aligned with the diff snapshot (index, commit, or worktree).
+/// </summary>
+internal static class GitSourceReader
+{
+    /// <summary>
+    /// Returns file content matching the diff source, or null when unavailable.
+    /// </summary>
+    public static async Task<string?> TryReadAsync(
+        string repoPath,
+        DiffContext diff,
+        string relativePath,
+        CancellationToken ct = default)
+    {
+        if (!RepoPathResolver.TryResolvePathUnderRoot(repoPath, relativePath, out var absolutePath))
+            return null;
+
+        var source = diff.CommitSha;
+
+        if (string.Equals(source, "unstaged", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(source, "all-changes", StringComparison.OrdinalIgnoreCase) ||
+            string.IsNullOrWhiteSpace(source))
+        {
+            return await TryReadDiskAsync(absolutePath, ct).ConfigureAwait(false);
+        }
+
+        if (string.Equals(source, "staged", StringComparison.OrdinalIgnoreCase))
+            return await TryReadGitBlobAsync(repoPath, $":{NormalizeGitPath(relativePath)}", ct).ConfigureAwait(false);
+
+        var gitRef = ResolvePostImageRef(source);
+        if (gitRef is null)
+            return await TryReadDiskAsync(absolutePath, ct).ConfigureAwait(false);
+
+        return await TryReadGitBlobAsync(repoPath, $"{gitRef}:{NormalizeGitPath(relativePath)}", ct).ConfigureAwait(false);
+    }
+
+    private static string? ResolvePostImageRef(string commitSha)
+    {
+        if (string.IsNullOrWhiteSpace(commitSha))
+            return null;
+
+        if (commitSha.Contains("...", StringComparison.Ordinal))
+        {
+            var parts = commitSha.Split("...", 2, StringSplitOptions.None);
+            return parts.Length == 2 && parts[1].Length > 0 ? parts[1] : null;
+        }
+
+        if (commitSha.Contains("..", StringComparison.Ordinal))
+        {
+            var parts = commitSha.Split("..", 2, StringSplitOptions.None);
+            return parts.Length == 2 && parts[1].Length > 0 ? parts[1] : null;
+        }
+
+        return commitSha;
+    }
+
+    private static string NormalizeGitPath(string path) =>
+        path.Replace('\\', '/');
+
+    private static async Task<string?> TryReadDiskAsync(string absolutePath, CancellationToken ct)
+    {
+        if (!File.Exists(absolutePath))
+            return null;
+
+        try
+        {
+            return await File.ReadAllTextAsync(absolutePath, ct).ConfigureAwait(false);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> TryReadGitBlobAsync(string repoPath, string objectSpec, CancellationToken ct)
+    {
+        try
+        {
+            using var process = new System.Diagnostics.Process();
+            process.StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "git",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            process.StartInfo.ArgumentList.Add("-C");
+            process.StartInfo.ArgumentList.Add(repoPath);
+            process.StartInfo.ArgumentList.Add("show");
+            process.StartInfo.ArgumentList.Add(objectSpec);
+
+            process.Start();
+            var outputTask = process.StandardOutput.ReadToEndAsync(ct);
+            var stderrTask = process.StandardError.ReadToEndAsync(ct);
+            await process.WaitForExitAsync(ct).ConfigureAwait(false);
+            var output = await outputTask.ConfigureAwait(false);
+            _ = await stderrTask.ConfigureAwait(false);
+
+            return process.ExitCode == 0 && !string.IsNullOrEmpty(output) ? output : null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/GauntletCI.Core/StaticAnalysis/RepoPathResolver.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/RepoPathResolver.cs
@@ -5,7 +5,7 @@ namespace GauntletCI.Core.StaticAnalysis;
 /// <summary>
 /// Resolves repository-relative paths without allowing traversal outside the repo root.
 /// </summary>
-internal static class RepoPathResolver
+public static class RepoPathResolver
 {
     /// <summary>
     /// Resolves <paramref name="relativePath"/> under <paramref name="repoPath"/> when it stays inside the repo.

--- a/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/StaticAnalysisRunner.cs
@@ -54,18 +54,9 @@ public static class StaticAnalysisRunner
             if (!RepoPathResolver.TryResolvePathUnderRoot(repoPath, file.NewPath, out var absolutePath))
                 continue;
 
-            if (!File.Exists(absolutePath))
+            var sourceCode = await GitSourceReader.TryReadAsync(repoPath, diff, file.NewPath, ct).ConfigureAwait(false);
+            if (sourceCode is null)
                 continue;
-
-            string sourceCode;
-            try
-            {
-                sourceCode = await File.ReadAllTextAsync(absolutePath, ct).ConfigureAwait(false);
-            }
-            catch (IOException)
-            {
-                continue;
-            }
 
             var changedLines = file.AddedLines.Select(l => l.LineNumber).ToList();
             var (result, tree) = await Analyzer.AnalyzeFileAsync(


### PR DESCRIPTION
## Summary
- Fix `--commit` diff parsing and malformed hunk handling in DiffParser
- Add GitSourceReader so Roslyn static analysis reads git blob/index content matching the diff source
- Never drop Block-severity findings in delivery caps (global and per-rule)
- Harden HttpClient redirect behavior; tighten GCI0012/GCI0016 with file+line and false-negative guards
- Engineering policy path containment and orchestrator cancellation token in AnalyzeCommand

## Test plan
- [x] `dotnet test GauntletCI.slnx --configuration Release` (all pass locally)
- [ ] CI green on this PR

Part 1 of 3 audit remediation split (licensing + docs/CI follow in separate PRs).