### PR TITLE
fix(ruleset): loose required status checks + bypass docs

### DIFF
--- a/.github/rulesets/main-update.json
+++ b/.github/rulesets/main-update.json
@@ -35,7 +35,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": true,
         "required_status_checks": [
           { "context": "GauntletCI Self-Analysis" },

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -303,7 +303,8 @@ GitHub evaluates **rulesets separately from Actions job success**. A green `buil
 |---------|--------------|-----|
 | `mergeStateStatus: BLOCKED`, CodeQL rollup `NEUTRAL` | Stale CodeQL category on `main` | See [CodeQL NEUTRAL](#codeql-status-check-is-neutral-merge-still-blocked) below |
 | BLOCKED, no failing job, `strict_required_status_checks_policy: true` | Head commit behind `main` | Click **Update branch** on the PR (strict policy requires up-to-date head) |
-| BLOCKED, admin user, all rules satisfied | API reports `BLOCKED` until rules pass; admins may still need UI bypass or `gh pr merge --admin` | Confirm `mergeStateStatus` is `CLEAN` on the PR checks page; non-admin contributors are the real gate |
+| BLOCKED, admin user, all rules satisfied | Rulesets can keep `mergeStateStatus: BLOCKED` in the API even when `viewerCanMergeAsAdmin` is true ([Atlantis #4116](https://github.com/runatlantis/atlantis/issues/4116)) | Use **Merge without waiting for requirements** in the UI, or `gh pr merge N --squash --admin`. Non-admin contributors still need `CLEAN`. |
+| BLOCKED, `statusCheckRollup.state: SUCCESS`, CodeQL `success` | `code_scanning` ruleset or strict up-to-date policy | Re-apply ruleset with `strict_required_status_checks_policy: false` in `main-update.json`; confirm CodeQL categories on `main` (see below) |
 | BLOCKED, invisible rule | Former `code_quality` ruleset entry | Keep `code_quality` out of `main-update.json` until Code Quality is configured |
 
 **Verify merge readiness** (replace `N` with PR number):


### PR DESCRIPTION
## Summary
- Set `strict_required_status_checks_policy: false` in canonical `main-update.json` (already applied live)
- Document ruleset admin-bypass API behavior and `code_scanning` vs green `statusCheckRollup`

## Why
Smoke tests (#258, #259) showed `mergeStateStatus: BLOCKED` while all Actions checks were `SUCCESS`. Strict up-to-date policy is a common hidden blocker; loose policy matches current live ruleset.

## Test plan
- [ ] Required CI + CodeQL pass
- [ ] `mergeStateStatus` becomes `CLEAN` (or merge without `--admin` succeeds)