### PR TITLE
fix(licensing): fail-closed paid features, network validation, and worker KV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,9 @@ jobs:
       - name: Analyze with GauntletCI
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GAUNTLETCI_LICENSE: ${{ secrets.GAUNTLETCI_LICENSE }}
           GAUNTLETCI_PR_NUMBER: ${{ github.event.pull_request.number }}
           GAUNTLETCI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: >
           dotnet run --project src/GauntletCI.Cli --no-build --configuration Release --
-          analyze --no-banner --ascii --github-annotations --github-pr-comments --severity warn --sensitivity balanced --no-baseline < pr.diff
+          analyze --no-banner --ascii --github-annotations --pr-comment-suggest --repo . --severity warn --sensitivity balanced --no-baseline < pr.diff

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -6,6 +6,7 @@ using GauntletCI.Cli.Analysis;
 using GauntletCI.Cli.Audit;
 using GauntletCI.Cli.Baseline;
 using GauntletCI.Cli.Enrichment;
+using GauntletCI.Cli.Licensing;
 using GauntletCI.Cli.LlmDaemon;
 using GauntletCI.Cli.Output;
 using GauntletCI.Cli.Presentation;
@@ -225,33 +226,14 @@ public static class AnalyzeCommand
                 if (ctx.ParseResult.FindResultFor(verboseFlag) is null)
                     verbose = config.Output.Verbose;
 
-                // Remote subscription check -- only when a licensed feature is in use.
-                // Fires once per 24h (cached). Fails open if the network is unreachable.
                 bool usingLicensedFeature = withLlm || withExpertCtx || ghPrComments || githubChecks;
-                if (usingLicensedFeature)
+                var licenseEnvVar = config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE";
+                var licenseExit = await PaidFeatureGate.TryEnsureLicensedAsync(
+                    usingLicensedFeature, licenseEnvVar, ct);
+                if (licenseExit is int exitCode)
                 {
-                    var envVar = config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE";
-                    var rawToken = LicenseService.ReadRawToken(envVar);
-                    if (rawToken is not null)
-                    {
-                        var netResult = await Licensing.NetworkLicenseValidator
-                            .ValidateAsync(rawToken, ct);
-                        if (!netResult.Valid)
-                        {
-                            Console.Error.WriteLine(
-                                $"[GauntletCI] License subscription is no longer active ({netResult.Reason ?? "cancelled"}). " +
-                                "Renew at https://gauntletci.com/pricing or run: gauntletci license renew");
-                            ctx.ExitCode = 1;
-                            return;
-                        }
-
-                        if (netResult.SkippedNetworkCheck)
-                        {
-                            Console.Error.WriteLine(
-                                "[GauntletCI] Warning: Could not verify license subscription online. " +
-                                "Using offline mode. Set GAUNTLETCI_OFFLINE=1 to suppress this warning.");
-                        }
-                    }
+                    ctx.ExitCode = exitCode;
+                    return;
                 }
 
                 // Severity: only apply config value if user did not explicitly pass --severity

--- a/src/GauntletCI.Cli/Licensing/NetworkLicenseValidator.cs
+++ b/src/GauntletCI.Cli/Licensing/NetworkLicenseValidator.cs
@@ -9,15 +9,16 @@ namespace GauntletCI.Cli.Licensing;
 /// <summary>
 /// Validates an active GauntletCI license against the remote status endpoint.
 /// Caches the result for 24 hours to avoid latency on every run.
-/// On network errors, reuses a stale cache entry when one exists for the same token.
-/// When no cache exists and the network is unreachable, fails open but flags
-/// <see cref="NetworkLicenseValidationResult.SkippedNetworkCheck"/> so callers can warn.
-/// Set GAUNTLETCI_OFFLINE=1 to skip the network check entirely (Enterprise/air-gap).
+/// On network errors, reuses a stale cache entry when one exists for the same token (max 72h).
+/// When no cache exists and the network is unreachable, fails closed unless
+/// <c>GAUNTLETCI_ENTERPRISE_AIRGAP=1</c> is set (Enterprise/air-gap).
+/// Set <c>GAUNTLETCI_OFFLINE=1</c> with enterprise air-gap to skip the network call entirely.
 /// </summary>
 public static class NetworkLicenseValidator
 {
     private const string StatusEndpoint = "https://gauntletci-license-worker.patient-water-71dd.workers.dev/license/status";
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
+    private static readonly TimeSpan MaxStaleCacheAge = TimeSpan.FromHours(72);
 
     private static readonly string DefaultCachePath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
@@ -39,7 +40,12 @@ public static class NetworkLicenseValidator
         CancellationToken ct = default)
     {
         if (IsOfflineMode())
+        {
+            if (!IsEnterpriseAirGap())
+                return new NetworkLicenseValidationResult(false, "offline_requires_enterprise_air_gap");
+
             return new NetworkLicenseValidationResult(true, null, SkippedNetworkCheck: true);
+        }
 
         var cached = TryReadCache(token, ignoreTtl: false);
         if (cached.HasValue)
@@ -56,6 +62,13 @@ public static class NetworkLicenseValidator
 
             using var response = await http.SendAsync(request, ct);
             var body = await response.Content.ReadAsStringAsync(ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                return new NetworkLicenseValidationResult(
+                    false,
+                    $"license_status_http_{(int)response.StatusCode}");
+            }
+
             using var doc = JsonDocument.Parse(body);
             var root = doc.RootElement;
             var valid = root.GetProperty("valid").GetBoolean();
@@ -71,18 +84,47 @@ public static class NetworkLicenseValidator
                 $"[NetworkLicenseValidator] Network check failed: {ex.Message}");
 
             var stale = TryReadCache(token, ignoreTtl: true);
-            if (stale.HasValue)
+            if (stale.HasValue && IsStaleCacheWithinGrace(token))
                 return new NetworkLicenseValidationResult(stale.Value.Valid, stale.Value.Reason);
 
-            // No prior validation record -- allow air-gapped first run, but flag it.
-            return new NetworkLicenseValidationResult(true, null, SkippedNetworkCheck: true);
+            if (IsEnterpriseAirGap())
+                return new NetworkLicenseValidationResult(true, null, SkippedNetworkCheck: true);
+
+            return new NetworkLicenseValidationResult(false, "network_unreachable");
         }
     }
 
     // -------------------------------------------------------------------------
 
     private static bool IsOfflineMode() =>
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GAUNTLETCI_OFFLINE"));
+        string.Equals(Environment.GetEnvironmentVariable("GAUNTLETCI_OFFLINE"), "1", StringComparison.Ordinal);
+
+    private static bool IsEnterpriseAirGap() =>
+        string.Equals(Environment.GetEnvironmentVariable("GAUNTLETCI_ENTERPRISE_AIRGAP"), "1", StringComparison.Ordinal);
+
+    private static bool IsStaleCacheWithinGrace(string token)
+    {
+        try
+        {
+            if (!File.Exists(CachePath))
+                return false;
+
+            using var stream = File.OpenRead(CachePath);
+            using var doc = JsonDocument.Parse(stream);
+            var root = doc.RootElement;
+
+            var cachedHash = root.TryGetProperty("tokenHash", out var h) ? h.GetString() : null;
+            if (cachedHash != TokenHash(token))
+                return false;
+
+            var cachedAt = DateTimeOffset.FromUnixTimeSeconds(root.GetProperty("cachedAt").GetInt64());
+            return DateTimeOffset.UtcNow - cachedAt <= MaxStaleCacheAge;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     internal static (bool Valid, string? Reason)? TryReadCache(string token, bool ignoreTtl)
     {

--- a/src/GauntletCI.Cli/Licensing/PaidFeatureGate.cs
+++ b/src/GauntletCI.Cli/Licensing/PaidFeatureGate.cs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Licensing;
+
+namespace GauntletCI.Cli.Licensing;
+
+/// <summary>
+/// Enforces license requirements before paid CLI features run.
+/// </summary>
+internal static class PaidFeatureGate
+{
+    /// <summary>
+    /// Returns an exit code when the caller must abort; null when execution may continue.
+    /// </summary>
+    public static async Task<int?> TryEnsureLicensedAsync(
+        bool usingLicensedFeature,
+        string licenseEnvVar,
+        CancellationToken ct = default)
+    {
+        if (!usingLicensedFeature)
+            return null;
+
+        var license = LicenseService.Load(licenseEnvVar);
+        if (!license.IsLicensed)
+        {
+            Console.Error.WriteLine(
+                "[GauntletCI] A valid Pro-or-higher license is required for this feature. " +
+                "Set GAUNTLETCI_LICENSE or run: gauntletci license status");
+            return 1;
+        }
+
+        var rawToken = LicenseService.ReadRawToken(licenseEnvVar);
+        if (rawToken is null)
+            return 1;
+
+        var netResult = await NetworkLicenseValidator.ValidateAsync(rawToken, ct).ConfigureAwait(false);
+        if (!netResult.Valid)
+        {
+            Console.Error.WriteLine(
+                $"[GauntletCI] License subscription is no longer active ({netResult.Reason ?? "cancelled"}). " +
+                "Renew at https://gauntletci.com/pricing or run: gauntletci license renew");
+            return 1;
+        }
+
+        if (netResult.SkippedNetworkCheck)
+        {
+            Console.Error.WriteLine(
+                "[GauntletCI] Warning: Could not verify license subscription online. " +
+                "Set GAUNTLETCI_ENTERPRISE_AIRGAP=1 to suppress this warning in approved air-gap environments.");
+        }
+
+        return null;
+    }
+}

--- a/src/GauntletCI.Core/Licensing/LicenseService.cs
+++ b/src/GauntletCI.Core/Licensing/LicenseService.cs
@@ -103,6 +103,11 @@ public static class LicenseService
                 if (expiresAt.Value < DateTimeOffset.UtcNow)
                     return LicenseInfo.Expired(expiresAt.Value);
             }
+            else if (!IsDevLicenseMode())
+            {
+                return LicenseInfo.Invalid(
+                    "License token is missing an expiry (exp) claim. Re-issue a token at https://gauntletci.com/pricing");
+            }
 
             var tierStr = root.TryGetProperty("tier", out var tierProp) ? tierProp.GetString() : null;
             var tier = tierStr?.ToLowerInvariant() switch
@@ -125,20 +130,26 @@ public static class LicenseService
 
     private static string ResolvePublicKeyPem()
     {
-        var inline = Environment.GetEnvironmentVariable("GAUNTLETCI_LICENSE_PUBLIC_KEY");
-        if (!string.IsNullOrWhiteSpace(inline))
-            return inline.Replace("\\n", "\n", StringComparison.Ordinal).Trim();
-
-        var keyFile = Environment.GetEnvironmentVariable("GAUNTLETCI_LICENSE_PUBLIC_KEY_FILE");
-        if (!string.IsNullOrWhiteSpace(keyFile) && File.Exists(keyFile))
+        if (IsDevLicenseMode())
         {
-            var pem = File.ReadAllText(keyFile).Trim();
-            if (!string.IsNullOrWhiteSpace(pem))
-                return pem;
+            var inline = Environment.GetEnvironmentVariable("GAUNTLETCI_LICENSE_PUBLIC_KEY");
+            if (!string.IsNullOrWhiteSpace(inline))
+                return inline.Replace("\\n", "\n", StringComparison.Ordinal).Trim();
+
+            var keyFile = Environment.GetEnvironmentVariable("GAUNTLETCI_LICENSE_PUBLIC_KEY_FILE");
+            if (!string.IsNullOrWhiteSpace(keyFile) && File.Exists(keyFile))
+            {
+                var pem = File.ReadAllText(keyFile).Trim();
+                if (!string.IsNullOrWhiteSpace(pem))
+                    return pem;
+            }
         }
 
         return EmbeddedPublicKey;
     }
+
+    internal static bool IsDevLicenseMode() =>
+        string.Equals(Environment.GetEnvironmentVariable("GAUNTLETCI_DEV"), "1", StringComparison.Ordinal);
 
     private static byte[] Base64UrlDecode(string input)
     {

--- a/src/GauntletCI.Tests/LicenseServiceTests.cs
+++ b/src/GauntletCI.Tests/LicenseServiceTests.cs
@@ -52,6 +52,7 @@ public class LicenseServiceTests
 
         try
         {
+            Environment.SetEnvironmentVariable("GAUNTLETCI_DEV", "1");
             Environment.SetEnvironmentVariable(publicKeyEnv, publicPem);
             Environment.SetEnvironmentVariable(licenseEnv, token);
 
@@ -65,6 +66,7 @@ public class LicenseServiceTests
         {
             Environment.SetEnvironmentVariable(licenseEnv, null);
             Environment.SetEnvironmentVariable(publicKeyEnv, null);
+            Environment.SetEnvironmentVariable("GAUNTLETCI_DEV", null);
         }
     }
 
@@ -81,6 +83,7 @@ public class LicenseServiceTests
 
         try
         {
+            Environment.SetEnvironmentVariable("GAUNTLETCI_DEV", "1");
             Environment.SetEnvironmentVariable(publicKeyFileEnv, keyPath);
             Environment.SetEnvironmentVariable(licenseEnv, token);
 
@@ -94,6 +97,7 @@ public class LicenseServiceTests
         {
             Environment.SetEnvironmentVariable(licenseEnv, null);
             Environment.SetEnvironmentVariable(publicKeyFileEnv, null);
+            Environment.SetEnvironmentVariable("GAUNTLETCI_DEV", null);
             if (File.Exists(keyPath))
                 File.Delete(keyPath);
         }

--- a/src/GauntletCI.Tests/NetworkLicenseValidatorTests.cs
+++ b/src/GauntletCI.Tests/NetworkLicenseValidatorTests.cs
@@ -55,15 +55,27 @@ public class NetworkLicenseValidatorTests : IDisposable
     }
 
     [Fact]
-    public async Task ValidateAsync_FailsOpenWhenNoCacheAndNetworkFails()
+    public async Task ValidateAsync_FailsClosedWhenNoCacheAndNetworkFails()
     {
         const string token = "test-token-no-cache";
         SimulateNetworkFailure();
 
         var result = await NetworkLicenseValidator.ValidateAsync(token);
 
-        Assert.True(result.Valid);
-        Assert.True(result.SkippedNetworkCheck);
+        Assert.False(result.Valid);
+        Assert.Equal("network_unreachable", result.Reason);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_IgnoresStaleCacheBeyondGracePeriod()
+    {
+        const string token = "test-token-expired-stale";
+        WriteStaleCache(token, valid: true, reason: null, age: TimeSpan.FromDays(5));
+
+        SimulateNetworkFailure();
+        var result = await NetworkLicenseValidator.ValidateAsync(token);
+
+        Assert.False(result.Valid);
     }
 
     [Fact]

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -75,8 +75,11 @@ async function handleLicenseStatus(request: Request, env: Env): Promise<Response
     return Response.json({ valid: false, reason: "subscription_cancelled", tier: "community" });
   }
 
-  // No KV record means the token was issued before KV was added -- trust the JWT.
-  return Response.json({ valid: true, tier: record?.tier ?? tier });
+  if (!record) {
+    return Response.json({ valid: false, reason: "subscription_not_found", tier: "community" });
+  }
+
+  return Response.json({ valid: true, tier: record.tier ?? tier });
 }
 
 // ---- KV helpers -------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `PaidFeatureGate` to block paid CLI features without a valid license
- Make `NetworkLicenseValidator` fail closed with 72h stale-cache grace and airgap support
- Gate `GAUNTLETCI_LICENSE_PUBLIC_KEY` override to `GAUNTLETCI_DEV=1`; require JWT `exp` in production
- Worker returns `subscription_not_found` when KV miss (no longer trusts JWT alone)

## Test plan
- [x] `dotnet test GauntletCI.slnx --configuration Release`
- [ ] CI green

Part 2 of 3 audit remediation split.