### PR TITLE
docs(rules): refresh corpus validation metrics

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -39,22 +39,57 @@ Sections marked **Status: Not yet implemented** describe planned behavior only. 
 
 ## Corpus validation (agent / internal)
 
-Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpus.db` (not the empty `./data/gauntletci-corpus.db` shell). As of the last audit snapshot (2026-04-19):
+Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpus.db` (not the empty `./data/gauntletci-corpus.db` shell).
+
+**Last queried:** 2026-06-13 (`python scripts/corpus-validation-summary.py`).
 
 | Metric | Value |
 |--------|------:|
-| Fixtures | 608 |
+| Fixtures | 608 (606 Discovery, 2 Gold) |
 | Human gold `expected_findings` rows | 414 |
-| Rules with gold labels | ~20 |
+| Distinct rules with gold labels | 41 |
+| Rule runs stored | 5,556 |
+| `aggregates` table last updated | 2026-04-19 |
+| Audit snapshot last taken | 2026-04-19 |
 
-**Latest labeled snapshot (subset):** only rules with measured tp/fp/fn in the snapshot are listed below. Most active rules lack sufficient gold labels for published precision claims.
+**Audit snapshot (labeled subset):** tp/fp/fn from human-adjudicated rows in `audit_snapshot_rows`, not raw trigger volume.
 
-| Rule | TP | FP | FN | Precision (snapshot) |
-|------|---:|---:|---:|---------------------:|
+| Rule | TP | FP | FN | Precision |
+|------|---:|---:|---:|----------:|
 | GCI0004 | 31 | 9 | 0 | 0.775 |
 | GCI0003 | 1 | 0 | 0 | 1.000 |
 
-**Discovery-tier aggregates** (full fixture sweep, April 2026) show GCI0003/GCI0004/GCI0006 with the strongest precision among high-volume rules; GCI0016, GCI0012, and GCI0021 show lower precision and need tuning before Block severity. Re-run `gauntletci corpus analyze --db` after rule changes to refresh metrics.
+**Gold labels vs latest run** (414 `expected_findings` rows; min 3 labeled pairs per rule):
+
+| Rule | TP | FP | FN | Precision |
+|------|---:|---:|---:|----------:|
+| GCI0004 | 34 | 12 | 0 | 0.74 |
+| GCI0003 | 27 | 9 | 0 | 0.75 |
+| GCI0006 | 17 | 4 | 0 | 0.81 |
+| GCI0015 | 11 | 5 | 0 | 0.69 |
+| GCI0010 | 1 | 6 | 0 | 0.14 |
+| GCI0024 | 2 | 7 | 0 | 0.22 |
+
+**Discovery-tier aggregates** (606-fixture sweep; last scored 2026-04-19):
+
+| Rule | Trigger rate | Precision | Recall |
+|------|-------------:|----------:|-------:|
+| GCI0006 | 0.29 | 0.82 | 0.50 |
+| GCI0003 | 0.27 | 0.73 | 0.51 |
+| GCI0004 | 0.25 | 0.68 | 0.75 |
+| GCI0016 | 0.15 | 0.48 | 0.25 |
+| GCI0007 | 0.04 | 1.00 | 1.00 |
+| GCI0010 | 0.04 | 0.88 | 0.11 |
+| GCI0012 | 0.02 | 0.45 | 0.06 |
+| GCI0021 | 0.02 | 0.30 | 0.13 |
+
+**High trigger, low precision (noise candidates):** GCI0001 (0.48 trigger, 0.00 precision in April aggregates — GCI0001 companion-file tuning landed in #264 after this score date), GCI0015, GCI0032, GCI0043.
+
+**Refresh after rule changes:**
+
+1. `gauntletci corpus run-all --tier discovery --db %USERPROFILE%\.gauntletci\corpus.db`
+2. `gauntletci corpus score --db %USERPROFILE%\.gauntletci\corpus.db`
+3. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
 
 ---
 

--- a/scripts/corpus-validation-summary.py
+++ b/scripts/corpus-validation-summary.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Compute corpus validation metrics for docs/rules.md refresh."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--db",
+        default=str(Path.home() / ".gauntletci" / "corpus.db"),
+    )
+    args = parser.parse_args()
+
+    con = sqlite3.connect(args.db)
+    con.row_factory = sqlite3.Row
+    cur = con.cursor()
+
+    fixtures = cur.execute("SELECT COUNT(*) FROM fixtures").fetchone()[0]
+    gold_rows = cur.execute("SELECT COUNT(*) FROM expected_findings").fetchone()[0]
+    gold_rules = cur.execute(
+        "SELECT COUNT(DISTINCT rule_id) FROM expected_findings"
+    ).fetchone()[0]
+    rule_runs = cur.execute("SELECT COUNT(*) FROM rule_runs").fetchone()[0]
+
+    snap = cur.execute(
+        """
+        SELECT id, snapped_at_utc, rules_snapped
+        FROM audit_snapshots
+        ORDER BY snapped_at_utc DESC
+        LIMIT 1
+        """
+    ).fetchone()
+
+    snapshot_rows: list[dict] = []
+    snapshot_date = None
+    if snap:
+        snapshot_date = snap["snapped_at_utc"]
+        rows = cur.execute(
+            """
+            SELECT rule_id, labeled, tp, fp, fn, precision_score
+            FROM audit_snapshot_rows
+            WHERE snapshot_id = ?
+              AND rule_id LIKE 'GCI%'
+              AND rule_id NOT LIKE 'GCI_SYN%'
+              AND (tp > 0 OR fp > 0 OR fn > 0)
+            ORDER BY fp DESC, fn DESC, tp DESC
+            """,
+            (snap["id"],),
+        ).fetchall()
+        snapshot_rows = [dict(r) for r in rows]
+
+    agg_updated = cur.execute(
+        "SELECT MAX(last_updated_utc) FROM aggregates"
+    ).fetchone()[0]
+
+    discovery_precision = cur.execute(
+        """
+        SELECT rule_id, trigger_rate, precision_score, recall_score
+        FROM aggregates
+        WHERE tier = 'Discovery'
+          AND rule_id LIKE 'GCI%'
+          AND rule_id NOT LIKE 'GCI_SYN%'
+          AND precision_score IS NOT NULL
+          AND precision_score > 0
+        ORDER BY trigger_rate DESC, precision_score DESC
+        LIMIT 12
+        """
+    ).fetchall()
+
+    low_precision = cur.execute(
+        """
+        SELECT rule_id, trigger_rate, precision_score, recall_score
+        FROM aggregates
+        WHERE tier = 'Discovery'
+          AND rule_id LIKE 'GCI%'
+          AND rule_id NOT LIKE 'GCI_SYN%'
+          AND trigger_rate >= 0.05
+          AND (precision_score IS NULL OR precision_score < 0.5)
+        ORDER BY trigger_rate DESC
+        LIMIT 8
+        """
+    ).fetchall()
+
+    # Gold-label TP/FP/FN: one verdict per (fixture, rule) on latest run
+    gold_metrics = cur.execute(
+        """
+        WITH latest AS (
+            SELECT fixture_id, MAX(id) AS run_id
+            FROM rule_runs
+            GROUP BY fixture_id
+        ),
+        pairs AS (
+            SELECT ef.rule_id,
+                   ef.fixture_id,
+                   ef.should_trigger,
+                   MAX(af.did_trigger) AS did_trigger
+            FROM expected_findings ef
+            JOIN latest lr ON lr.fixture_id = ef.fixture_id
+            JOIN actual_findings af
+              ON af.fixture_id = ef.fixture_id
+             AND af.rule_id = ef.rule_id
+             AND af.run_id = lr.run_id
+            WHERE ef.is_inconclusive = 0
+            GROUP BY ef.rule_id, ef.fixture_id, ef.should_trigger
+        )
+        SELECT rule_id,
+               SUM(CASE WHEN should_trigger = 1 AND did_trigger = 1 THEN 1 ELSE 0 END) AS tp,
+               SUM(CASE WHEN should_trigger = 0 AND did_trigger = 1 THEN 1 ELSE 0 END) AS fp,
+               SUM(CASE WHEN should_trigger = 1 AND did_trigger = 0 THEN 1 ELSE 0 END) AS fn,
+               COUNT(*) AS pairs
+        FROM pairs
+        GROUP BY rule_id
+        HAVING pairs >= 3
+        ORDER BY fp DESC, fn DESC
+        LIMIT 15
+        """
+    ).fetchall()
+
+    out = {
+        "generated_utc": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+        "fixtures": fixtures,
+        "expected_findings_rows": gold_rows,
+        "expected_findings_rules": gold_rules,
+        "rule_runs": rule_runs,
+        "aggregates_last_updated": agg_updated,
+        "audit_snapshot_date": snapshot_date,
+        "audit_snapshot_rows_with_tp_fp_fn": snapshot_rows,
+        "discovery_precision_top": [dict(r) for r in discovery_precision],
+        "discovery_low_precision_high_trigger": [dict(r) for r in low_precision],
+        "gold_label_latest_run_metrics": [
+            {
+                "rule_id": r[0],
+                "tp": r[1],
+                "fp": r[2],
+                "fn": r[3],
+                "pairs": r[4],
+                "precision": round(r[1] / (r[1] + r[2]), 3) if (r[1] + r[2]) else None,
+            }
+            for r in gold_metrics
+        ],
+    }
+    print(json.dumps(out, indent=2))
+    con.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Refresh the Corpus validation section in docs/rules.md with June 2026 metrics from ~/.gauntletci/corpus.db.
- Add discovery-tier precision table, gold-label latest-run tp/fp/fn, and an honest refresh procedure (run-all + score + summary script).
- Add scripts/corpus-validation-summary.py to regenerate metrics for future doc updates.

## Test plan

- [x] python scripts/corpus-validation-summary.py against agent corpus DB
- [x] Pre-commit GauntletCI (doc-only low finding)
- [ ] CI on PR