### PR TITLE
fix(docs-ci): case study rule IDs, hooks, security workflow, E2E Release

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,10 +30,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          failed=0
           while IFS= read -r project; do
             echo "Auditing $project"
-            dotnet list "$project" package --vulnerable --include-transitive
+            if dotnet list "$project" package --vulnerable --include-transitive | grep -q "has the following vulnerable packages"; then
+              echo "Vulnerable packages found in $project"
+              failed=1
+            fi
           done < <(find src -name '*.csproj' | sort)
+          exit $failed
 
   npm-audit:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: "true"
   fail-on-findings:
-    description: "Exit with code 1 if any findings are produced (fails the check)."
+    description: "When true (default), pass through GauntletCI's exit code. Block-severity findings fail by default (exitOn: Block); set exitOn to Warn in .gauntletci.json to also fail on warnings."
     required: false
     default: "true"
   inline-comments:

--- a/docs/features-benefits.md
+++ b/docs/features-benefits.md
@@ -175,7 +175,7 @@ Drop-in composite action with inputs for commit SHA, fail-on-findings, inline PR
 | GCI0003: Removed logic without tests | Return/throw removed from production code with no test diff | Multiple repos |
 | GCI0004: Breaking API change | Public method signatures changed or removed | Multiple repos |
 | GCI0006: Edge case handling | `OpenAsyncWriteStream(string path, ...)` added with no null guard on `path` | SharpCompress |
-| GCI0007: Breaking serialization change | `[JsonProperty]` / `[DataMember]` attributes removed from DTO | Multiple repos |
+| GCI0007: Error Handling Integrity | Swallowed exceptions or removed error logging in catch blocks | Multiple repos |
 | GCI0010: Hardcoded secret | `_secretKey = "secretkey"`: credential-like string literal in AWS signing code | aws-sdk-net |
 | GCI0012: Hardcoded secret | Password literal assigned in production code | Multiple repos |
 | GCI0015: Unchecked cast | `(int)input.Position`: `Stream.Position` is `long`; overflows for files >2 GB | SharpCompress |

--- a/site/app/articles/azure-sdk-pr-57223-risk-analysis/page.tsx
+++ b/site/app/articles/azure-sdk-pr-57223-risk-analysis/page.tsx
@@ -81,7 +81,7 @@ const jsonLd = {
 const findings = [
   {
     rule: "GCI0004",
-    title: "Public API Exposure",
+    title: "Breaking Change Risk",
     count: 3929,
     severity: "High",
     description: "Types or methods changed from internal to public visibility without proper versioning",
@@ -89,7 +89,7 @@ const findings = [
   },
   {
     rule: "GCI0003",
-    title: "Signature Changes",
+    title: "Behavioral Change Detection",
     count: 2723,
     severity: "Block",
     description: "Method signatures changed in ways that break callers. Parameters removed, types changed, defaults removed.",
@@ -97,7 +97,7 @@ const findings = [
   },
   {
     rule: "GCI0006",
-    title: "Null Dereference Risk",
+    title: "Edge Case Handling",
     count: 193,
     severity: "Warn",
     description: "New code paths access nullable values without null checks",
@@ -105,7 +105,7 @@ const findings = [
   },
   {
     rule: "GCI0024",
-    title: "Security - Dangerous APIs",
+    title: "Resource Lifecycle",
     count: 97,
     severity: "Block",
     description: "Unsafe reflection usage, dynamic code generation, or dangerous string operations",
@@ -113,7 +113,7 @@ const findings = [
   },
   {
     rule: "GCI0047",
-    title: "Resource Lifecycle Risk",
+    title: "Naming/Contract Alignment",
     count: 85,
     severity: "Warn",
     description: "Disposable resources created but not properly disposed in new code paths",
@@ -168,11 +168,11 @@ export default function AzureSDKAnalysisPage() {
                 </div>
                 <div className="bg-cyan-500/5 p-4 rounded border-l-4 border-cyan-500">
                   <div className="text-3xl font-bold text-cyan-500">3,929</div>
-                  <div className="text-sm text-muted-foreground">API Exposure Issues</div>
+                  <div className="text-sm text-muted-foreground">Breaking Change Risk</div>
                 </div>
                 <div className="bg-cyan-500/5 p-4 rounded border-l-4 border-cyan-500">
                   <div className="text-3xl font-bold text-cyan-500">2,723</div>
-                  <div className="text-sm text-muted-foreground">Signature Changes</div>
+                  <div className="text-sm text-muted-foreground">Behavioral Changes</div>
                 </div>
                 <div className="bg-cyan-500/5 p-4 rounded border-l-4 border-cyan-500">
                   <div className="text-3xl font-bold text-cyan-500">3</div>
@@ -212,7 +212,7 @@ export default function AzureSDKAnalysisPage() {
               <div className="mb-8 pb-8 border-b border-border">
                 <div className="flex items-start justify-between mb-3">
                   <div>
-                    <h3 className="text-xl font-bold">GCI0004 - Public API Exposure</h3>
+                    <h3 className="text-xl font-bold">GCI0004 - Breaking Change Risk</h3>
                     <p className="text-sm text-muted-foreground mt-1">Types or methods changed from internal to public visibility without proper versioning</p>
                   </div>
                   <div className="text-right">
@@ -228,7 +228,7 @@ export default function AzureSDKAnalysisPage() {
               <div className="mb-8 pb-8 border-b border-border">
                 <div className="flex items-start justify-between mb-3">
                   <div>
-                    <h3 className="text-xl font-bold">GCI0003 - Signature Changes</h3>
+                    <h3 className="text-xl font-bold">GCI0003 - Behavioral Change Detection</h3>
                     <p className="text-sm text-muted-foreground mt-1">Method signatures changed in ways that break callers. Parameters removed, types changed, defaults removed.</p>
                   </div>
                   <div className="text-right">
@@ -244,7 +244,7 @@ export default function AzureSDKAnalysisPage() {
               <div className="mb-8 pb-8 border-b border-border">
                 <div className="flex items-start justify-between mb-3">
                   <div>
-                    <h3 className="text-xl font-bold">GCI0006 - Null Dereference Risk</h3>
+                    <h3 className="text-xl font-bold">GCI0006 - Edge Case Handling</h3>
                     <p className="text-sm text-muted-foreground mt-1">New code paths access nullable values without null checks</p>
                   </div>
                   <div className="text-right">
@@ -260,7 +260,7 @@ export default function AzureSDKAnalysisPage() {
               <div className="mb-8 pb-8 border-b border-border">
                 <div className="flex items-start justify-between mb-3">
                   <div>
-                    <h3 className="text-xl font-bold">GCI0024 - Security - Dangerous APIs</h3>
+                    <h3 className="text-xl font-bold">GCI0024 - Resource Lifecycle</h3>
                     <p className="text-sm text-muted-foreground mt-1">Unsafe reflection usage, dynamic code generation, or dangerous string operations</p>
                   </div>
                   <div className="text-right">
@@ -276,7 +276,7 @@ export default function AzureSDKAnalysisPage() {
               <div className="mb-8 pb-8 border-b border-border last:border-b-0">
                 <div className="flex items-start justify-between mb-3">
                   <div>
-                    <h3 className="text-xl font-bold">GCI0047 - Resource Lifecycle Risk</h3>
+                    <h3 className="text-xl font-bold">GCI0047 - Naming/Contract Alignment</h3>
                     <p className="text-sm text-muted-foreground mt-1">Disposable resources created but not properly disposed in new code paths</p>
                   </div>
                   <div className="text-right">
@@ -293,7 +293,7 @@ export default function AzureSDKAnalysisPage() {
             <section className="mb-12">
               <h2 className="text-2xl font-bold mb-4">Deep Dive: The Top Two Categories</h2>
 
-              <h3 className="text-xl font-bold mb-3 mt-8">GCI0004 - API Exposure (3,929 unique findings)</h3>
+              <h3 className="text-xl font-bold mb-3 mt-8">GCI0004 - Breaking Change Risk (3,929 unique findings)</h3>
               <p className="mb-4">
                 More than 59% of the unique risk signals in this PR are categorized as API exposure violations. This means internal types, methods, or classes were promoted to public visibility.
               </p>
@@ -311,7 +311,7 @@ export default function AzureSDKAnalysisPage() {
                 Without behavioral analysis, this risk stays hidden until users upgrade and encounter breaking changes.
               </p>
 
-              <h3 className="text-xl font-bold mb-3 mt-8">GCI0003 - Signature Changes (2,723 unique findings)</h3>
+              <h3 className="text-xl font-bold mb-3 mt-8">GCI0003 - Behavioral Change Detection (2,723 unique findings)</h3>
               <p className="mb-4">
                 The second major category: method signatures changed in incompatible ways. This includes:
               </p>

--- a/site/app/articles/stackexchange-redis-pr-3028/page.tsx
+++ b/site/app/articles/stackexchange-redis-pr-3028/page.tsx
@@ -43,11 +43,11 @@ const jsonLd = {
 };
 
 const findings = [
-  { rule: "GCI0015", title: "Async/Await Pattern Changes", count: 671, severity: "High", description: "Async method implementation changes" },
-  { rule: "GCI0016", title: "Promise/Task Handling", count: 640, severity: "High", description: "Concurrent operation pattern changes" },
-  { rule: "GCI0003", title: "Signature Changes", count: 568, severity: "Block", description: "Breaking API changes" },
-  { rule: "GCI0004", title: "API Exposure", count: 447, severity: "High", description: "Visibility changes in public APIs" },
-  { rule: "GCI0006", title: "Null Dereference Risk", count: 381, severity: "Warn", description: "Nullable access without checks" },
+  { rule: "GCI0015", title: "Data Integrity Risk", count: 671, severity: "High", description: "Async method implementation changes" },
+  { rule: "GCI0016", title: "Async Concurrency Risk", count: 640, severity: "High", description: "Concurrent operation pattern changes" },
+  { rule: "GCI0003", title: "Behavioral Change Detection", count: 568, severity: "Block", description: "Breaking API changes" },
+  { rule: "GCI0004", title: "Breaking Change Risk", count: 447, severity: "High", description: "Visibility changes in public APIs" },
+  { rule: "GCI0006", title: "Edge Case Handling", count: 381, severity: "Warn", description: "Nullable access without checks" },
 ];
 
 const readingTime = "2 min read";
@@ -89,7 +89,7 @@ export default function RedisAnalysisPage() {
             </div>
             <div className="bg-red-500/5 p-4 rounded border-l-4 border-red-500">
               <div className="text-3xl font-bold text-red-500">568</div>
-              <div className="text-sm text-muted-foreground">Signature Changes</div>
+              <div className="text-sm text-muted-foreground">Behavioral Changes</div>
             </div>
           </div>
         </section>

--- a/site/app/detections/page.tsx
+++ b/site/app/detections/page.tsx
@@ -69,7 +69,7 @@ const detections = [
     finding: "GCI0004: Required parameter 'includeArchived' added to public method at line 1. Callers in external assemblies compiled against the old signature will throw MissingMethodException at runtime.",
   },
   {
-    id: "GCI0012",
+    id: "GCI0010",
     title: "Security: hardcoded connection string",
     severity: "High",
     category: "Security",

--- a/site/app/docs/integrations/github-action/page.tsx
+++ b/site/app/docs/integrations/github-action/page.tsx
@@ -194,7 +194,7 @@ export default function GithubActionPage() {
               <tbody className="divide-y divide-border">
                 {[
                   ["sensitivity", '"balanced"', "strict | balanced | permissive. Controls which confidence levels trigger findings."],
-                  ["fail-on-findings", '"true"', "Exit with code 1 when any findings are produced, failing the GitHub check."],
+                  ["fail-on-findings", '"true"', "Pass through GauntletCI exit code. Block-severity findings fail by default; set exitOn to Warn in .gauntletci.json to also fail on warnings."],
                   ["inline-comments", '"false"', "Post findings as inline PR review comments. Requires pull-requests: write."],
                   ["no-llm", '"true"', "Disable LLM enrichment. Recommended for CI - keeps the step deterministic and fast."],
                   ["ascii", '"true"', "Use ASCII-only output. Recommended for CI logs - avoids encoding issues."],

--- a/site/components/features-benefits.tsx
+++ b/site/components/features-benefits.tsx
@@ -31,7 +31,7 @@ const items = [
   {
     icon: GitPullRequestArrow,
     feature: "CI Gate with GitHub Inline Comments",
-    what: "A drop-in GitHub Actions composite action runs GauntletCI on every PR, fails the check if findings are produced, and posts findings as inline review comments directly on the diff.",
+    what: "A drop-in GitHub Actions composite action runs GauntletCI on every PR, fails the check on Block-severity findings by default (Warn severity with exitOn: Warn in .gauntletci.json), and posts findings as inline review comments directly on the diff.",
     benefit: "Risky changes can't merge unless reviewed or suppressed. Findings appear on the exact lines that triggered them, no separate report to read, no manual triage.",
   },
   {

--- a/src/GauntletCI.Cli/Hooks/gauntletci-hook.ps1
+++ b/src/GauntletCI.Cli/Hooks/gauntletci-hook.ps1
@@ -109,7 +109,8 @@ $gauntletci = Resolve-GauntletCiInvocation
 if ($null -eq $gauntletci) {
     Write-Host "GauntletCI not found. Install with: dotnet tool install -g GauntletCI" -ForegroundColor Yellow
     Write-Host "Or from this repo: ./scripts/install-gauntletci-global-tool.ps1" -ForegroundColor Yellow
-    exit 0
+    if ($env:GAUNTLETCI_HOOK_OPTIONAL -eq "1") { exit 0 }
+    exit 1
 }
 
 Write-Host "GauntletCI: Analyzing staged changes..." -ForegroundColor Cyan

--- a/src/GauntletCI.Cli/Hooks/gauntletci-hook.sh
+++ b/src/GauntletCI.Cli/Hooks/gauntletci-hook.sh
@@ -61,7 +61,10 @@ GAUNTLETCI_REPO_ROOT=""
 if ! resolve_gauntletci; then
     echo "GauntletCI not found. Install with: dotnet tool install -g GauntletCI"
     echo "Or from this repo: ./scripts/install-gauntletci-global-tool.ps1"
-    exit 0
+    if [ "${GAUNTLETCI_HOOK_OPTIONAL:-}" = "1" ]; then
+        exit 0
+    fi
+    exit 1
 fi
 
 echo "GauntletCI: Analyzing staged changes..."

--- a/src/GauntletCI.Cli/Output/HtmlWriter.cs
+++ b/src/GauntletCI.Cli/Output/HtmlWriter.cs
@@ -559,7 +559,7 @@ public static class HtmlWriter
                 </div>
                 <div class=""stat-card"">
                     <div class=""stat-label"">Rules Evaluated</div>
-                    <div class=""stat-value"">${data.RulesEvaluated || 34}</div>
+                    <div class=""stat-value"">${data.RulesEvaluated || 37}</div>
                 </div>
             `;
         }
@@ -728,7 +728,7 @@ public static class HtmlWriter
             const now = new Date().toLocaleString();
             footer.innerHTML = `
                 <p><a href=""https://github.com/gaunlet-ai/gauntletci"" target=""_blank"" style=""color: #667eea; text-decoration: none; font-weight: 600;"">GauntletCI Analysis Report</a> | Generated: ${now}</p>
-                <p style=""margin-top: 10px; font-size: 0.85em;"">Rules Evaluated: ${data.RulesEvaluated || 34} | Total Findings: ${(data.Findings || []).length}</p>
+                <p style=""margin-top: 10px; font-size: 0.85em;"">Rules Evaluated: ${data.RulesEvaluated || 37} | Total Findings: ${(data.Findings || []).length}</p>
             `;
         }
 

--- a/src/GauntletCI.Tests/EndToEndTests.cs
+++ b/src/GauntletCI.Tests/EndToEndTests.cs
@@ -33,9 +33,15 @@ public class EndToEndTests
 
     private static (string dll, bool skip) GetCliDll()
     {
-        var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
-            "../../../../GauntletCI.Cli/bin/Debug/net8.0/GauntletCI.Cli.dll"));
-        return (path, !File.Exists(path));
+        foreach (var configuration in new[] { "Release", "Debug" })
+        {
+            var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
+                $"../../../../GauntletCI.Cli/bin/{configuration}/net8.0/GauntletCI.Cli.dll"));
+            if (File.Exists(path))
+                return (path, false);
+        }
+
+        return (string.Empty, true);
     }
 
     private static async Task<(string stdout, string stderr, int exitCode)> RunCliAsync(


### PR DESCRIPTION
## Summary
- Fix incorrect GCI rule IDs on case studies and detections page
- Align fail-on-findings documentation across action.yml, docs, and site
- HtmlWriter fallback rule count 34 → 37
- Git hooks fail closed unless `GAUNTLETCI_HOOK_OPTIONAL=1`
- Security workflow fails on NuGet vulnerabilities
- E2E tests resolve CLI dll in Release CI builds

## Test plan
- [x] `dotnet test GauntletCI.slnx --configuration Release`
- [ ] CI green

Part 3 of 3 audit remediation split.