### PR TITLE
fix(security): harden outbound URLs, hooks, worker, and E2E strict mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: dotnet build GauntletCI.slnx --no-restore --configuration Release
 
       - name: Test
+        env:
+          GAUNTLETCI_E2E_STRICT: "1"
         run: dotnet test GauntletCI.slnx --no-build --configuration Release --verbosity normal
 
   update-badge:

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -274,7 +274,7 @@ public static class AnalyzeCommand
                 var orchestrator = RuleOrchestrator.CreateDefault(config, repoPath: repo.FullName);
 
                 // Run static analysis on changed C# files (null when no repo path or no .cs changes)
-                var repoPath = diffFile is null ? repo.FullName : null;
+                var repoPath = repo.FullName;
                 var sw = Stopwatch.StartNew();
                 var staticAnalysis = await StaticAnalysisRunner.RunAsync(diff, repoPath, ct);
 

--- a/src/GauntletCI.Cli/Hooks/gauntletci-hook.ps1
+++ b/src/GauntletCI.Cli/Hooks/gauntletci-hook.ps1
@@ -128,30 +128,30 @@ try {
 
     $result = $output | ConvertFrom-Json
 
-    # Confidence: 0=Low, 1=Medium, 2=High
-    $highFindings   = $result.Findings | Where-Object { $_.Confidence -eq 2 }
-    $mediumFindings = $result.Findings | Where-Object { $_.Confidence -eq 1 }
-    $lowFindings    = $result.Findings | Where-Object { $_.Confidence -eq 0 }
+    # Severity: 1=Info, 2=Warn, 3=Block
+    $blockFindings = $result.Findings | Where-Object { $_.Severity -eq 3 }
+    $warnFindings  = $result.Findings | Where-Object { $_.Severity -eq 2 }
+    $infoFindings  = $result.Findings | Where-Object { $_.Severity -eq 1 }
 
-    $total     = @($result.Findings).Count
-    $highCount = @($highFindings).Count
+    $total      = @($result.Findings).Count
+    $blockCount = @($blockFindings).Count
 
-    if ($highCount -gt 0) {
+    if ($blockCount -gt 0) {
         Write-Host ""
-        Write-Host "GauntletCI found $highCount high-confidence issue(s):" -ForegroundColor Red
-        foreach ($f in $highFindings) {
+        Write-Host "GauntletCI found $blockCount Block-severity issue(s):" -ForegroundColor Red
+        foreach ($f in $blockFindings) {
             Write-Host "  - [$($f.RuleId)] $($f.Summary)" -ForegroundColor Red
             Write-Host "    $($f.Evidence)" -ForegroundColor DarkRed
         }
         Write-Host ""
-        Write-Host "Commit aborted. Fix high-confidence issues or use --no-verify to bypass." -ForegroundColor Red
+        Write-Host "Commit aborted. Fix Block-severity issues or use --no-verify to bypass." -ForegroundColor Red
         exit 1
     }
     elseif ($total -gt 0) {
         Write-Host ""
-        Write-Host "GauntletCI found $total issue(s) (none high-confidence):" -ForegroundColor Yellow
-        foreach ($f in $result.Findings) {
-            $color = if ($f.Confidence -eq 1) { "Yellow" } else { "Gray" }
+        Write-Host "GauntletCI found $total issue(s) (Warn/Info only):" -ForegroundColor Yellow
+        foreach ($f in ($warnFindings + $infoFindings)) {
+            $color = if ($f.Severity -eq 2) { "Yellow" } else { "Gray" }
             Write-Host "  - [$($f.RuleId)] $($f.Summary)" -ForegroundColor $color
         }
         Write-Host ""

--- a/src/GauntletCI.Cli/Hooks/gauntletci-hook.sh
+++ b/src/GauntletCI.Cli/Hooks/gauntletci-hook.sh
@@ -75,45 +75,45 @@ if command -v jq &> /dev/null; then
     HAS_JQ=1
 fi
 
-# Run gauntletci — JSON output uses Confidence: 0=Low, 1=Medium, 2=High
+# Run gauntletci — JSON output uses Severity: 1=Info, 2=Warn, 3=Block
 OUTPUT=$(run_gauntletci analyze --staged --output json --no-banner 2>&1) || {
     echo "GauntletCI failed to run. Commit aborted."
     echo "$OUTPUT"
     exit 1
 }
 
-# Count findings by confidence level
+# Count findings by severity level
 if [ $HAS_JQ -eq 1 ]; then
-    HIGH_COUNT=$(echo "$OUTPUT" | jq '[.Findings[] | select(.Confidence == 2)] | length')
-    MEDIUM_COUNT=$(echo "$OUTPUT" | jq '[.Findings[] | select(.Confidence == 1)] | length')
-    LOW_COUNT=$(echo "$OUTPUT" | jq '[.Findings[] | select(.Confidence == 0)] | length')
+    BLOCK_COUNT=$(echo "$OUTPUT" | jq '[.Findings[] | select(.Severity == 3)] | length')
+    WARN_COUNT=$(echo "$OUTPUT" | jq '[.Findings[] | select(.Severity == 2)] | length')
+    INFO_COUNT=$(echo "$OUTPUT" | jq '[.Findings[] | select(.Severity == 1)] | length')
 else
-    HIGH_COUNT=$(echo "$OUTPUT" | grep -c '"Confidence": 2' || true)
-    MEDIUM_COUNT=$(echo "$OUTPUT" | grep -c '"Confidence": 1' || true)
-    LOW_COUNT=$(echo "$OUTPUT" | grep -c '"Confidence": 0' || true)
-    HIGH_COUNT="${HIGH_COUNT:-0}"
-    MEDIUM_COUNT="${MEDIUM_COUNT:-0}"
-    LOW_COUNT="${LOW_COUNT:-0}"
+    BLOCK_COUNT=$(echo "$OUTPUT" | grep -c '"Severity": 3' || true)
+    WARN_COUNT=$(echo "$OUTPUT" | grep -c '"Severity": 2' || true)
+    INFO_COUNT=$(echo "$OUTPUT" | grep -c '"Severity": 1' || true)
+    BLOCK_COUNT="${BLOCK_COUNT:-0}"
+    WARN_COUNT="${WARN_COUNT:-0}"
+    INFO_COUNT="${INFO_COUNT:-0}"
 fi
 
-TOTAL=$((HIGH_COUNT + MEDIUM_COUNT + LOW_COUNT))
+TOTAL=$((BLOCK_COUNT + WARN_COUNT + INFO_COUNT))
 
-if [ "$HIGH_COUNT" -gt 0 ]; then
+if [ "$BLOCK_COUNT" -gt 0 ]; then
     echo ""
-    echo "GauntletCI found $HIGH_COUNT high-confidence issue(s):"
+    echo "GauntletCI found $BLOCK_COUNT Block-severity issue(s):"
     if [ $HAS_JQ -eq 1 ]; then
-        echo "$OUTPUT" | jq -r '.Findings[] | select(.Confidence == 2) | "  • \u001b[31m[\(.RuleId)]\u001b[0m \(.Summary)\n    \(.Evidence)"'
+        echo "$OUTPUT" | jq -r '.Findings[] | select(.Severity == 3) | "  • \u001b[31m[\(.RuleId)]\u001b[0m \(.Summary)\n    \(.Evidence)"'
     else
-        echo "$OUTPUT" | grep -A 5 '"Confidence": 2' | head -30
+        echo "$OUTPUT" | grep -A 5 '"Severity": 3' | head -30
     fi
     echo ""
-    echo "Commit aborted. Fix high-confidence issues or use --no-verify to bypass."
+    echo "Commit aborted. Fix Block-severity issues or use --no-verify to bypass."
     exit 1
 elif [ "$TOTAL" -gt 0 ]; then
     echo ""
-    echo "GauntletCI found $TOTAL issue(s) (none high-confidence):"
+    echo "GauntletCI found $TOTAL issue(s) (Warn/Info only):"
     if [ $HAS_JQ -eq 1 ]; then
-        echo "$OUTPUT" | jq -r '.Findings[] | "  • [\(.RuleId)] \(.Summary)"'
+        echo "$OUTPUT" | jq -r '.Findings[] | select(.Severity == 2 or .Severity == 1) | "  • [\(.RuleId)] \(.Summary)"'
     else
         echo "$OUTPUT"
     fi

--- a/src/GauntletCI.Cli/Licensing/NetworkLicenseValidator.cs
+++ b/src/GauntletCI.Cli/Licensing/NetworkLicenseValidator.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using GauntletCI.Core;
+using GauntletCI.Core.Licensing;
 
 namespace GauntletCI.Cli.Licensing;
 
@@ -41,7 +42,7 @@ public static class NetworkLicenseValidator
     {
         if (IsOfflineMode())
         {
-            if (!IsEnterpriseAirGap())
+            if (!QualifiesForEnterpriseAirGap(token))
                 return new NetworkLicenseValidationResult(false, "offline_requires_enterprise_air_gap");
 
             return new NetworkLicenseValidationResult(true, null, SkippedNetworkCheck: true);
@@ -87,7 +88,7 @@ public static class NetworkLicenseValidator
             if (stale.HasValue && IsStaleCacheWithinGrace(token))
                 return new NetworkLicenseValidationResult(stale.Value.Valid, stale.Value.Reason);
 
-            if (IsEnterpriseAirGap())
+            if (QualifiesForEnterpriseAirGap(token))
                 return new NetworkLicenseValidationResult(true, null, SkippedNetworkCheck: true);
 
             return new NetworkLicenseValidationResult(false, "network_unreachable");
@@ -101,6 +102,15 @@ public static class NetworkLicenseValidator
 
     internal static bool IsEnterpriseAirGap() =>
         string.Equals(Environment.GetEnvironmentVariable("GAUNTLETCI_ENTERPRISE_AIRGAP"), "1", StringComparison.Ordinal);
+
+    private static bool QualifiesForEnterpriseAirGap(string token) =>
+        IsEnterpriseAirGap() && IsEnterpriseToken(token);
+
+    private static bool IsEnterpriseToken(string token)
+    {
+        var license = LicenseService.ParseToken(token);
+        return license.IsValid && license.Tier == LicenseTier.Enterprise;
+    }
 
     private static bool IsStaleCacheWithinGrace(string token)
     {

--- a/src/GauntletCI.Cli/LlmDaemon/LlmEngineSelector.cs
+++ b/src/GauntletCI.Cli/LlmDaemon/LlmEngineSelector.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 using GauntletCI.Core.Configuration;
 using GauntletCI.Core.Licensing;
+using GauntletCI.Core.Security;
 using GauntletCI.Llm;
 
 namespace GauntletCI.Cli.LlmDaemon;
@@ -105,6 +106,12 @@ internal static class LlmEngineSelector
                 $"--with-llm was passed but no API key was found in ${llmCfg.CiApiKeyEnv}.",
                 "A remote LLM endpoint is configured but the API key env var is missing.",
                 $"Set ${llmCfg.CiApiKeyEnv} in your pipeline secrets and retry.");
+
+        if (!OutboundUrlValidator.TryValidateHttpsUrl(llmCfg.CiEndpoint, out var endpointError))
+            return WarnAndSkip(
+                $"--with-llm was passed but 'llm.ciEndpoint' is not a valid outbound HTTPS URL: {endpointError}",
+                "Remote LLM endpoints must use HTTPS and must not target private or loopback hosts.",
+                "Set 'llm.ciEndpoint' to a public HTTPS OpenAI-compatible URL.");
 
         return new RemoteLlmEngine(llmCfg.CiEndpoint, llmCfg.CiModel, apiKey,
             llmCfg.NumCtx, llmCfg.MaxCompleteTokens);

--- a/src/GauntletCI.Cli/Output/SlackTeamsNotifier.cs
+++ b/src/GauntletCI.Cli/Output/SlackTeamsNotifier.cs
@@ -82,7 +82,7 @@ public static class SlackTeamsNotifier
             using var response = await _http.PostAsync(slackUrl, content, ct);
             if (!response.IsSuccessStatusCode)
             {
-                var body = await response.Content.ReadAsStringAsync(ct);
+                var body = TruncateForLog(await response.Content.ReadAsStringAsync(ct));
                 Console.Error.WriteLine($"[GauntletCI] Slack notification failed: {response.StatusCode}: {body}");
             }
         }
@@ -107,7 +107,7 @@ public static class SlackTeamsNotifier
             using var response = await _http.PostAsync(teamsUrl, content, ct);
             if (!response.IsSuccessStatusCode)
             {
-                var body = await response.Content.ReadAsStringAsync(ct);
+                var body = TruncateForLog(await response.Content.ReadAsStringAsync(ct));
                 Console.Error.WriteLine($"[GauntletCI] Teams notification failed: {response.StatusCode}: {body}");
             }
         }
@@ -196,5 +196,14 @@ public static class SlackTeamsNotifier
         }
 
         return null;
+    }
+
+    private static string TruncateForLog(string? body, int maxLen = 120)
+    {
+        if (string.IsNullOrEmpty(body))
+            return "(empty)";
+
+        var trimmed = body.Replace('\r', ' ').Replace('\n', ' ');
+        return trimmed.Length <= maxLen ? trimmed : trimmed[..maxLen] + "…";
     }
 }

--- a/src/GauntletCI.Cli/TicketProviders/JiraTicketProvider.cs
+++ b/src/GauntletCI.Cli/TicketProviders/JiraTicketProvider.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using GauntletCI.Core;
 using GauntletCI.Core.Model;
+using GauntletCI.Core.Security;
 namespace GauntletCI.Cli.TicketProviders;
 
 public sealed class JiraTicketProvider : ITicketProvider
@@ -14,23 +15,23 @@ public sealed class JiraTicketProvider : ITicketProvider
     public string ProviderName => "Jira";
 
     public bool IsAvailable =>
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JIRA_BASE_URL")) &&
+        TryGetValidatedBaseUrl(out _, out _) &&
         !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JIRA_API_TOKEN")) &&
         !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JIRA_USER_EMAIL"));
 
     public async Task<TicketInfo?> FetchAsync(string issueKey, CancellationToken ct = default)
     {
-        var baseUrl = Environment.GetEnvironmentVariable("JIRA_BASE_URL");
+        if (!TryGetValidatedBaseUrl(out var baseUrl, out _))
+            return null;
+
         var token = Environment.GetEnvironmentVariable("JIRA_API_TOKEN");
         var email = Environment.GetEnvironmentVariable("JIRA_USER_EMAIL");
 
-        if (string.IsNullOrEmpty(baseUrl) || string.IsNullOrEmpty(token) || string.IsNullOrEmpty(email))
-        {
-            return null;  // Not available
-        }
+        if (string.IsNullOrEmpty(token) || string.IsNullOrEmpty(email))
+            return null;
 
         var creds = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{email}:{token}"));
-        var cleanUrl = baseUrl.TrimEnd('/');
+        var cleanUrl = baseUrl!.TrimEnd('/');
 
         using var req = new HttpRequestMessage(HttpMethod.Get,
             $"{cleanUrl}/rest/api/3/issue/{issueKey}?fields=summary,description");
@@ -51,9 +52,15 @@ public sealed class JiraTicketProvider : ITicketProvider
             Id = issueKey,
             Title = summary ?? issueKey,
             Description = desc,
-            Url = $"{baseUrl}/browse/{issueKey}",
+            Url = $"{cleanUrl}/browse/{issueKey}",
             Provider = "Jira",
         };
+    }
+
+    internal static bool TryGetValidatedBaseUrl(out string? baseUrl, out string? error)
+    {
+        baseUrl = Environment.GetEnvironmentVariable("JIRA_BASE_URL");
+        return OutboundUrlValidator.TryValidateHttpsUrl(baseUrl, out error);
     }
 
     private static string? ExtractDescription(JsonElement fields)

--- a/src/GauntletCI.Core/Licensing/LicenseService.cs
+++ b/src/GauntletCI.Core/Licensing/LicenseService.cs
@@ -48,6 +48,11 @@ public static class LicenseService
     public static string? ReadRawToken(string envVarName = "GAUNTLETCI_LICENSE") =>
         ReadToken(envVarName);
 
+    /// <summary>
+    /// Parses a license JWT string without reading from env or disk.
+    /// </summary>
+    public static LicenseInfo ParseToken(string token) => Parse(token);
+
     private static string? ReadToken(string envVarName)
     {
         var envVal = Environment.GetEnvironmentVariable(envVarName);

--- a/src/GauntletCI.Core/Security/OutboundUrlValidator.cs
+++ b/src/GauntletCI.Core/Security/OutboundUrlValidator.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Elastic-2.0
+using System.Net;
+using System.Net.Sockets;
+
+namespace GauntletCI.Core.Security;
+
+/// <summary>
+/// Shared HTTPS URL validation for outbound requests. Blocks private, loopback, and link-local hosts.
+/// </summary>
+public static class OutboundUrlValidator
+{
+    /// <summary>
+    /// Returns true when <paramref name="url"/> is an absolute HTTPS URL with an allowed public host.
+    /// </summary>
+    public static bool TryValidateHttpsUrl(string? url, out string? error)
+    {
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            error = "URL is empty.";
+            return false;
+        }
+
+        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri))
+        {
+            error = "URL is not a valid absolute URI.";
+            return false;
+        }
+
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            error = "URL must use HTTPS.";
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            error = "URL must not contain embedded credentials.";
+            return false;
+        }
+
+        var host = uri.IdnHost.ToLowerInvariant();
+        if (IsBlockedHost(host))
+        {
+            error = "URL host is not allowed.";
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool IsBlockedHost(string host)
+    {
+        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (host.EndsWith(".local", StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith(".internal", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!IPAddress.TryParse(host, out var ip))
+            return false;
+
+        if (IPAddress.IsLoopback(ip))
+            return true;
+
+        if (ip.AddressFamily == AddressFamily.InterNetwork)
+            return IsBlockedIPv4(ip.GetAddressBytes());
+
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+            return IsBlockedIPv6(ip.GetAddressBytes());
+
+        return false;
+    }
+
+    private static bool IsBlockedIPv4(byte[] bytes)
+    {
+        if (bytes.All(static b => b == 0))
+            return true;
+
+        return bytes[0] switch
+        {
+            10 => true,
+            127 => true,
+            169 when bytes[1] == 254 => true,
+            172 when bytes[1] is >= 16 and <= 31 => true,
+            192 when bytes[1] == 168 => true,
+            _ => false,
+        };
+    }
+
+    private static bool IsBlockedIPv6(byte[] bytes)
+    {
+        if (bytes.All(static b => b == 0))
+            return true;
+
+        // fc00::/7 unique local
+        if ((bytes[0] & 0xfe) == 0xfc)
+            return true;
+
+        // fe80::/10 link-local
+        if (bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80)
+            return true;
+
+        return false;
+    }
+}

--- a/src/GauntletCI.Core/Security/WebhookUrlValidator.cs
+++ b/src/GauntletCI.Core/Security/WebhookUrlValidator.cs
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: Elastic-2.0
-using System.Net;
-
 namespace GauntletCI.Core.Security;
 
 /// <summary>
@@ -78,39 +76,10 @@ public static class WebhookUrlValidator
         Func<string, bool> hostAllowed,
         out string? error)
     {
-        error = null;
-
-        if (string.IsNullOrWhiteSpace(url))
-        {
-            error = "Webhook URL is empty.";
+        if (!OutboundUrlValidator.TryValidateHttpsUrl(url, out error))
             return false;
-        }
 
-        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri))
-        {
-            error = "Webhook URL is not a valid absolute URI.";
-            return false;
-        }
-
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            error = "Webhook URL must use HTTPS.";
-            return false;
-        }
-
-        if (!string.IsNullOrEmpty(uri.UserInfo))
-        {
-            error = "Webhook URL must not contain embedded credentials.";
-            return false;
-        }
-
-        var host = uri.IdnHost.ToLowerInvariant();
-        if (IsBlockedHost(host))
-        {
-            error = "Webhook URL host is not allowed.";
-            return false;
-        }
-
+        var host = new Uri(url!.Trim()).IdnHost.ToLowerInvariant();
         if (!hostAllowed(host))
         {
             error = "Webhook URL host is not an allowed notification endpoint.";
@@ -118,40 +87,5 @@ public static class WebhookUrlValidator
         }
 
         return true;
-    }
-
-    private static bool IsBlockedHost(string host)
-    {
-        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        if (host.EndsWith(".local", StringComparison.OrdinalIgnoreCase)
-            || host.EndsWith(".internal", StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        if (!IPAddress.TryParse(host, out var ip))
-            return false;
-
-        if (IPAddress.IsLoopback(ip))
-            return true;
-
-        if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
-        {
-            var bytes = ip.GetAddressBytes();
-            if (bytes.All(static b => b == 0))
-                return true;
-
-            return bytes[0] switch
-            {
-                10 => true,
-                127 => true,
-                169 when bytes[1] == 254 => true,
-                172 when bytes[1] is >= 16 and <= 31 => true,
-                192 when bytes[1] == 168 => true,
-                _ => false,
-            };
-        }
-
-        return false;
     }
 }

--- a/src/GauntletCI.Tests/EndToEndTests.cs
+++ b/src/GauntletCI.Tests/EndToEndTests.cs
@@ -35,10 +35,13 @@ public class EndToEndTests
     {
         foreach (var configuration in new[] { "Release", "Debug" })
         {
-            var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
-                $"../../../../GauntletCI.Cli/bin/{configuration}/net8.0/GauntletCI.Cli.dll"));
-            if (File.Exists(path))
-                return (path, false);
+            foreach (var assemblyName in new[] { "gauntletci.dll", "GauntletCI.Cli.dll" })
+            {
+                var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
+                    $"../../../../GauntletCI.Cli/bin/{configuration}/net8.0/{assemblyName}"));
+                if (File.Exists(path))
+                    return (path, false);
+            }
         }
 
         return (string.Empty, true);
@@ -71,6 +74,14 @@ public class EndToEndTests
         await Task.WhenAll(stdoutTask, stderrTask);
         await proc.WaitForExitAsync();
         return (stdoutTask.Result, stderrTask.Result, proc.ExitCode);
+    }
+
+    [Fact]
+    public void CliDll_MustExist_InReleaseBuilds()
+    {
+        var (_, skip) = GetCliDll();
+        if (string.Equals(Environment.GetEnvironmentVariable("GAUNTLETCI_E2E_STRICT"), "1", StringComparison.Ordinal))
+            Assert.False(skip, "CLI DLL not found at expected Release/Debug path. Build GauntletCI.Cli before running E2E tests.");
     }
 
     [Fact]

--- a/src/GauntletCI.Tests/OutboundUrlValidatorTests.cs
+++ b/src/GauntletCI.Tests/OutboundUrlValidatorTests.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Security;
+
+namespace GauntletCI.Tests;
+
+public class OutboundUrlValidatorTests
+{
+    [Theory]
+    [InlineData("https://api.example.com/v1/chat/completions")]
+    [InlineData("https://mycompany.atlassian.net")]
+    public void TryValidateHttpsUrl_AcceptsPublicHosts(string url)
+    {
+        Assert.True(OutboundUrlValidator.TryValidateHttpsUrl(url, out var error));
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData("http://api.example.com/path")]
+    [InlineData("https://127.0.0.1/path")]
+    [InlineData("https://169.254.169.254/latest/meta-data")]
+    [InlineData("https://10.0.0.1/internal")]
+    [InlineData("https://192.168.1.1/internal")]
+    [InlineData("https://localhost/path")]
+    [InlineData("https://[::1]/path")]
+    [InlineData("https://[fc00::1]/path")]
+    [InlineData("https://[fe80::1]/path")]
+    public void TryValidateHttpsUrl_RejectsUnsafeUrls(string url)
+    {
+        Assert.False(OutboundUrlValidator.TryValidateHttpsUrl(url, out var error));
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -41,7 +41,7 @@ export default {
       return handleLicenseStatus(request, env);
     }
 
-    if (request.method === "POST") {
+    if (request.method === "POST" && url.pathname === "/stripe/webhook") {
       return handleStripeWebhook(request, env);
     }
 
@@ -60,12 +60,20 @@ async function handleLicenseStatus(request: Request, env: Env): Promise<Response
 
   let email: string;
   let tier: string;
+  let exp: number | undefined;
   try {
     const publicKey = await importSPKI(env.GAUNTLETCI_PUBLIC_KEY, "RS256");
     const { payload } = await jwtVerify(token, publicKey, { issuer: "gauntletci.com" });
     email = payload["email"] as string;
     tier  = payload["tier"]  as string;
+    exp   = payload["exp"] as number | undefined;
     if (!email || !tier) throw new Error("missing claims");
+    if (typeof exp !== "number") {
+      return Response.json({ valid: false, reason: "missing_exp" }, { status: 401 });
+    }
+    if (exp <= Math.floor(Date.now() / 1000)) {
+      return Response.json({ valid: false, reason: "token_expired", tier: "community" }, { status: 401 });
+    }
   } catch {
     return Response.json({ valid: false, reason: "invalid_token" }, { status: 401 });
   }
@@ -250,10 +258,17 @@ function extractSessionEmail(session: Record<string, unknown>): string | undefin
 }
 
 function extractSessionPriceId(session: Record<string, unknown>): string | undefined {
-  return (
+  const fromLineItems = (
     (session["line_items"] as { data: { price: { id: string } }[] } | undefined)
       ?.data?.[0]?.price?.id
   );
+  if (fromLineItems) return fromLineItems;
+
+  const metadata = session["metadata"] as { price_id?: string } | undefined;
+  if (metadata?.price_id) return metadata.price_id;
+
+  const displayItems = session["display_items"] as { price?: { id: string } }[] | undefined;
+  return displayItems?.[0]?.price?.id;
 }
 
 function extractInvoicePriceId(invoice: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
## Summary
- Add `OutboundUrlValidator` and apply SSRF checks to webhooks, Jira, and LLM CI endpoints
- Fix `--diff` Roslyn analysis to always use full repo name
- Pre-commit hooks block on Block severity (not confidence-only)
- Enterprise air-gap requires Enterprise-tier token; worker JWT/exp and Stripe fixes
- E2E strict mode in CI (`GAUNTLETCI_E2E_STRICT=1`)

## Test plan
- [x] `dotnet test GauntletCI.slnx --configuration Release` (1705 passed)
- [ ] CI green
