### PR TITLE
fix(licensing): tier gates for MCP, baseline, trace, and paid analyze features

### DIFF
--- a/src/GauntletCI.Cli/Baseline/BaselineStore.cs
+++ b/src/GauntletCI.Cli/Baseline/BaselineStore.cs
@@ -20,6 +20,9 @@ public static class BaselineStore
     /// <summary>Returns the absolute path to the baseline file for the given repo root.</summary>
     public static string GetPath(string repoRoot) => Path.Combine(repoRoot, FileName);
 
+    /// <summary>Returns true when a baseline file exists in the repository.</summary>
+    public static bool Exists(string repoRoot) => File.Exists(GetPath(repoRoot));
+
     // Strips a leading "Line N: " prefix from evidence so fingerprints survive line-number shifts
     private static readonly Regex LineNumberPrefixRegex = new(
         @"^Line \d+:\s*", RegexOptions.Compiled);

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -226,10 +226,26 @@ public static class AnalyzeCommand
                 if (ctx.ParseResult.FindResultFor(verboseFlag) is null)
                     verbose = config.Output.Verbose;
 
-                bool usingLicensedFeature = withLlm || withExpertCtx || ghPrComments || githubChecks;
+                notifySlack ??= config.Notifications.SlackWebhook;
+                notifyTeams ??= config.Notifications.TeamsWebhook;
+
+                var useBaseline = !noBaseline && BaselineStore.Exists(repo.FullName);
+                var engineeringPolicyWillRun =
+                    config.Experimental.EngineeringPolicy.Enabled && withLlm;
+                var requiredTier = PaidFeatureGate.ComputeAnalyzeRequiredTier(
+                    withLlm, withExpertCtx, ghPrComments, githubChecks,
+                    withTicketCtx, withCoverage,
+                    !string.IsNullOrWhiteSpace(notifySlack),
+                    !string.IsNullOrWhiteSpace(notifyTeams),
+                    useBaseline, engineeringPolicyWillRun);
+
                 var licenseEnvVar = config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE";
-                var licenseExit = await PaidFeatureGate.TryEnsureLicensedAsync(
-                    usingLicensedFeature, licenseEnvVar, ct);
+                var licenseExit = await PaidFeatureGate.TryEnsureTierAsync(
+                    requiredTier > LicenseTier.Community,
+                    requiredTier,
+                    "analyze with the selected options",
+                    licenseEnvVar,
+                    ct);
                 if (licenseExit is int exitCode)
                 {
                     ctx.ExitCode = exitCode;
@@ -253,10 +269,6 @@ public static class AnalyzeCommand
                     NoBanner = noBanner,
                     OutputFormat = output ?? "text",
                 });
-
-                // Notifications: CLI arg takes precedence, then config, then env var (handled downstream)
-                notifySlack ??= config.Notifications.SlackWebhook;
-                notifyTeams ??= config.Notifications.TeamsWebhook;
 
                 var ignoreList = IgnoreList.Load(repo.FullName);
                 var orchestrator = RuleOrchestrator.CreateDefault(config, repoPath: repo.FullName);

--- a/src/GauntletCI.Cli/Commands/BaselineCommand.cs
+++ b/src/GauntletCI.Cli/Commands/BaselineCommand.cs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.CommandLine;
 using GauntletCI.Cli.Baseline;
+using GauntletCI.Cli.Licensing;
 using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Licensing;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Rules;
 using GauntletCI.Core.StaticAnalysis;
@@ -78,6 +80,15 @@ public static class BaselineCommand
             try
             {
                 var config = ConfigLoader.Load(repo.FullName);
+                var licenseEnvVar = config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE";
+                var licenseExit = await PaidFeatureGate.TryEnsureTierAsync(
+                    LicenseTier.Pro, "baseline create", licenseEnvVar, ct);
+                if (licenseExit is int code)
+                {
+                    ctx.ExitCode = code;
+                    return;
+                }
+
                 var diff = diffFile is not null
                     ? DiffParser.FromFile(diffFile.FullName)
                     : commit is not null

--- a/src/GauntletCI.Cli/Commands/McpCommand.cs
+++ b/src/GauntletCI.Cli/Commands/McpCommand.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.CommandLine;
+using GauntletCI.Cli.Licensing;
 using GauntletCI.Cli.Mcp;
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Licensing;
 using GauntletCI.Llm;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -38,8 +41,21 @@ public static class McpCommand
 
         cmd.SetHandler(async (System.CommandLine.Invocation.InvocationContext ctx) =>
         {
+            var repoPath = ctx.ParseResult.GetValueForOption(repoOption);
             var ollamaModel = ctx.ParseResult.GetValueForOption(ollamaModelOption);
             var ollamaUrl = ctx.ParseResult.GetValueForOption(ollamaUrlOption)!;
+            var ct = ctx.GetCancellationToken();
+
+            var repoRoot = repoPath ?? Directory.GetCurrentDirectory();
+            var config = ConfigLoader.Load(repoRoot);
+            var licenseEnvVar = config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE";
+            var licenseExit = await PaidFeatureGate.TryEnsureTierAsync(
+                LicenseTier.Pro, "MCP server", licenseEnvVar, ct);
+            if (licenseExit is int code)
+            {
+                ctx.ExitCode = code;
+                return;
+            }
 
             if (ollamaModel is not null)
             {
@@ -64,7 +80,7 @@ public static class McpCommand
                 .WithStdioServerTransport()
                 .WithToolsFromAssembly(typeof(GauntletTools).Assembly);
 
-            await builder.Build().RunAsync(ctx.GetCancellationToken());
+            await builder.Build().RunAsync(ct);
         });
 
         return cmd;

--- a/src/GauntletCI.Cli/Commands/PostmortemCommand.cs
+++ b/src/GauntletCI.Cli/Commands/PostmortemCommand.cs
@@ -2,9 +2,11 @@
 using System.CommandLine;
 using System.Diagnostics;
 using System.Text.Json;
+using GauntletCI.Cli.Licensing;
 using GauntletCI.Cli.Output;
 using GauntletCI.Cli.Presentation;
 using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Licensing;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Rules;
 using Spectre.Console;
@@ -41,12 +43,22 @@ public static class PostmortemCommand
             var output = ctx.ParseResult.GetValueForOption(outputOption)!;
             var noBanner = ctx.ParseResult.GetValueForOption(noBannerOption);
             var ascii = ctx.ParseResult.GetValueForOption(asciiFlag);
+            var ct = ctx.GetCancellationToken();
 
             CliBanner.PrintIfEnabled(new BannerContext { NoBanner = noBanner, OutputFormat = output });
 
             try
             {
                 var config = ConfigLoader.Load(repo.FullName);
+                var licenseEnvVar = config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE";
+                var licenseExit = await PaidFeatureGate.TryEnsureTierAsync(
+                    LicenseTier.Enterprise, "postmortem", licenseEnvVar, ct);
+                if (licenseExit is int code)
+                {
+                    ctx.ExitCode = code;
+                    return;
+                }
+
                 var diff = await DiffParser.FromGitAsync(repo.FullName, commit, config.DiffContextLines);
                 var ignoreList = IgnoreList.Load(repo.FullName);
                 var orchestrator = RuleOrchestrator.CreateDefault(config);

--- a/src/GauntletCI.Cli/Commands/TraceCommand.cs
+++ b/src/GauntletCI.Cli/Commands/TraceCommand.cs
@@ -2,8 +2,10 @@
 using System.CommandLine;
 using System.Text;
 using GauntletCI.Cli.IncidentCorrelation;
+using GauntletCI.Cli.Licensing;
 using GauntletCI.Cli.Presentation;
 using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Licensing;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.Rules;
@@ -114,12 +116,21 @@ public static class TraceCommand
 
             try
             {
+                var config = ConfigLoader.Load(repo.FullName);
+                var licenseEnvVar = config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE";
+                var licenseExit = await PaidFeatureGate.TryEnsureTierAsync(
+                    LicenseTier.Enterprise, "trace", licenseEnvVar, ct);
+                if (licenseExit is int code)
+                {
+                    ctx.ExitCode = code;
+                    return;
+                }
+
                 var now = DateTimeOffset.UtcNow;
                 var sinceDto = IncidentClient.ParseSince(since, now);
 
                 // Step 1: get diff from base ref to HEAD using three-dot range
                 var rangeRef = $"{baseRef}...HEAD";
-                var config = ConfigLoader.Load(repo.FullName);
                 var diff = await DiffParser.FromGitAsync(repo.FullName, rangeRef, config.DiffContextLines, ct);
 
                 // Step 2: run rule orchestrator

--- a/src/GauntletCI.Cli/Licensing/NetworkLicenseValidator.cs
+++ b/src/GauntletCI.Cli/Licensing/NetworkLicenseValidator.cs
@@ -99,7 +99,7 @@ public static class NetworkLicenseValidator
     private static bool IsOfflineMode() =>
         string.Equals(Environment.GetEnvironmentVariable("GAUNTLETCI_OFFLINE"), "1", StringComparison.Ordinal);
 
-    private static bool IsEnterpriseAirGap() =>
+    internal static bool IsEnterpriseAirGap() =>
         string.Equals(Environment.GetEnvironmentVariable("GAUNTLETCI_ENTERPRISE_AIRGAP"), "1", StringComparison.Ordinal);
 
     private static bool IsStaleCacheWithinGrace(string token)

--- a/src/GauntletCI.Cli/Licensing/PaidFeatureGate.cs
+++ b/src/GauntletCI.Cli/Licensing/PaidFeatureGate.cs
@@ -4,15 +4,27 @@ using GauntletCI.Core.Licensing;
 namespace GauntletCI.Cli.Licensing;
 
 /// <summary>
-/// Enforces license requirements before paid CLI features run.
+/// Enforces license tier requirements before paid CLI features run.
 /// </summary>
 internal static class PaidFeatureGate
 {
     /// <summary>
     /// Returns an exit code when the caller must abort; null when execution may continue.
     /// </summary>
-    public static async Task<int?> TryEnsureLicensedAsync(
+    public static Task<int?> TryEnsureTierAsync(
+        LicenseTier minimumTier,
+        string featureLabel,
+        string licenseEnvVar,
+        CancellationToken ct = default) =>
+        TryEnsureTierAsync(minimumTier > LicenseTier.Community, minimumTier, featureLabel, licenseEnvVar, ct);
+
+    /// <summary>
+    /// Returns an exit code when the caller must abort; null when execution may continue.
+    /// </summary>
+    public static async Task<int?> TryEnsureTierAsync(
         bool usingLicensedFeature,
+        LicenseTier minimumTier,
+        string featureLabel,
         string licenseEnvVar,
         CancellationToken ct = default)
     {
@@ -20,10 +32,10 @@ internal static class PaidFeatureGate
             return null;
 
         var license = LicenseService.Load(licenseEnvVar);
-        if (!license.IsLicensed)
+        if (!license.HasTier(minimumTier))
         {
             Console.Error.WriteLine(
-                "[GauntletCI] A valid Pro-or-higher license is required for this feature. " +
+                $"[GauntletCI] A valid {TierLabel(minimumTier)} license is required for {featureLabel}. " +
                 "Set GAUNTLETCI_LICENSE or run: gauntletci license status");
             return 1;
         }
@@ -43,11 +55,61 @@ internal static class PaidFeatureGate
 
         if (netResult.SkippedNetworkCheck)
         {
-            Console.Error.WriteLine(
-                "[GauntletCI] Warning: Could not verify license subscription online. " +
-                "Set GAUNTLETCI_ENTERPRISE_AIRGAP=1 to suppress this warning in approved air-gap environments.");
+            if (NetworkLicenseValidator.IsEnterpriseAirGap() && license.HasTier(LicenseTier.Enterprise))
+            {
+                Console.Error.WriteLine(
+                    "[GauntletCI] Using enterprise air-gap offline license mode.");
+            }
+            else
+            {
+                Console.Error.WriteLine(
+                    "[GauntletCI] Could not verify license subscription online. " +
+                    "Renew network access or set GAUNTLETCI_ENTERPRISE_AIRGAP=1 with an Enterprise license.");
+                return 1;
+            }
         }
 
         return null;
     }
+
+    /// <summary>Legacy helper: Pro-or-higher with network validation.</summary>
+    public static Task<int?> TryEnsureLicensedAsync(
+        bool usingLicensedFeature,
+        string licenseEnvVar,
+        CancellationToken ct = default) =>
+        TryEnsureTierAsync(usingLicensedFeature, LicenseTier.Pro, "this feature", licenseEnvVar, ct);
+
+    internal static LicenseTier ComputeAnalyzeRequiredTier(
+        bool withLlm,
+        bool withExpertCtx,
+        bool ghPrComments,
+        bool githubChecks,
+        bool withTicketCtx,
+        bool withCoverage,
+        bool notifySlack,
+        bool notifyTeams,
+        bool useBaseline,
+        bool engineeringPolicyEnabled)
+    {
+        var tier = LicenseTier.Community;
+
+        if (withLlm || withExpertCtx || useBaseline)
+            tier = Max(tier, LicenseTier.Pro);
+
+        if (ghPrComments || githubChecks || withTicketCtx || withCoverage
+            || notifySlack || notifyTeams || engineeringPolicyEnabled)
+            tier = Max(tier, LicenseTier.Teams);
+
+        return tier;
+    }
+
+    private static LicenseTier Max(LicenseTier a, LicenseTier b) => a > b ? a : b;
+
+    private static string TierLabel(LicenseTier tier) => tier switch
+    {
+        LicenseTier.Pro => "Pro-or-higher",
+        LicenseTier.Teams => "Teams-or-higher",
+        LicenseTier.Enterprise => "Enterprise",
+        _ => "Pro-or-higher",
+    };
 }

--- a/src/GauntletCI.Cli/LlmDaemon/LlmEngineSelector.cs
+++ b/src/GauntletCI.Cli/LlmDaemon/LlmEngineSelector.cs
@@ -38,6 +38,15 @@ internal static class LlmEngineSelector
         var ollamaUrl = config.Corpus.OllamaEndpoints.FirstOrDefault(e => e.Enabled)?.Url;
         if (!string.IsNullOrWhiteSpace(ollamaUrl))
         {
+            var license = LicenseService.Load(config.Llm?.LicenseKeyEnv ?? "GAUNTLETCI_LICENSE");
+            if (!license.HasTier(LicenseTier.Pro))
+            {
+                return WarnAndSkip(
+                    "--with-llm was passed but no valid Pro license was found.",
+                    "Local Ollama LLM enrichment requires a GauntletCI Pro or higher license.",
+                    "Get a license at https://gauntletci.com/pricing");
+            }
+
             var endpoint = ollamaUrl.TrimEnd('/') + "/v1/chat/completions";
             if (!Uri.TryCreate(endpoint, UriKind.Absolute, out _))
             {

--- a/src/GauntletCI.Core/Licensing/LicenseService.cs
+++ b/src/GauntletCI.Core/Licensing/LicenseService.cs
@@ -130,6 +130,7 @@ public static class LicenseService
 
     private static string ResolvePublicKeyPem()
     {
+#if DEBUG
         if (IsDevLicenseMode())
         {
             var inline = Environment.GetEnvironmentVariable("GAUNTLETCI_LICENSE_PUBLIC_KEY");
@@ -144,6 +145,7 @@ public static class LicenseService
                     return pem;
             }
         }
+#endif
 
         return EmbeddedPublicKey;
     }

--- a/src/GauntletCI.Tests/LicenseServiceTests.cs
+++ b/src/GauntletCI.Tests/LicenseServiceTests.cs
@@ -41,6 +41,7 @@ public class LicenseServiceTests
         Assert.Equal(LicenseTier.Community, license.Tier);
     }
 
+#if DEBUG
     [Fact]
     public void Load_ValidToken_WithPublicKeyEnvOverride_AcceptsProTier()
     {
@@ -69,7 +70,9 @@ public class LicenseServiceTests
             Environment.SetEnvironmentVariable("GAUNTLETCI_DEV", null);
         }
     }
+#endif
 
+#if DEBUG
     [Fact]
     public void Load_ValidToken_WithPublicKeyFileOverride_AcceptsProTier()
     {
@@ -102,6 +105,7 @@ public class LicenseServiceTests
                 File.Delete(keyPath);
         }
     }
+#endif
 
     private static string SignTestJwt(RSA rsa, object payload)
     {


### PR DESCRIPTION
## Summary
- Expand PaidFeatureGate with Pro / Teams / Enterprise minimum tiers and network fail-closed (except Enterprise air-gap)
- Gate MCP serve, baseline create, trace, postmortem, and expanded analyze options (notifications, ticket context, coverage, baseline delta)
- Restrict GAUNTLETCI_DEV public-key override to Debug builds only
- Require Pro license for local Ollama LLM path

## Test plan
- [x] dotnet test GauntletCI.slnx --configuration Release
- [ ] CI green

Part 1 of 3 Round 3 audit remediation.