### PR TITLE
fix(audit): doctor tiers, CI self-analysis gate, GCI0001 resweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,15 @@ jobs:
           GAUNTLETCI_LICENSE: ${{ secrets.GAUNTLETCI_LICENSE }}
           GAUNTLETCI_PR_NUMBER: ${{ github.event.pull_request.number }}
           GAUNTLETCI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-        run: >
-          dotnet run --project src/GauntletCI.Cli --no-build --configuration Release --
-          analyze --no-banner --ascii --github-annotations --pr-comment-suggest --repo . --severity warn --sensitivity balanced --no-baseline < pr.diff
+        run: |
+          set -o pipefail
+          set +e
+          dotnet run --project src/GauntletCI.Cli --no-build --configuration Release -- \
+            analyze --no-banner --ascii --github-annotations --pr-comment-suggest --repo . \
+            --severity warn --sensitivity balanced --no-baseline < pr.diff
+          exit_code=$?
+          set -e
+          if [ "$exit_code" -ne 0 ]; then
+            echo "::error::GauntletCI self-analysis reported block-level findings (exit $exit_code). See annotations and PR comments."
+            exit "$exit_code"
+          fi

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -219,6 +219,43 @@ GauntletCI exits with code 1 when high-severity findings are present and `fail-o
 
 ---
 
+## Licensing (offline / air-gapped)
+
+### Network unreachable with a valid license
+
+GauntletCI caches license status for 24 hours. If the network is down and no fresh cache exists, validation fails closed unless you qualify for enterprise air-gap mode.
+
+**Enterprise air-gap (no network call):**
+
+```bash
+export GAUNTLETCI_ENTERPRISE_AIRGAP=1
+export GAUNTLETCI_OFFLINE=1
+export GAUNTLETCI_LICENSE="<enterprise-jwt>"
+gauntletci license status --offline
+```
+
+Requirements (all must hold):
+
+- License JWT tier is **Enterprise**
+- `GAUNTLETCI_ENTERPRISE_AIRGAP=1` is set
+- `GAUNTLETCI_OFFLINE=1` skips the remote status call entirely
+
+**Stale cache grace:** when the network fails but a prior successful cache exists for the same token, GauntletCI reuses it for up to **72 hours**.
+
+Non-enterprise tokens cannot use offline mode; fix network access or refresh cache while online.
+
+### `corpus doctor` shows fewer fixtures than indexed
+
+If SQLite lists fixtures with tier `unknown` (or other invalid values), they are indexed but not materialized. Run:
+
+```bash
+gauntletci corpus doctor --db ~/.gauntletci/corpus.db --fixtures ./data/fixtures --verbose
+```
+
+Invalid-tier fixture IDs print under `--verbose`. Re-hydrate or delete stale index rows, or set tier to `Discovery` before normalization.
+
+---
+
 ## Still stuck?
 
 Open an issue on GitHub with:

--- a/eval/reports/gci0001-resweep.json
+++ b/eval/reports/gci0001-resweep.json
@@ -1,0 +1,8 @@
+{
+  "prior_gci0001_fixture_count": 40,
+  "still_fires_gci0001": 15,
+  "resolved_noise_reduction": 25,
+  "missing_diff": 0,
+  "not_in_gold_suite": 0,
+  "prior_report_gci0001_total": 171
+}

--- a/scripts/resweep-gci0001-gold.py
+++ b/scripts/resweep-gci0001-gold.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Re-count GCI0001 on gold fixtures that fired before the companion-file fix."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+REPORT = REPO / "eval" / "reports" / "gold-noise-sweep.json"
+OUT = REPO / "eval" / "reports" / "gci0001-resweep.json"
+
+sys.path.insert(0, str(REPO / "scripts"))
+from benchmark_lib import REPO as _REPO, load_suite, resolve_diff, suite_fixtures  # noqa: E402
+
+assert _REPO == REPO
+
+
+def prior_gci0001_fixtures() -> list[str]:
+    if not REPORT.exists():
+        return []
+    data = json.loads(REPORT.read_text(encoding="utf-8-sig"))
+    out: list[str] = []
+    for m in data.get("fixtures_by_sensitivity", {}).get("balanced", []):
+        if m.get("rule_histogram", {}).get("GCI0001", 0) > 0:
+            out.append(m["fixture_id"])
+    return out
+
+
+def analyze_gci0001(entry: dict) -> bool:
+    diff = resolve_diff(entry)
+    if not diff:
+        return False
+    proc = subprocess.run(
+        [
+            "dotnet",
+            "run",
+            "--project",
+            str(REPO / "src/GauntletCI.Cli"),
+            "--no-build",
+            "-c",
+            "Release",
+            "--",
+            "analyze",
+            "--diff",
+            str(diff),
+            "--output",
+            "json",
+            "--sensitivity",
+            "balanced",
+            "--no-banner",
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode not in (0, 1):
+        return False
+    try:
+        doc = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return False
+    return any(f.get("RuleId") == "GCI0001" for f in doc.get("Findings") or [])
+
+
+def main() -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Re-count GCI0001 on prior gold noise hits")
+    ap.add_argument("--limit", type=int, default=0, help="Max fixtures to re-run (0 = all)")
+    args = ap.parse_args()
+
+    suite = load_suite()
+    gold = {e["fixture_id"]: e for e in suite_fixtures(suite, tier="gold")}
+    targets = prior_gci0001_fixtures()
+    if not targets:
+        print("No prior GCI0001 hits in gold-noise-sweep.json; run full sweep first.")
+        raise SystemExit(0)
+    if args.limit > 0:
+        targets = targets[: args.limit]
+
+    fired = 0
+    missing_diff = 0
+    errors = 0
+    for fid in targets:
+        entry = gold.get(fid)
+        if not entry:
+            errors += 1
+            print(f"skip {fid}: not in gold suite")
+            continue
+        if not resolve_diff(entry):
+            missing_diff += 1
+            print(f"skip {fid}: no diff")
+            continue
+        hits = analyze_gci0001(entry)
+        if hits:
+            fired += 1
+        print(f"{'GCI0001' if hits else 'ok'} {fid}")
+
+    summary = {
+        "prior_gci0001_fixture_count": len(targets),
+        "still_fires_gci0001": fired,
+        "resolved_noise_reduction": len(targets) - fired - missing_diff - errors,
+        "missing_diff": missing_diff,
+        "not_in_gold_suite": errors,
+        "prior_report_gci0001_total": 171,
+    }
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/GauntletCI.Cli/Commands/Factories/CorpusUtilityFactory.cs
+++ b/src/GauntletCI.Cli/Commands/Factories/CorpusUtilityFactory.cs
@@ -339,10 +339,39 @@ public static class CorpusUtilityFactory
                     var all = await store.ListFixturesAsync(null, ct);
                     Console.WriteLine($"Indexed in database: {indexedCount}");
                     Console.WriteLine($"Loaded metadata:     {all.Count}");
-                    if (all.Count < indexedCount)
+
+                    var invalidTierIds = new List<string>();
+                    using (var tierCmd = db.Connection.CreateCommand())
+                    {
+                        tierCmd.CommandText = """
+                            SELECT fixture_id, tier
+                            FROM fixtures
+                            WHERE tier IS NULL
+                               OR tier = ''
+                               OR lower(tier) NOT IN ('discovery', 'silver', 'gold')
+                            ORDER BY fixture_id
+                            """;
+                        using var tierReader = await tierCmd.ExecuteReaderAsync(ct);
+                        while (await tierReader.ReadAsync(ct))
+                        {
+                            invalidTierIds.Add(tierReader.GetString(0));
+                        }
+                    }
+
+                    if (invalidTierIds.Count > 0)
                     {
                         Console.WriteLine(
-                            $"⚠ Warning: {indexedCount - all.Count} indexed fixture(s) could not be materialized (invalid tier or missing index fields)");
+                            $"⚠ Warning: {invalidTierIds.Count} indexed fixture(s) have invalid tier values (not Discovery/Silver/Gold)");
+                        if (verbose)
+                        {
+                            foreach (var fixtureId in invalidTierIds)
+                                Console.WriteLine($"    {fixtureId}");
+                        }
+                    }
+                    else if (all.Count < indexedCount)
+                    {
+                        Console.WriteLine(
+                            $"⚠ Warning: {indexedCount - all.Count} indexed fixture(s) could not be materialized (missing index fields)");
                     }
 
                     var byTier = all.GroupBy(m => m.Tier).ToDictionary(g => g.Key, g => g.ToList());


### PR DESCRIPTION
## Summary

- **Corpus doctor**: surfaces invalid-tier index rows (`unknown`, etc.) with optional `--verbose` ID list (22 stubs in agent corpus are MassTransit/Prowlarr/Radarr/Sonarr/bitwarden index-only rows).
- **CI self-analysis**: PR job now fails when `gauntletci analyze` exits non-zero (block-level findings under balanced sensitivity).
- **GCI0001 validation**: `scripts/resweep-gci0001-gold.py` re-runs prior gold hits; 40-fixture sample shows **25/40 resolved (62.5%)**, extrapolating ~106 of 171 historical noise findings removed.
- **Docs**: enterprise air-gap licensing (`GAUNTLETCI_OFFLINE` + `GAUNTLETCI_ENTERPRISE_AIRGAP`) and corpus doctor tier guidance in `TROUBLESHOOTING.md`.

## Test plan

- [x] Focused GCI0001 + corpus factory tests
- [x] `scripts/resweep-gci0001-gold.py --limit 40`
- [ ] CI green on PR
