### PR TITLE
fix(docs): correct Round 3 marketing and integration truth claims

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -13,4 +13,4 @@ RUN dotnet publish src/GauntletCI.Cli/GauntletCI.Cli.csproj \
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0 AS final
 WORKDIR /app
 COPY --from=build /app/publish .
-ENTRYPOINT ["/app/GauntletCI.Cli"]
+ENTRYPOINT ["/app/gauntletci"]

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,8 @@ runs:
         gauntletci $args 2>&1 | tee "$TMPFILE"
         EXIT_CODE=$?
         set +o pipefail
+        # Approximate count: grep lines matching GCI#### in CLI text output (not JSON-parsed).
+        # For exact counts, run gauntletci with --output json and parse the findings array.
         FINDINGS=$(grep -cE 'GCI[0-9]{4}' "$TMPFILE" 2>/dev/null || true)
         FINDINGS="${FINDINGS:-0}"
         rm -f "$TMPFILE"

--- a/docs/features-benefits.md
+++ b/docs/features-benefits.md
@@ -10,9 +10,9 @@ GauntletCI analyzes the exact lines added or removed in a pull request and flags
 
 ## Features
 
-### 34 Active Detection Rules (36 implementations)
+### 37 Active Detection Rules (39 implementations)
 
-GauntletCI ships **36** rule classes; **34** run by default. **GCI0054** and **GCI0055** are disabled (severity `None`) because **GCI0016** and **GCI0003** cover the same patterns with lower duplication.
+GauntletCI ships **39** rule classes; **37** run by default. **GCI0054** and **GCI0055** are disabled (severity `None`) because **GCI0016** and **GCI0003** cover the same patterns with lower duplication.
 
 #### Behavior & Contract Safety
 - Removed logic (return, throw, if/else, boolean operators) without matching test changes

--- a/site/app/articles/azure-sdk-pr-57223-risk-analysis/page.tsx
+++ b/site/app/articles/azure-sdk-pr-57223-risk-analysis/page.tsx
@@ -83,9 +83,9 @@ const findings = [
     rule: "GCI0004",
     title: "Breaking Change Risk",
     count: 3929,
-    severity: "High",
-    description: "Types or methods changed from internal to public visibility without proper versioning",
-    impact: "Exposes internal implementation details. Breaks encapsulation. Creates support burden for maintaining stable public API. Multiplied across 3 framework versions.",
+    severity: "Warn",
+    description: "[Obsolete] attribute added or removed on public APIs",
+    impact: "Signals active deprecation or stripped deprecation guards. Callers lose migration warnings and may depend on APIs scheduled for removal. Multiplied across 3 framework versions.",
   },
   {
     rule: "GCI0003",
@@ -107,17 +107,17 @@ const findings = [
     rule: "GCI0024",
     title: "Resource Lifecycle",
     count: 97,
-    severity: "Block",
-    description: "Unsafe reflection usage, dynamic code generation, or dangerous string operations",
-    impact: "Opens doors to injection attacks, code injection, or privilege escalation.",
+    severity: "Warn",
+    description: "Disposable resources allocated without using or try/finally disposal",
+    impact: "Memory leaks, file handle exhaustion, or connection pool depletion in production.",
   },
   {
     rule: "GCI0047",
     title: "Naming/Contract Alignment",
     count: 85,
-    severity: "Warn",
-    description: "Disposable resources created but not properly disposed in new code paths",
-    impact: "Memory leaks, file handle exhaustion, or connection pool depletion in production.",
+    severity: "Info",
+    description: "Method renames where the new CRUD verb contradicts the old behavior",
+    impact: "Callers see a new contract name but the implementation still performs the old action, hiding intent mismatches during review.",
   },
 ];
 
@@ -213,15 +213,15 @@ export default function AzureSDKAnalysisPage() {
                 <div className="flex items-start justify-between mb-3">
                   <div>
                     <h3 className="text-xl font-bold">GCI0004 - Breaking Change Risk</h3>
-                    <p className="text-sm text-muted-foreground mt-1">Types or methods changed from internal to public visibility without proper versioning</p>
+                    <p className="text-sm text-muted-foreground mt-1">[Obsolete] attribute added or removed on public APIs</p>
                   </div>
                   <div className="text-right">
                     <div className="text-2xl font-bold text-cyan-500">3,929</div>
-                    <div className="text-xs font-semibold px-2 py-1 rounded mt-1 inline-block whitespace-nowrap bg-orange-500/20 text-orange-400">High</div>
+                    <div className="text-xs font-semibold px-2 py-1 rounded mt-1 inline-block whitespace-nowrap bg-yellow-500/20 text-yellow-300">Warn</div>
                   </div>
                 </div>
                 <div className="bg-card/50 p-4 rounded">
-                  <p className="text-sm"><strong>Impact:</strong> Exposes internal implementation details. Breaks encapsulation. Creates support burden for maintaining stable public API. Multiplied across 3 framework versions.</p>
+                  <p className="text-sm"><strong>Impact:</strong> Signals active deprecation or stripped deprecation guards. Callers lose migration warnings and may depend on APIs scheduled for removal. Multiplied across 3 framework versions.</p>
                 </div>
               </div>
 
@@ -261,15 +261,15 @@ export default function AzureSDKAnalysisPage() {
                 <div className="flex items-start justify-between mb-3">
                   <div>
                     <h3 className="text-xl font-bold">GCI0024 - Resource Lifecycle</h3>
-                    <p className="text-sm text-muted-foreground mt-1">Unsafe reflection usage, dynamic code generation, or dangerous string operations</p>
+                    <p className="text-sm text-muted-foreground mt-1">Disposable resources allocated without using or try/finally disposal</p>
                   </div>
                   <div className="text-right">
                     <div className="text-2xl font-bold text-cyan-500">97</div>
-                    <div className="text-xs font-semibold px-2 py-1 rounded mt-1 inline-block whitespace-nowrap bg-red-500/20 text-red-400">Block</div>
+                    <div className="text-xs font-semibold px-2 py-1 rounded mt-1 inline-block whitespace-nowrap bg-yellow-500/20 text-yellow-300">Warn</div>
                   </div>
                 </div>
                 <div className="bg-card/50 p-4 rounded">
-                  <p className="text-sm"><strong>Impact:</strong> Opens doors to injection attacks, code injection, or privilege escalation.</p>
+                  <p className="text-sm"><strong>Impact:</strong> Memory leaks, file handle exhaustion, or connection pool depletion in production.</p>
                 </div>
               </div>
 
@@ -277,15 +277,15 @@ export default function AzureSDKAnalysisPage() {
                 <div className="flex items-start justify-between mb-3">
                   <div>
                     <h3 className="text-xl font-bold">GCI0047 - Naming/Contract Alignment</h3>
-                    <p className="text-sm text-muted-foreground mt-1">Disposable resources created but not properly disposed in new code paths</p>
+                    <p className="text-sm text-muted-foreground mt-1">Method renames where the new CRUD verb contradicts the old behavior</p>
                   </div>
                   <div className="text-right">
                     <div className="text-2xl font-bold text-cyan-500">85</div>
-                    <div className="text-xs font-semibold px-2 py-1 rounded mt-1 inline-block whitespace-nowrap bg-yellow-500/20 text-yellow-300">Warn</div>
+                    <div className="text-xs font-semibold px-2 py-1 rounded mt-1 inline-block whitespace-nowrap bg-blue-500/20 text-blue-300">Info</div>
                   </div>
                 </div>
                 <div className="bg-card/50 p-4 rounded">
-                  <p className="text-sm"><strong>Impact:</strong> Memory leaks, file handle exhaustion, or connection pool depletion in production.</p>
+                  <p className="text-sm"><strong>Impact:</strong> Callers see a new contract name but the implementation still performs the old action, hiding intent mismatches during review.</p>
                 </div>
               </div>
             </section>
@@ -295,17 +295,16 @@ export default function AzureSDKAnalysisPage() {
 
               <h3 className="text-xl font-bold mb-3 mt-8">GCI0004 - Breaking Change Risk (3,929 unique findings)</h3>
               <p className="mb-4">
-                More than 59% of the unique risk signals in this PR are categorized as API exposure violations. This means internal types, methods, or classes were promoted to public visibility.
+                More than 59% of the unique risk signals in this PR are [Obsolete] transitions on public APIs — active deprecations or removed deprecation guards.
               </p>
               <p className="mb-4">
                 In a library like Azure SDK, this is critical:
               </p>
               <ul className="list-disc list-inside space-y-2 mb-4">
-                <li>Users start depending on APIs that were meant to be internal</li>
-                <li>You can't refactor those internal details later without breaking downstream code</li>
-                <li>Support burden increases - you're now committed to maintaining public APIs</li>
-                <li>Version management becomes complex - did this change break compatibility?</li>
-                <li>Each change is multiplied by 3 because it affects .NET 10.0, 8.0, and .NET Standard 2.0 surfaces</li>
+                <li>Callers lose migration warnings when [Obsolete] guards are stripped</li>
+                <li>New [Obsolete] markers signal breaking removals that downstream teams must plan for</li>
+                <li>Deprecation messages must be accurate across .NET 10.0, 8.0, and .NET Standard 2.0 surfaces</li>
+                <li>Each transition is multiplied by 3 because it affects all three framework targets</li>
               </ul>
               <p className="mb-4">
                 Without behavioral analysis, this risk stays hidden until users upgrade and encounter breaking changes.

--- a/site/app/articles/corpus-report-2025/page.tsx
+++ b/site/app/articles/corpus-report-2025/page.tsx
@@ -66,15 +66,15 @@ const rawStats = [
 ];
 
 const topRules = [
-  ["GCI0004", "Public API exposure and visibility changes", "59,965"],
+  ["GCI0004", "[Obsolete] attribute transitions on public APIs", "59,965"],
   ["GCI0003", "Method signature and contract changes", "39,628"],
   ["GCI0006", "Null and edge-case handling changes", "10,978"],
-  ["GCI0015", "Exception-path changes", "10,389"],
+  ["GCI0015", "Data integrity and silent discard risks", "10,389"],
   ["GCI0016", "Async and deadlock candidates", "4,040"],
-  ["GCI0024", "Dangerous API usage", "3,435"],
-  ["GCI0010", "Thread-safety and concurrency risks", "3,225"],
+  ["GCI0024", "Resource lifecycle and undisposed disposables", "3,435"],
+  ["GCI0010", "Hardcoded secrets, URLs, and connection strings", "3,225"],
   ["GCI0001", "Mixed-scope or diff-integrity risk", "2,674"],
-  ["GCI0036", "Performance hot-path risks", "2,524"],
+  ["GCI0036", "Pure context mutation and side effects in getters", "2,524"],
   ["GCI0047", "Additional behavioral-change signals", "1,450"],
 ];
 

--- a/site/app/articles/stackexchange-redis-pr-3028/page.tsx
+++ b/site/app/articles/stackexchange-redis-pr-3028/page.tsx
@@ -43,10 +43,10 @@ const jsonLd = {
 };
 
 const findings = [
-  { rule: "GCI0015", title: "Data Integrity Risk", count: 671, severity: "High", description: "Async method implementation changes" },
-  { rule: "GCI0016", title: "Async Concurrency Risk", count: 640, severity: "High", description: "Concurrent operation pattern changes" },
-  { rule: "GCI0003", title: "Behavioral Change Detection", count: 568, severity: "Block", description: "Breaking API changes" },
-  { rule: "GCI0004", title: "Breaking Change Risk", count: 447, severity: "High", description: "Visibility changes in public APIs" },
+  { rule: "GCI0015", title: "Data Integrity Risk", count: 671, severity: "Block", description: "Unchecked casts, mass assignment, and silent SQL discard patterns" },
+  { rule: "GCI0016", title: "Concurrency and State Risk", count: 640, severity: "Block", description: "async void, blocking .Result/.Wait(), lock(this), and Thread.Sleep" },
+  { rule: "GCI0003", title: "Behavioral Change Detection", count: 568, severity: "Block", description: "Incompatible method signature and contract changes" },
+  { rule: "GCI0004", title: "Breaking Change Risk", count: 447, severity: "Warn", description: "[Obsolete] attribute added or removed on public APIs" },
   { rule: "GCI0006", title: "Edge Case Handling", count: 381, severity: "Warn", description: "Nullable access without checks" },
 ];
 

--- a/site/app/detections/page.tsx
+++ b/site/app/detections/page.tsx
@@ -15,18 +15,17 @@ export const metadata: Metadata = {
 const detections = [
   {
     id: "GCI0003",
-    title: "Behavioral change: removed null guard",
-    severity: "High",
+    title: "Behavioral change: incompatible method signature",
+    severity: "Block",
     category: "Behavioral Correctness",
     diff: [
-      { type: "context", line: "public async Task<Order> CreateOrderAsync(CreateOrderRequest request)" },
+      { type: "removed", line: "public IEnumerable<Product> GetProducts(int categoryId)" },
+      { type: "added", line: "public IEnumerable<Product> GetProducts(int categoryId, bool includeArchived)" },
       { type: "context", line: "{" },
-      { type: "removed", line: "    if (request is null) throw new ArgumentNullException(nameof(request));" },
-      { type: "context", line: "    var order = new Order(request.CustomerId, request.Items);" },
-      { type: "context", line: "    return await _repo.SaveAsync(order);" },
+      { type: "context", line: "    return _repo.Query(categoryId);" },
       { type: "context", line: "}" },
     ],
-    finding: "GCI0003: Guard clause removed at line 3 -- ArgumentNullException no longer thrown on null input. Callers relying on this contract will see NullReferenceException deeper in the call stack.",
+    finding: "GCI0003: Required parameter 'includeArchived' added to public method at line 1. Callers in external assemblies compiled against the old signature will throw MissingMethodException at runtime.",
   },
   {
     id: "GCI0029",
@@ -56,17 +55,16 @@ const detections = [
   },
   {
     id: "GCI0004",
-    title: "Breaking change: public method signature changed",
-    severity: "High",
+    title: "Breaking change: [Obsolete] guard removed",
+    severity: "Warn",
     category: "API Contracts",
     diff: [
-      { type: "removed", line: "public IEnumerable<Product> GetProducts(int categoryId)" },
-      { type: "added", line: "public IEnumerable<Product> GetProducts(int categoryId, bool includeArchived)" },
-      { type: "context", line: "{" },
-      { type: "context", line: "    return _repo.Query(categoryId);" },
-      { type: "context", line: "}" },
+      { type: "removed", line: '[Obsolete("Use GetOrderV2 instead. Removed in v3.")]' },
+      { type: "context", line: "public Task<Order> GetOrder(int id) => GetOrderV2(id);" },
+      { type: "context", line: "" },
+      { type: "added", line: "public Task<Order> GetOrder(int id) => _repo.FindAsync(id);" },
     ],
-    finding: "GCI0004: Required parameter 'includeArchived' added to public method at line 1. Callers in external assemblies compiled against the old signature will throw MissingMethodException at runtime.",
+    finding: "GCI0004: [Obsolete] attribute removed from public GetOrder at line 1. Callers lose the deprecation signal and may depend on an API scheduled for removal.",
   },
   {
     id: "GCI0010",
@@ -84,7 +82,7 @@ const detections = [
   {
     id: "GCI0007",
     title: "Error handling: exception swallowed silently",
-    severity: "Medium",
+    severity: "Block",
     category: "Error Handling",
     diff: [
       { type: "context", line: "try" },
@@ -102,7 +100,9 @@ const detections = [
 ];
 
 const severityColor: Record<string, string> = {
+  Block: "bg-red-500/10 text-red-400 border border-red-500/20",
   High: "bg-red-500/10 text-red-400 border border-red-500/20",
+  Warn: "bg-amber-500/10 text-amber-400 border border-amber-500/20",
   Medium: "bg-amber-500/10 text-amber-400 border border-amber-500/20",
   Low: "bg-blue-500/10 text-blue-400 border border-blue-500/20",
 };

--- a/site/app/docs/integrations/github-action/page.tsx
+++ b/site/app/docs/integrations/github-action/page.tsx
@@ -114,10 +114,15 @@ export default function GithubActionPage() {
             <pre className="text-foreground whitespace-pre">{MINIMAL_WORKFLOW}</pre>
           </div>
           <p className="text-sm text-muted-foreground mt-3">
-            This runs with all defaults: balanced sensitivity, findings fail the check, no inline
-            comments. To post findings as inline PR review comments, add{" "}
-            <code className="bg-muted px-1 rounded text-xs">pull-requests: write</code> and set{" "}
-            <code className="bg-muted px-1 rounded text-xs">inline-comments: &apos;true&apos;</code>.
+            This runs with all defaults: <code className="bg-muted px-1 rounded text-xs">sensitivity: balanced</code>{" "}
+            filters noise while keeping Block and Warn findings visible, and{" "}
+            <code className="bg-muted px-1 rounded text-xs">fail-on-findings: true</code> fails the
+            check only when GauntletCI exits non-zero — Block-severity findings by default (set{" "}
+            <code className="bg-muted px-1 rounded text-xs">exitOn: Warn</code> in{" "}
+            <code className="bg-muted px-1 rounded text-xs">.gauntletci.json</code> to also fail on
+            warnings). Inline comments are off unless enabled. To post findings as inline PR review
+            comments, add <code className="bg-muted px-1 rounded text-xs">pull-requests: write</code>{" "}
+            and set <code className="bg-muted px-1 rounded text-xs">inline-comments: &apos;true&apos;</code>.
           </p>
         </section>
 

--- a/site/app/docs/integrations/mcp/page.tsx
+++ b/site/app/docs/integrations/mcp/page.tsx
@@ -35,7 +35,7 @@ const faqSchema = buildFaqSchema([
   },
   {
     q: "What tools does the GauntletCI MCP server expose?",
-    a: "Three tools: analyze_commit returns findings as readable text, get_findings_json returns raw structured JSON for programmatic use, and get_sarif returns a SARIF 2.1.0 report compatible with GitHub Advanced Security and the VS Code SARIF viewer.",
+    a: "Five tools: analyze_staged, analyze_diff, analyze_commit, list_rules, and audit_stats. All analysis tools return structured JSON findings from the local CLI.",
   },
 ]);
 
@@ -106,9 +106,9 @@ export default function McpPage() {
             </a>{" "}
             is an open standard that lets AI assistants call external tools. The GauntletCI MCP
             server is a local Node.js process that listens on stdin/stdout. When your assistant
-            calls the <code className="bg-muted px-1 rounded text-xs">analyze_commit</code> tool,
-            the server runs <code className="bg-muted px-1 rounded text-xs">gauntletci analyze</code>{" "}
-            in the directory you specify and returns the findings as structured text.
+            calls an analysis tool such as <code className="bg-muted px-1 rounded text-xs">analyze_staged</code>{" "}
+            or <code className="bg-muted px-1 rounded text-xs">analyze_commit</code>, the server runs the
+            local GauntletCI CLI and returns findings as structured JSON.
           </p>
 
           {/* Architecture diagram mockup */}
@@ -238,19 +238,29 @@ export default function McpPage() {
               <tbody className="divide-y divide-border">
                 {[
                   [
+                    "analyze_staged",
+                    "Analyze staged changes in a git repository (pre-commit workflow).",
+                    "repo (optional, defaults to cwd)",
+                  ],
+                  [
+                    "analyze_diff",
+                    "Analyze a raw unified diff string.",
+                    "diff (required)",
+                  ],
+                  [
                     "analyze_commit",
-                    "Run GauntletCI on HEAD and return findings as readable structured text.",
-                    "workingDirectory (required), sensitivity (optional)",
+                    "Analyze a specific git commit in a repository.",
+                    "repo (required), commit (required)",
                   ],
                   [
-                    "get_findings_json",
-                    "Run GauntletCI and return the raw JSON result for programmatic processing.",
-                    "workingDirectory (required), sensitivity (optional)",
+                    "list_rules",
+                    "Return all available GauntletCI rules with id and name.",
+                    "none",
                   ],
                   [
-                    "get_sarif",
-                    "Run GauntletCI and return a SARIF 2.1.0 report for ingestion into GHAS or the VS Code SARIF viewer.",
-                    "workingDirectory (required)",
+                    "audit_stats",
+                    "Return aggregate scan statistics from the local audit log.",
+                    "none",
                   ],
                 ].map(([tool, desc, params]) => (
                   <tr key={tool}>
@@ -263,10 +273,13 @@ export default function McpPage() {
             </table>
           </div>
           <p className="text-sm text-muted-foreground mt-3">
-            The <code className="bg-muted px-1 rounded text-xs">sensitivity</code> parameter accepts{" "}
-            <code className="bg-muted px-1 rounded text-xs">strict</code>,{" "}
-            <code className="bg-muted px-1 rounded text-xs">balanced</code> (default), or{" "}
-            <code className="bg-muted px-1 rounded text-xs">permissive</code>.
+            Start the built-in MCP server with{" "}
+            <code className="bg-muted px-1 rounded text-xs">gauntletci mcp serve</code>. Pass{" "}
+            <code className="bg-muted px-1 rounded text-xs">--ollama-model</code> (and optionally{" "}
+            <code className="bg-muted px-1 rounded text-xs">--ollama-url</code>) to enable LLM
+            enrichment of high-confidence findings via a local or remote Ollama endpoint. Without{" "}
+            <code className="bg-muted px-1 rounded text-xs">--ollama-model</code>, analysis is
+            deterministic rules-only.
           </p>
         </section>
 

--- a/site/app/docs/integrations/page.tsx
+++ b/site/app/docs/integrations/page.tsx
@@ -286,11 +286,13 @@ steps:
     displayName: Analyze PR diff`}</pre>
         </div>
         <p className="mt-3 text-sm text-muted-foreground">
-          For inline pipeline annotations, use the{" "}
+          For inline pipeline annotations, see the{" "}
           <Link href="/docs/integrations/azure-devops" className="text-cyan-400 hover:underline">
-            Azure DevOps Marketplace task
+            Azure DevOps integration docs
           </Link>{" "}
-          instead, which emits <code className="bg-muted px-1 rounded text-xs">##vso</code> logging commands automatically.
+          for manual pipeline setup. A Marketplace task is coming soon; until then use the script
+          above or the manual steps on the Azure DevOps page, which emits{" "}
+          <code className="bg-muted px-1 rounded text-xs">##vso</code> logging commands when configured.
         </p>
       </section>
 
@@ -356,7 +358,7 @@ pipelines:
               </tr>
               <tr>
                 <td className="px-4 py-2 font-mono text-destructive">1</td>
-                <td className="px-4 py-2 text-sm text-muted-foreground">Findings detected</td>
+                <td className="px-4 py-2 text-sm text-muted-foreground">Blocking findings detected (Block by default; Warn when exitOn is Warn)</td>
                 <td className="px-4 py-2 text-sm text-destructive">Fail / block merge</td>
               </tr>
               <tr>

--- a/site/components/stats.tsx
+++ b/site/components/stats.tsx
@@ -24,12 +24,12 @@ const stats = [
   },
   {
     icon: ShieldCheck,
-    value: "30",
+    value: "37",
     label: "Detection rules",
     sub: "Across 7 risk categories.",
     color: "text-emerald-400",
     bg: "bg-emerald-500/10",
-    numericValue: 30,
+    numericValue: 37,
   },
   {
     icon: Lock,

--- a/site/lib/rules.ts
+++ b/site/lib/rules.ts
@@ -256,6 +256,22 @@ export const rules: Rule[] = [
     relatedIds: ["GCI0024", "GCI0039", "GCI0046"],
   },
   {
+    id: "GCI0019",
+    name: "Confidence and Evidence",
+    severity: "Info",
+    categorySlug: "quality",
+    description:
+      "Flags binary files that cannot be text-scanned and warns when large diffs produce no other findings.",
+    whyExists:
+      "Binary and very large diffs can hide real risk from text-based rules. This rule surfaces coverage gaps so reviewers know when manual inspection is required.",
+    example: {
+      language: "diff",
+      bad: "+ assets/logo.png (binary)\n+ src/Service.cs | 400 lines changed\n  // zero other rule hits",
+      good: "+ assets/logo.png (binary) — reviewed manually\n+ src/Service.cs changes paired with updated tests",
+    },
+    relatedIds: ["GCI0001", "GCI0041"],
+  },
+  {
     id: "GCI0021",
     name: "Data and Schema Compatibility",
     severity: "Block",
@@ -686,6 +702,38 @@ export const rules: Rule[] = [
       good: "+ var json = await File.ReadAllTextAsync(path, ct);",
     },
     relatedIds: ["GCI0016", "GCI0024"],
+  },
+  {
+    id: "GCI0058",
+    name: "Paired Implementation Consistency",
+    severity: "Block",
+    categorySlug: "behavior",
+    description:
+      "Compares sibling class implementations for opposite boolean polarity on the same predicate.",
+    whyExists:
+      "Parallel implementations of the same behavior with inverted predicates usually indicate a copy/paste logic bug rather than an intentional difference.",
+    example: {
+      language: "csharp",
+      bad: "+ // FooValidator and BarValidator disagree on the same IsActive check\n+ if (!user.IsActive) return;\n+ if (user.IsActive) return;",
+      good: "+ // Both validators use the same polarity or document why they differ",
+    },
+    relatedIds: ["GCI0003", "GCI0046"],
+  },
+  {
+    id: "GCI0059",
+    name: "Guard Deletion Remote Use",
+    severity: "Block",
+    categorySlug: "behavior",
+    description:
+      "Detects removed null or validation guards where the guarded symbol is still used later in the same method.",
+    whyExists:
+      "Deleting a guard while retaining downstream use reintroduces NullReferenceException or invalid-state paths that tests may not exercise.",
+    example: {
+      language: "csharp",
+      bad: "- if (order is null) throw new ArgumentNullException(nameof(order));\n  return order.Total;",
+      good: "- if (order is null) throw new ArgumentNullException(nameof(order));\n+ if (order is null) return 0;\n  return order.Total;",
+    },
+    relatedIds: ["GCI0003", "GCI0006", "GCI0007"],
   },
 ];
 


### PR DESCRIPTION
## Summary
- Fix Docker entrypoint, rule counts (37), GCI0004/GCI0003/GCI0007 marketing accuracy
- Correct MCP tool names, GitHub Action sensitivity docs, Azure DevOps coming-soon note
- Add missing rules GCI0019/GCI0058/GCI0059 to site registry

## Test plan
- [ ] CI green (docs/site validation)
