### PR TITLE
docs(eval): full GCI0001 gold resweep report

### DIFF
--- a/eval/reports/gci0001-resweep.json
+++ b/eval/reports/gci0001-resweep.json
@@ -1,7 +1,7 @@
 {
-  "prior_gci0001_fixture_count": 40,
-  "still_fires_gci0001": 15,
-  "resolved_noise_reduction": 25,
+  "prior_gci0001_fixture_count": 171,
+  "still_fires_gci0001": 71,
+  "resolved_noise_reduction": 100,
   "missing_diff": 0,
   "not_in_gold_suite": 0,
   "prior_report_gci0001_total": 171


### PR DESCRIPTION
## Summary
- Updates `eval/reports/gci0001-resweep.json` from the 40-fixture sample to the full 171-fixture re-run after the GCI0001 companion-file fix (#250).
- **100/171** prior gold-noise GCI0001 hits no longer fire (**58.5%** noise reduction); **71** still fire (likely true mixed-scope).

## Test plan
- [x] Report values match local `scripts/resweep-gci0001-gold.py` run (no `--limit`)
- [x] Doc-only change; pre-commit GauntletCI pass on staged diff