### PR TITLE
fix(ruleset): drop creation/update rules blocking PR merge

### DIFF
--- a/.github/rulesets/main-update.json
+++ b/.github/rulesets/main-update.json
@@ -9,15 +9,30 @@
     }
   },
   "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
     { "type": "deletion" },
     { "type": "non_fast_forward" },
-    { "type": "creation" },
-    { "type": "update" },
     {
-      "type": "copilot_code_review",
+      "type": "required_status_checks",
       "parameters": {
-        "review_on_push": true,
-        "review_draft_pull_requests": true
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          { "context": "GauntletCI Self-Analysis" },
+          { "context": "build-and-test (ubuntu-latest)" },
+          { "context": "build-and-test (windows-latest)" }
+        ]
       }
     },
     {
@@ -33,27 +48,10 @@
       }
     },
     {
-      "type": "required_status_checks",
+      "type": "copilot_code_review",
       "parameters": {
-        "strict_required_status_checks_policy": false,
-        "do_not_enforce_on_create": true,
-        "required_status_checks": [
-          { "context": "GauntletCI Self-Analysis" },
-          { "context": "build-and-test (ubuntu-latest)" },
-          { "context": "build-and-test (windows-latest)" }
-        ]
-      }
-    },
-    {
-      "type": "pull_request",
-      "parameters": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": false,
-        "required_reviewers": [],
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_review_thread_resolution": false,
-        "allowed_merge_methods": ["merge", "squash", "rebase"]
+        "review_on_push": true,
+        "review_draft_pull_requests": true
       }
     }
   ],

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -303,8 +303,9 @@ GitHub evaluates **rulesets separately from Actions job success**. A green `buil
 |---------|--------------|-----|
 | `mergeStateStatus: BLOCKED`, CodeQL rollup `NEUTRAL` | Stale CodeQL category on `main` | See [CodeQL NEUTRAL](#codeql-status-check-is-neutral-merge-still-blocked) below |
 | BLOCKED, no failing job, `strict_required_status_checks_policy: true` | Head commit behind `main` | Click **Update branch** on the PR (strict policy requires up-to-date head) |
-| BLOCKED, admin user, all rules satisfied | Rulesets can keep `mergeStateStatus: BLOCKED` in the API even when `viewerCanMergeAsAdmin` is true ([Atlantis #4116](https://github.com/runatlantis/atlantis/issues/4116)) | Use **Merge without waiting for requirements** in the UI, or `gh pr merge N --squash --admin`. Non-admin contributors still need `CLEAN`. |
-| BLOCKED, `statusCheckRollup.state: SUCCESS`, CodeQL `success` | `code_scanning` ruleset or strict up-to-date policy | Re-apply ruleset with `strict_required_status_checks_policy: false` in `main-update.json`; confirm CodeQL categories on `main` (see below) |
+| BLOCKED, admin user, all rules satisfied | Leftover `creation`/`update` rules, or API lag while checks finish | Fix ruleset first (see rows above). If `mergeStateStatus` is `CLEAN`, merge normally. Admins can use `gh pr merge N --squash --admin` only when a rule is intentionally unsatisfied. |
+| BLOCKED, `statusCheckRollup.state: SUCCESS`, CodeQL `success` | `creation` / `update` ruleset entries fighting `pull_request` | **Remove** `creation` and `update` from `main-update.json`; `pull_request` already blocks direct pushes. Verified on PR #262 (`CLEAN` + merge without `--admin`). |
+| BLOCKED, `statusCheckRollup.state: SUCCESS`, strict policy | `strict_required_status_checks_policy: true` | Use `false` in `main-update.json` (loose up-to-date) |
 | BLOCKED, invisible rule | Former `code_quality` ruleset entry | Keep `code_quality` out of `main-update.json` until Code Quality is configured |
 
 **Verify merge readiness** (replace `N` with PR number):


### PR DESCRIPTION
## Summary
- Remove `creation` and `update` rules from `main-update.json` (they blocked PR merges despite green CI)
- Reorder rules with `pull_request` first; keep deletion, non_fast_forward, status checks, CodeQL, Copilot
- Document root cause in `docs/TROUBLESHOOTING.md`

## Root cause
Binary search on PRs #260–#262: `mergeStateStatus` stayed `BLOCKED` with `creation`+`update`+`pull_request` even when `statusCheckRollup.state` was `SUCCESS`. Removing `creation`/`update` yielded `CLEAN` and normal merge (no `--admin`).

## Test plan
- [x] PR #262: full rules minus creation/update → `CLEAN`, merged without admin
- [ ] This PR: same after CI + CodeQL