### PR TITLE
Add corpus audit snapshot script and fix Completed status filter

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -50,14 +50,18 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 | Distinct rules with gold labels | 41 |
 | Rule runs stored | 6,162 |
 | `aggregates` table last updated | 2026-06-13 |
-| Audit snapshot last taken | 2026-04-19 |
+| Audit snapshot last taken | 2026-06-13 |
 
-**Audit snapshot (labeled subset):** tp/fp/fn from human-adjudicated rows in `audit_snapshot_rows`, not raw trigger volume. Snapshot not refreshed this run.
+**Audit snapshot (labeled subset):** tp/fp/fn from `expected_findings` vs latest completed run (`audit_snapshot_rows` snapshot #17).
 
-| Rule | TP | FP | FN | Precision |
-|------|---:|---:|---:|----------:|
-| GCI0004 | 31 | 9 | 0 | 0.775 |
-| GCI0003 | 1 | 0 | 0 | 1.000 |
+| Rule | Labeled | TP | FP | FN | Precision |
+|------|--------:|---:|---:|---:|----------:|
+| GCI0004 | 53 | 31 | 11 | 3 | 0.74 |
+| GCI0003 | 44 | 27 | 9 | 0 | 0.75 |
+| GCI0006 | 29 | 17 | 4 | 0 | 0.81 |
+| GCI0015 | 26 | 11 | 5 | 0 | 0.69 |
+| GCI0024 | 19 | 2 | 7 | 0 | 0.22 |
+| GCI0010 | 19 | 1 | 6 | 1 | 0.14 |
 
 **Gold labels vs latest run** (414 `expected_findings` rows in DB; min 3 labeled pairs per rule):
 
@@ -92,6 +96,8 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 2. `gauntletci corpus run-all --tier discovery --db %USERPROFILE%\.gauntletci\corpus.db`
 3. `gauntletci corpus score --db %USERPROFILE%\.gauntletci\corpus.db`
 4. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
+5. `python scripts/corpus-audit-snapshot.py` — refresh `audit_snapshots`
+6. `python scripts/build-rule-audit.py --full-corpus` — regenerate `eval/rule-audit.json`
 
 ---
 

--- a/scripts/build-rule-audit.py
+++ b/scripts/build-rule-audit.py
@@ -152,7 +152,7 @@ def load_corpus_metrics() -> dict[str, dict]:
             WITH latest_run AS (
                 SELECT fixture_id, MAX(id) AS run_id
                 FROM rule_runs
-                WHERE status = 'completed'
+                WHERE UPPER(status) = 'COMPLETED'
                 GROUP BY fixture_id
             )
             SELECT af.rule_id, COUNT(DISTINCT af.fixture_id)
@@ -202,7 +202,7 @@ def load_labeled_classifier_metrics() -> dict[str, dict]:
             WITH latest_run AS (
                 SELECT fixture_id, MAX(id) AS run_id
                 FROM rule_runs
-                WHERE status = 'completed'
+                WHERE UPPER(status) = 'COMPLETED'
                 GROUP BY fixture_id
             ),
             fired AS (
@@ -239,7 +239,7 @@ def load_labeled_classifier_metrics() -> dict[str, dict]:
             WITH latest_run AS (
                 SELECT fixture_id, MAX(id) AS run_id
                 FROM rule_runs
-                WHERE status = 'completed'
+                WHERE UPPER(status) = 'COMPLETED'
                 GROUP BY fixture_id
             ),
             fired AS (

--- a/scripts/corpus-audit-snapshot.py
+++ b/scripts/corpus-audit-snapshot.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Insert a labeled TP/FP/FN audit snapshot into the agent corpus DB."""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def compute_rule_rows(cur: sqlite3.Cursor) -> list[dict]:
+    """Classify expected_findings vs latest completed run (EvaluationClassifier parity)."""
+    rows = cur.execute(
+        """
+        WITH latest AS (
+            SELECT fixture_id, MAX(id) AS run_id
+            FROM rule_runs
+            WHERE UPPER(status) = 'COMPLETED'
+            GROUP BY fixture_id
+        ),
+        pairs AS (
+            SELECT ef.rule_id,
+                   ef.fixture_id,
+                   ef.should_trigger,
+                   COALESCE(MAX(af.did_trigger), 0) AS did_trigger
+            FROM expected_findings ef
+            INNER JOIN latest lr ON lr.fixture_id = ef.fixture_id
+            LEFT JOIN actual_findings af
+              ON af.fixture_id = ef.fixture_id
+             AND af.rule_id = ef.rule_id
+             AND af.run_id = lr.run_id
+            WHERE COALESCE(ef.is_inconclusive, 0) = 0
+            GROUP BY ef.rule_id, ef.fixture_id, ef.should_trigger
+        )
+        SELECT rule_id,
+               COUNT(*) AS labeled,
+               SUM(CASE WHEN should_trigger = 1 AND did_trigger = 1 THEN 1 ELSE 0 END) AS tp,
+               SUM(CASE WHEN should_trigger = 0 AND did_trigger = 1 THEN 1 ELSE 0 END) AS fp,
+               SUM(CASE WHEN should_trigger = 1 AND did_trigger = 0 THEN 1 ELSE 0 END) AS fn
+        FROM pairs
+        GROUP BY rule_id
+        ORDER BY rule_id
+        """
+    ).fetchall()
+
+    usefulness: dict[str, float | None] = {}
+    for rule_id, avg in cur.execute(
+        "SELECT rule_id, AVG(usefulness) FROM evaluations GROUP BY rule_id"
+    ).fetchall():
+        usefulness[rule_id] = round(float(avg), 3) if avg is not None else None
+
+    result: list[dict] = []
+    for rule_id, labeled, tp, fp, fn in rows:
+        tp = int(tp or 0)
+        fp = int(fp or 0)
+        fn = int(fn or 0)
+        labeled = int(labeled or 0)
+        precision = round(tp / (tp + fp), 3) if (tp + fp) else None
+        recall = round(tp / (tp + fn), 3) if (tp + fn) else None
+        result.append(
+            {
+                "rule_id": rule_id,
+                "labeled": labeled,
+                "tp": tp,
+                "fp": fp,
+                "fn": fn,
+                "precision_score": precision,
+                "recall_score": recall,
+                "usefulness_score": usefulness.get(rule_id),
+            }
+        )
+    return result
+
+
+def insert_snapshot(con: sqlite3.Connection, rows: list[dict], notes: str | None) -> int:
+    cur = con.cursor()
+    cur.execute(
+        """
+        INSERT INTO audit_snapshots (snapped_at_utc, rules_snapped, notes)
+        VALUES (?, ?, ?)
+        """,
+        (
+            datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+            len(rows),
+            notes,
+        ),
+    )
+    snapshot_id = int(cur.lastrowid)
+    for row in rows:
+        cur.execute(
+            """
+            INSERT INTO audit_snapshot_rows (
+                snapshot_id, rule_id, labeled, tp, fp, fn,
+                precision_score, recall_score, usefulness_score
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                snapshot_id,
+                row["rule_id"],
+                row["labeled"],
+                row["tp"],
+                row["fp"],
+                row["fn"],
+                row["precision_score"],
+                row["recall_score"],
+                row["usefulness_score"],
+            ),
+        )
+    con.commit()
+    return snapshot_id
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--db",
+        default=str(Path.home() / ".gauntletci" / "corpus.db"),
+    )
+    parser.add_argument(
+        "--notes",
+        default="post run-all labeled metrics",
+        help="Optional snapshot note stored in audit_snapshots.notes",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print top rows only; do not insert",
+    )
+    args = parser.parse_args()
+
+    con = sqlite3.connect(args.db)
+    con.row_factory = sqlite3.Row
+    rows = compute_rule_rows(con.cursor())
+
+    top = sorted(
+        [r for r in rows if r["tp"] or r["fp"] or r["fn"]],
+        key=lambda r: (r["fp"], r["fn"], -r["tp"]),
+        reverse=True,
+    )[:8]
+
+    print(f"rules_with_labels={len(rows)}")
+    for r in top:
+        print(
+            f"{r['rule_id']:10} labeled={r['labeled']:3} "
+            f"tp={r['tp']:3} fp={r['fp']:3} fn={r['fn']:3} "
+            f"prec={r['precision_score']}"
+        )
+
+    if args.dry_run:
+        con.close()
+        return
+
+    snapshot_id = insert_snapshot(con, rows, args.notes)
+    print(f"snapshot_id={snapshot_id} rows={len(rows)}")
+    con.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh-agent-corpus.ps1
+++ b/scripts/refresh-agent-corpus.ps1
@@ -37,4 +37,12 @@ Write-Log "Writing validation summary JSON"
 python (Join-Path $repo "scripts\corpus-validation-summary.py") --db $corpus 2>&1 |
     ForEach-Object { Write-Log $_ }
 
+Write-Log "Writing audit snapshot"
+python (Join-Path $repo "scripts\corpus-audit-snapshot.py") --db $corpus 2>&1 |
+    ForEach-Object { Write-Log $_ }
+
+Write-Log "Regenerating eval/rule-audit.json"
+python (Join-Path $repo "scripts\build-rule-audit.py") --full-corpus 2>&1 |
+    ForEach-Object { Write-Log $_ }
+
 Write-Log "Corpus refresh complete"


### PR DESCRIPTION
## Summary

- Add `scripts/corpus-audit-snapshot.py` to write labeled TP/FP/FN rows into `audit_snapshots` after a discovery run-all.
- Fix `build-rule-audit.py` using `UPPER(status) = 'COMPLETED'` (DB stores `Completed`, not `completed`).
- Extend `refresh-agent-corpus.ps1` with snapshot + rule-audit regeneration steps.
- Refresh `docs/rules.md` audit snapshot table (snapshot #17, 2026-06-13).

## Test plan

- [x] `python scripts/corpus-audit-snapshot.py --dry-run` shows 38 labeled rules
- [x] Snapshot insert produces GCI0004 tp=31 fp=11 fn=3
- [x] Pre-commit GauntletCI analyze clean