### PR TITLE
Fix corpus score Manual LabelSource and refresh June metrics

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -41,55 +41,57 @@ Sections marked **Status: Not yet implemented** describe planned behavior only. 
 
 Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpus.db` (not the empty `./data/gauntletci-corpus.db` shell).
 
-**Last queried:** 2026-06-13 (`python scripts/corpus-validation-summary.py`).
+**Last queried:** 2026-06-13 (`python scripts/corpus-validation-summary.py` after discovery `run-all` + `corpus score`).
 
 | Metric | Value |
 |--------|------:|
 | Fixtures | 608 (606 Discovery, 2 Gold) |
 | Human gold `expected_findings` rows | 414 |
 | Distinct rules with gold labels | 41 |
-| Rule runs stored | 5,556 |
-| `aggregates` table last updated | 2026-04-19 |
+| Rule runs stored | 6,162 |
+| `aggregates` table last updated | 2026-06-13 |
 | Audit snapshot last taken | 2026-04-19 |
 
-**Audit snapshot (labeled subset):** tp/fp/fn from human-adjudicated rows in `audit_snapshot_rows`, not raw trigger volume.
+**Audit snapshot (labeled subset):** tp/fp/fn from human-adjudicated rows in `audit_snapshot_rows`, not raw trigger volume. Snapshot not refreshed this run.
 
 | Rule | TP | FP | FN | Precision |
 |------|---:|---:|---:|----------:|
 | GCI0004 | 31 | 9 | 0 | 0.775 |
 | GCI0003 | 1 | 0 | 0 | 1.000 |
 
-**Gold labels vs latest run** (414 `expected_findings` rows; min 3 labeled pairs per rule):
+**Gold labels vs latest run** (414 `expected_findings` rows in DB; min 3 labeled pairs per rule):
 
 | Rule | TP | FP | FN | Precision |
 |------|---:|---:|---:|----------:|
-| GCI0004 | 34 | 12 | 0 | 0.74 |
+| GCI0004 | 31 | 11 | 0 | 0.74 |
 | GCI0003 | 27 | 9 | 0 | 0.75 |
 | GCI0006 | 17 | 4 | 0 | 0.81 |
 | GCI0015 | 11 | 5 | 0 | 0.69 |
 | GCI0010 | 1 | 6 | 0 | 0.14 |
 | GCI0024 | 2 | 7 | 0 | 0.22 |
+| GCI0016 | 6 | 0 | 0 | 1.00 |
 
-**Discovery-tier aggregates** (606-fixture sweep; last scored 2026-04-19):
+**Discovery-tier trigger rates** (606-fixture sweep; scored 2026-06-13). Per-fixture `expected.json` exists on only ~24 fixtures, so `aggregates.precision_score` for Discovery is mostly 0 — use the gold-label table above for labeled precision.
 
-| Rule | Trigger rate | Precision | Recall |
-|------|-------------:|----------:|-------:|
-| GCI0006 | 0.29 | 0.82 | 0.50 |
-| GCI0003 | 0.27 | 0.73 | 0.51 |
-| GCI0004 | 0.25 | 0.68 | 0.75 |
-| GCI0016 | 0.15 | 0.48 | 0.25 |
-| GCI0007 | 0.04 | 1.00 | 1.00 |
-| GCI0010 | 0.04 | 0.88 | 0.11 |
-| GCI0012 | 0.02 | 0.45 | 0.06 |
-| GCI0021 | 0.02 | 0.30 | 0.13 |
+| Rule | Trigger rate |
+|------|-------------:|
+| GCI0019 | 0.22 |
+| GCI0003 | 0.18 |
+| GCI0006 | 0.12 |
+| GCI0024 | 0.09 |
+| GCI0001 | 0.08 |
+| GCI0045 | 0.06 |
+| GCI0043 | 0.06 |
+| GCI0032 | 0.06 |
 
-**High trigger, low precision (noise candidates):** GCI0001 (0.48 trigger, 0.00 precision in April aggregates — GCI0001 companion-file tuning landed in #264 after this score date), GCI0015, GCI0032, GCI0043.
+**High trigger, low gold precision (noise candidates):** GCI0019 (22% trigger, unlabeled discovery), GCI0010 (0.14 gold precision), GCI0024 (0.22). GCI0001 trigger dropped to 8% post-#264 companion-file fix (was ~48% in April aggregates).
 
 **Refresh after rule changes:**
 
-1. `gauntletci corpus run-all --tier discovery --db %USERPROFILE%\.gauntletci\corpus.db`
-2. `gauntletci corpus score --db %USERPROFILE%\.gauntletci\corpus.db`
-3. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
+1. `.\scripts\refresh-agent-corpus.ps1` — or manually:
+2. `gauntletci corpus run-all --tier discovery --db %USERPROFILE%\.gauntletci\corpus.db`
+3. `gauntletci corpus score --db %USERPROFILE%\.gauntletci\corpus.db`
+4. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
 
 ---
 

--- a/scripts/refresh-agent-corpus.ps1
+++ b/scripts/refresh-agent-corpus.ps1
@@ -1,0 +1,40 @@
+# Agent corpus refresh: discovery run-all, score, validation summary.
+# Log: %USERPROFILE%\.gauntletci\corpus-run-all-YYYYMMDD-HHmmss.log
+$ErrorActionPreference = "Continue"
+$corpus = Join-Path $env:USERPROFILE ".gauntletci\corpus.db"
+$log = Join-Path $env:USERPROFILE (".gauntletci\corpus-run-all-{0:yyyyMMdd-HHmmss}.log" -f (Get-Date))
+$repo = "C:\Users\ericc\source\repos\GauntletCI"
+Set-Location $repo
+
+function Write-Log([string]$Message) {
+    $line = "[{0:yyyy-MM-dd HH:mm:ss}] {1}" -f (Get-Date), $Message
+    Write-Output $line
+    Add-Content -Path $log -Value $line
+}
+
+Write-Log "Starting discovery run-all (606 fixtures)"
+Write-Log "Corpus DB: $corpus"
+Write-Log "Fixtures: $repo\data\fixtures"
+
+dotnet run --project src/GauntletCI.Cli -- corpus run-all --tier discovery --db $corpus --fixtures ./data/fixtures 2>&1 |
+    ForEach-Object { Write-Log $_ }
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Log "run-all failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+Write-Log "Starting corpus score"
+dotnet run --project src/GauntletCI.Cli -- corpus score --db $corpus --fixtures ./data/fixtures 2>&1 |
+    ForEach-Object { Write-Log $_ }
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Log "score failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+Write-Log "Writing validation summary JSON"
+python (Join-Path $repo "scripts\corpus-validation-summary.py") --db $corpus 2>&1 |
+    ForEach-Object { Write-Log $_ }
+
+Write-Log "Corpus refresh complete"

--- a/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
+++ b/src/GauntletCI.Corpus/Labeling/SilverLabelEngine.cs
@@ -784,6 +784,7 @@ public sealed class SilverLabelEngine
             {
                 if (!overwriteExisting &&
                     (existingLabel.LabelSource == LabelSource.HumanReview ||
+                     existingLabel.LabelSource == LabelSource.Manual ||
                      existingLabel.LabelSource == LabelSource.Seed))
                 {
                     continue;

--- a/src/GauntletCI.Corpus/Models/Enums.cs
+++ b/src/GauntletCI.Corpus/Models/Enums.cs
@@ -7,4 +7,4 @@ public enum PrSizeBucket { Tiny, Small, Medium, Large, Huge }
 
 public enum MergeState { Open, Merged, Closed }
 
-public enum LabelSource { Heuristic, FilePathCorrelation, HumanReview, Seed, LlmReview }
+public enum LabelSource { Heuristic, FilePathCorrelation, HumanReview, Manual, Seed, LlmReview }

--- a/src/GauntletCI.Corpus/Scoring/EvaluationClassifier.cs
+++ b/src/GauntletCI.Corpus/Scoring/EvaluationClassifier.cs
@@ -47,7 +47,7 @@ public sealed class EvaluationClassifier : IEvaluationClassifier
                     Status = label.ShouldTrigger
                                         ? EvaluationStatus.TruePositive
                                         : EvaluationStatus.FalsePositive,
-                    LabelConfidence = label.LabelSource == LabelSource.HumanReview
+                    LabelConfidence = label.LabelSource is LabelSource.HumanReview or LabelSource.Manual
                                         ? LabelConfidence.Trusted
                                         : LabelConfidence.Heuristic,
                     LabelReason = label.Reason,
@@ -80,7 +80,7 @@ public sealed class EvaluationClassifier : IEvaluationClassifier
                 Status = label.ShouldTrigger
                                     ? EvaluationStatus.FalseNegative
                                     : EvaluationStatus.TrueNegative,
-                LabelConfidence = label.LabelSource == LabelSource.HumanReview
+                LabelConfidence = label.LabelSource is LabelSource.HumanReview or LabelSource.Manual
                                     ? LabelConfidence.Trusted
                                     : LabelConfidence.Heuristic,
                 LabelReason = label.Reason,

--- a/tests/GauntletCI.Tests/Corpus/CorpusAutoLabelTests.cs
+++ b/tests/GauntletCI.Tests/Corpus/CorpusAutoLabelTests.cs
@@ -301,4 +301,10 @@ public sealed class CorpusAutoLabelTests
     {
         Assert.True(Enum.IsDefined(typeof(LabelSource), LabelSource.LlmReview));
     }
+
+    [Fact]
+    public void LabelSource_ContainsManualValue()
+    {
+        Assert.True(Enum.IsDefined(typeof(LabelSource), LabelSource.Manual));
+    }
 }

--- a/tests/GauntletCI.Tests/EvaluationClassifierTests.cs
+++ b/tests/GauntletCI.Tests/EvaluationClassifierTests.cs
@@ -141,6 +141,18 @@ public sealed class EvaluationClassifierTests
     }
 
     [Fact]
+    public void Classify_ManualLabel_LabelConfidenceIsTrusted()
+    {
+        var fixture = Fixture();
+        var expected = new[] { Label("GCI0001", shouldTrigger: true, source: LabelSource.Manual) };
+        var actual = new[] { Actual("GCI0001", didTrigger: true) };
+
+        var results = _classifier.Classify(fixture, expected, actual);
+
+        Assert.Equal(LabelConfidence.Trusted, Assert.Single(results).LabelConfidence);
+    }
+
+    [Fact]
     public void Classify_HeuristicLabel_LabelConfidenceIsHeuristic()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- Add `LabelSource.Manual` so gold fixture `expected.json` files (and eval ground truth) deserialize during `corpus score`.
- Treat Manual labels as trusted in `EvaluationClassifier`; protect Manual from overwrite in `SilverLabelEngine`.
- Add `scripts/refresh-agent-corpus.ps1` (run-all, score, validation summary).
- Update `docs/rules.md` corpus section after June 2026 discovery run-all (606 fixtures, aggregates refreshed 2026-06-13).

## Test plan

- [x] `dotnet build GauntletCI.slnx`
- [x] `EvaluationClassifierTests` (includes Manual trusted case)
- [x] `corpus score` against `%USERPROFILE%\.gauntletci\corpus.db` succeeds after run-all
- [x] Pre-commit GauntletCI analyze on staged diff