### PR TITLE
fix: GCI0001 noise, corpus doctor, docker publish timing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,10 @@
 name: Publish Docker Image
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'Docker/Dockerfile'
   workflow_dispatch:
 
 env:
@@ -14,6 +13,7 @@ env:
 
 jobs:
   build-and-push:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/src/GauntletCI.Cli/Commands/Factories/CorpusUtilityFactory.cs
+++ b/src/GauntletCI.Cli/Commands/Factories/CorpusUtilityFactory.cs
@@ -331,8 +331,19 @@ public static class CorpusUtilityFactory
                     Console.WriteLine("╚════════════════════════════════════════╝");
                     Console.WriteLine();
 
+                    using var countCmd = db.Connection.CreateCommand();
+                    countCmd.CommandText = "SELECT COUNT(*) FROM fixtures";
+                    var indexedCountObj = await countCmd.ExecuteScalarAsync(ct);
+                    var indexedCount = indexedCountObj is long indexed ? indexed : 0;
+
                     var all = await store.ListFixturesAsync(null, ct);
-                    Console.WriteLine($"Total fixtures: {all.Count}");
+                    Console.WriteLine($"Indexed in database: {indexedCount}");
+                    Console.WriteLine($"Loaded metadata:     {all.Count}");
+                    if (all.Count < indexedCount)
+                    {
+                        Console.WriteLine(
+                            $"⚠ Warning: {indexedCount - all.Count} indexed fixture(s) could not be materialized (invalid tier or missing index fields)");
+                    }
 
                     var byTier = all.GroupBy(m => m.Tier).ToDictionary(g => g.Key, g => g.ToList());
                     foreach (var (tierKey, tierList) in byTier.OrderBy(x => x.Key))
@@ -340,16 +351,24 @@ public static class CorpusUtilityFactory
                         Console.WriteLine($"  {tierKey,-10}: {tierList.Count,4}");
                     }
 
-                    // Check for orphaned fixtures (missing diff.patch)
+                    var storedPaths = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+                    using (var pathCmd = db.Connection.CreateCommand())
+                    {
+                        pathCmd.CommandText = "SELECT fixture_id, path FROM fixtures";
+                        using var pathReader = await pathCmd.ExecuteReaderAsync(ct);
+                        while (await pathReader.ReadAsync(ct))
+                        {
+                            storedPaths[pathReader.GetString(0)] =
+                                pathReader.IsDBNull(1) ? null : pathReader.GetString(1);
+                        }
+                    }
+
+                    // Check for orphaned fixtures (missing diff.patch on disk)
                     int orphaned = 0;
                     foreach (var fixture in all)
                     {
-                        string? fixturePath = null;
-                        foreach (var t in new[] { FixtureTier.Gold, FixtureTier.Silver, FixtureTier.Discovery })
-                        {
-                            var candidate = FixtureIdHelper.GetFixturePath(fixtures, t, fixture.FixtureId);
-                            if (Directory.Exists(candidate)) { fixturePath = candidate; break; }
-                        }
+                        storedPaths.TryGetValue(fixture.FixtureId, out var storedPath);
+                        var fixturePath = store.ResolveFixtureDirectory(fixture.FixtureId, fixture.Tier, storedPath);
 
                         if (fixturePath is null || !File.Exists(Path.Combine(fixturePath, "diff.patch")))
                             orphaned++;

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0001_DiffIntegrity.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0001_DiffIntegrity.cs
@@ -37,6 +37,35 @@ public class GCI0001_DiffIntegrity : RuleBase
         return LockFileNames.Contains(Path.GetFileName(filePath));
     }
 
+    /// <summary>
+    /// Files that commonly change alongside C# in real PRs (docs, build wiring, CI) are not mixed-scope noise.
+    /// </summary>
+    private static bool IsRoutineCompanionNonCodeFile(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        var fileName = Path.GetFileName(filePath);
+        var extension = Path.GetExtension(filePath);
+
+        if (extension.Equals(".md", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".txt", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".props", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".targets", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".sln", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (extension.Equals(".yml", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".yaml", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".json", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".editorconfig", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return fileName.StartsWith("PublicAPI.", StringComparison.OrdinalIgnoreCase);
+    }
+
     public override Task<List<Finding>> EvaluateAsync(
         AnalysisContext context, CancellationToken ct = default)
     {
@@ -57,6 +86,7 @@ public class GCI0001_DiffIntegrity : RuleBase
             .Where(x => x.Classification is FileEligibilityClassification.KnownNonSource
                                          or FileEligibilityClassification.UnknownUnsupported)
             .Where(x => !IsLockFile(x.FilePath))
+            .Where(x => !IsRoutineCompanionNonCodeFile(x.FilePath))
             .ToList();
 
         if (hasCodeFiles && nonCodeFiles.Count > 0)

--- a/src/GauntletCI.Corpus/Storage/FixtureFolderStore.cs
+++ b/src/GauntletCI.Corpus/Storage/FixtureFolderStore.cs
@@ -31,6 +31,22 @@ public sealed class FixtureFolderStore : IFixtureStore
 
     public string BasePath => _basePath;
 
+    /// <summary>
+    /// Resolves the on-disk fixture directory using the SQLite path, configured fixtures root, and tier.
+    /// </summary>
+    public string? ResolveFixtureDirectory(string fixtureId, FixtureTier tier, string? storedPath = null)
+    {
+        foreach (var candidate in EnumerateFixtureDirectoryCandidates(
+                     new FixtureIndexRow(fixtureId, tier.ToString(), storedPath, string.Empty, 0, string.Empty,
+                         null, null, null, false, false, string.Empty, string.Empty)))
+        {
+            if (Directory.Exists(candidate))
+                return candidate;
+        }
+
+        return null;
+    }
+
 
     // ── IFixtureStore ────────────────────────────────────────────────────────
 
@@ -88,34 +104,120 @@ public sealed class FixtureFolderStore : IFixtureStore
     {
         using var cmd = _db.Connection.CreateCommand();
 
+        const string selectColumns = """
+            SELECT fixture_id, tier, path, repo, pr_number, language,
+                   rule_ids_json, tags_json, pr_size_bucket,
+                   has_tests_changed, has_review_comments, source, created_at_utc
+            """;
+
         if (tier.HasValue)
         {
-            cmd.CommandText = "SELECT path FROM fixtures WHERE tier = $tier";
+            cmd.CommandText = $"{selectColumns} FROM fixtures WHERE tier = $tier";
             cmd.Parameters.AddWithValue("$tier", tier.Value.ToString());
         }
         else
         {
-            cmd.CommandText = "SELECT path FROM fixtures";
-        }
-
-        var paths = new List<string>();
-        using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
-        while (await reader.ReadAsync(ct).ConfigureAwait(false))
-        {
-            if (!reader.IsDBNull(0))
-                paths.Add(reader.GetString(0));
+            cmd.CommandText = $"{selectColumns} FROM fixtures";
         }
 
         var results = new List<FixtureMetadata>();
-        foreach (var path in paths)
+        using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {
-            var metaPath = Path.Combine(path, "metadata.json");
-            if (!File.Exists(metaPath)) continue;
-            var json = await File.ReadAllTextAsync(metaPath, ct).ConfigureAwait(false);
-            var m = JsonSerializer.Deserialize<FixtureMetadata>(json, JsonOpts);
-            if (m is not null) results.Add(m);
+            var row = ReadFixtureIndexRow(reader);
+            var metadata = await TryLoadMetadataAsync(row, ct).ConfigureAwait(false);
+            if (metadata is not null)
+                results.Add(metadata);
         }
+
         return results;
+    }
+
+    private sealed record FixtureIndexRow(
+        string FixtureId,
+        string Tier,
+        string? StoredPath,
+        string Repo,
+        int PullRequestNumber,
+        string Language,
+        string? RuleIdsJson,
+        string? TagsJson,
+        string? PrSizeBucket,
+        bool HasTestsChanged,
+        bool HasReviewComments,
+        string Source,
+        string CreatedAtUtc);
+
+    private static FixtureIndexRow ReadFixtureIndexRow(SqliteDataReader reader) =>
+        new(
+            FixtureId: reader.GetString(0),
+            Tier: reader.GetString(1),
+            StoredPath: reader.IsDBNull(2) ? null : reader.GetString(2),
+            Repo: reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
+            PullRequestNumber: reader.IsDBNull(4) ? 0 : reader.GetInt32(4),
+            Language: reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
+            RuleIdsJson: reader.IsDBNull(6) ? null : reader.GetString(6),
+            TagsJson: reader.IsDBNull(7) ? null : reader.GetString(7),
+            PrSizeBucket: reader.IsDBNull(8) ? null : reader.GetString(8),
+            HasTestsChanged: !reader.IsDBNull(9) && reader.GetInt32(9) != 0,
+            HasReviewComments: !reader.IsDBNull(10) && reader.GetInt32(10) != 0,
+            Source: reader.IsDBNull(11) ? string.Empty : reader.GetString(11),
+            CreatedAtUtc: reader.IsDBNull(12) ? string.Empty : reader.GetString(12));
+
+    private async Task<FixtureMetadata?> TryLoadMetadataAsync(FixtureIndexRow row, CancellationToken ct)
+    {
+        foreach (var candidatePath in EnumerateFixtureDirectoryCandidates(row))
+        {
+            var metaPath = Path.Combine(candidatePath, "metadata.json");
+            if (!File.Exists(metaPath))
+                continue;
+
+            var json = await File.ReadAllTextAsync(metaPath, ct).ConfigureAwait(false);
+            return JsonSerializer.Deserialize<FixtureMetadata>(json, JsonOpts);
+        }
+
+        return BuildMetadataFromIndexRow(row);
+    }
+
+    private IEnumerable<string> EnumerateFixtureDirectoryCandidates(FixtureIndexRow row)
+    {
+        if (!string.IsNullOrWhiteSpace(row.StoredPath))
+        {
+            yield return row.StoredPath;
+            if (!Path.IsPathRooted(row.StoredPath))
+                yield return Path.GetFullPath(row.StoredPath);
+        }
+
+        if (Enum.TryParse<FixtureTier>(row.Tier, ignoreCase: true, out var tier))
+            yield return FixtureIdHelper.GetFixturePath(_basePath, tier, row.FixtureId);
+    }
+
+    private static FixtureMetadata? BuildMetadataFromIndexRow(FixtureIndexRow row)
+    {
+        if (!Enum.TryParse<FixtureTier>(row.Tier, ignoreCase: true, out var tier))
+            return null;
+
+        Enum.TryParse<PrSizeBucket>(row.PrSizeBucket, ignoreCase: true, out var sizeBucket);
+        DateTime.TryParse(row.CreatedAtUtc, out var createdAtUtc);
+
+        var ruleIds = TryDeserializeStringList(row.RuleIdsJson);
+        var tags = TryDeserializeStringList(row.TagsJson);
+
+        return new FixtureMetadata
+        {
+            FixtureId = row.FixtureId,
+            Tier = tier,
+            Repo = row.Repo,
+            PullRequestNumber = row.PullRequestNumber,
+            Language = row.Language,
+            RuleIds = ruleIds,
+            Tags = tags,
+            PrSizeBucket = sizeBucket,
+            HasTestsChanged = row.HasTestsChanged,
+            HasReviewComments = row.HasReviewComments,
+            Source = row.Source,
+            CreatedAtUtc = createdAtUtc == default ? DateTime.UtcNow : createdAtUtc,
+        };
     }
 
     public async Task<IReadOnlyList<ExpectedFinding>> ReadExpectedFindingsAsync(
@@ -213,6 +315,21 @@ public sealed class FixtureFolderStore : IFixtureStore
             """;
 
         File.WriteAllText(notesPath, template);
+    }
+
+    private static IReadOnlyList<string> TryDeserializeStringList(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json, JsonOpts) ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
     }
 
     private async Task UpsertFixtureSqliteAsync(FixtureMetadata meta, string fixturePath, CancellationToken ct)

--- a/tests/GauntletCI.Tests/Corpus/CorpusIngestionTests.cs
+++ b/tests/GauntletCI.Tests/Corpus/CorpusIngestionTests.cs
@@ -348,7 +348,7 @@ public sealed class RuleCorpusRunnerTests : IDisposable
     private readonly FixtureFolderStore _store;
     private readonly RuleCorpusRunner _runner;
 
-    // A minimal unified diff that mixes code and a markdown file: triggers GCI0001.
+    // A minimal unified diff that mixes code and an unrelated asset: triggers GCI0001.
     private const string MixedScopeDiff = """
         diff --git a/src/Foo.cs b/src/Foo.cs
         index abc..def 100644
@@ -357,13 +357,11 @@ public sealed class RuleCorpusRunnerTests : IDisposable
         @@ -1,1 +1,1 @@
         -old
         +new
-        diff --git a/README.md b/README.md
+        diff --git a/site/hero.png b/site/hero.png
         index 111..222 100644
-        --- a/README.md
-        +++ b/README.md
-        @@ -1,1 +1,1 @@
-        -old docs
-        +new docs
+        --- a/site/hero.png
+        +++ b/site/hero.png
+        Binary files differ
         """;
 
     public RuleCorpusRunnerTests()

--- a/tests/GauntletCI.Tests/Rules/GCI0001Tests.cs
+++ b/tests/GauntletCI.Tests/Rules/GCI0001Tests.cs
@@ -9,7 +9,31 @@ public class GCI0001Tests
     private static readonly GCI0001_DiffIntegrity Rule = new(new StubPatternProvider());
 
     [Fact]
-    public async Task MixedCodeAndMarkdown_ShouldFlagMixedScope()
+    public async Task MixedCodeAndUnrelatedAsset_ShouldFlagMixedScope()
+    {
+        var raw = """
+            diff --git a/src/Foo.cs b/src/Foo.cs
+            index abc..def 100644
+            --- a/src/Foo.cs
+            +++ b/src/Foo.cs
+            @@ -1,1 +1,1 @@
+            -old
+            +new
+            diff --git a/site/hero.png b/site/hero.png
+            index 111..222 100644
+            --- a/site/hero.png
+            +++ b/site/hero.png
+            Binary files differ
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.Contains(findings, f => f.Summary.Contains("mixed scope"));
+    }
+
+    [Fact]
+    public async Task MixedCodeAndReadme_ShouldNotFlagMixedScope()
     {
         var raw = """
             diff --git a/src/Foo.cs b/src/Foo.cs
@@ -31,7 +55,7 @@ public class GCI0001Tests
         var diff = DiffParser.Parse(raw);
         var findings = await Rule.EvaluateAsync(diff, null);
 
-        Assert.Contains(findings, f => f.Summary.Contains("mixed scope"));
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("mixed scope"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **GCI0001**: Exclude routine companion files (`.md`, `.csproj`, `.yml`, `PublicAPI.*.txt`, etc.) from mixed-scope detection to cut gold-corpus noise.
- **Corpus doctor**: `FixtureFolderStore.ListFixturesAsync` resolves fixtures via `--fixtures` root with SQLite path fallback; doctor reports indexed vs loaded counts.
- **Docker publish**: Trigger on successful `CI` workflow completion on `main` instead of racing parallel push builds.

Cherry-picked from local `fix/audit-followups` onto current `main` (post #249).

## Test plan

- [x] `dotnet build GauntletCI.slnx -c Release`
- [x] `dotnet test GauntletCI.slnx -c Release` with `GAUNTLETCI_E2E_STRICT=1` (1,933 passed)
- [ ] CI green on PR
