### PR TITLE
Add benchmark discovery metrics drift check

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -98,7 +98,7 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 4. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
 5. `python scripts/corpus-audit-snapshot.py` — refresh `audit_snapshots`
 6. `python scripts/build-rule-audit.py --full-corpus` — regenerate `eval/rule-audit.json` (uses `corpus_db_read` indexes; ~10s on agent DB)
-7. `python scripts/check-benchmark-discovery-metrics.py` — benchmark page discovery table vs agent DB (skip in CI with `--skip-if-missing-db`)
+7. `python scripts/corpus-benchmark-discovery-drift.py` — benchmark page discovery table vs agent DB (skip in CI with `--skip-if-missing-db`)
 
 ---
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -98,6 +98,7 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 4. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
 5. `python scripts/corpus-audit-snapshot.py` — refresh `audit_snapshots`
 6. `python scripts/build-rule-audit.py --full-corpus` — regenerate `eval/rule-audit.json` (uses `corpus_db_read` indexes; ~10s on agent DB)
+7. `python scripts/verify-benchmark-discovery-metrics.py` — benchmark page discovery table vs agent DB (skip in CI with `--skip-if-missing-db`)
 
 ---
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -98,7 +98,7 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 4. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
 5. `python scripts/corpus-audit-snapshot.py` — refresh `audit_snapshots`
 6. `python scripts/build-rule-audit.py --full-corpus` — regenerate `eval/rule-audit.json` (uses `corpus_db_read` indexes; ~10s on agent DB)
-7. `python scripts/verify-benchmark-discovery-metrics.py` — benchmark page discovery table vs agent DB (skip in CI with `--skip-if-missing-db`)
+7. `python scripts/check-benchmark-discovery-metrics.py` — benchmark page discovery table vs agent DB (skip in CI with `--skip-if-missing-db`)
 
 ---
 

--- a/scripts/corpus-benchmark-discovery-drift.py
+++ b/scripts/corpus-benchmark-discovery-drift.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Check benchmark page discovery sweep matches agent corpus DB (when present)."""
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+BENCHMARK = REPO / "site" / "app" / "benchmark" / "page.tsx"
+DEFAULT_DB = Path.home() / ".gauntletci" / "corpus.db"
+
+sys.path.insert(0, str(REPO / "scripts"))
+from corpus_db_read import ensure_read_indexes  # noqa: E402
+
+
+def parse_benchmark_table(path: Path) -> dict[str, dict[str, str | None]]:
+    text = path.read_text(encoding="utf-8")
+    block = re.search(
+        r"const discoverySweepJune2026.*?=\s*\[(.*?)\];",
+        text,
+        re.DOTALL,
+    )
+    if not block:
+        raise SystemExit(f"Could not find discoverySweepJune2026 in {path}")
+
+    rows: dict[str, dict[str, str | None]] = {}
+    for entry in re.finditer(
+        r'\{\s*id:\s*"([^"]+)"[^}]*triggerPct:\s*"([^"]+)"'
+        r'(?:[^}]*goldPrecision:\s*"([^"]*)")?',
+        block.group(1),
+    ):
+        rule_id, trigger_pct, gold_prec = entry.group(1), entry.group(2), entry.group(3)
+        rows[rule_id] = {
+            "triggerPct": trigger_pct,
+            "goldPrecision": gold_prec,
+        }
+    return rows
+
+
+def pct_string(rate: float | None) -> str | None:
+    if rate is None:
+        return None
+    return f"{round(rate * 100)}%"
+
+
+def load_db_metrics(db_path: Path) -> tuple[dict[str, str], dict[str, str]]:
+    con = sqlite3.connect(db_path)
+    ensure_read_indexes(con)
+    cur = con.cursor()
+
+    trigger_rows = cur.execute(
+        """
+        SELECT rule_id, trigger_rate
+        FROM aggregates
+        WHERE tier = 'Discovery'
+          AND rule_id LIKE 'GCI%'
+        """
+    ).fetchall()
+    triggers = {rid: pct_string(rate) for rid, rate in trigger_rows if rate is not None}
+
+    gold_rows = cur.execute(
+        """
+        WITH latest AS (
+            SELECT fixture_id, MAX(id) AS run_id
+            FROM rule_runs
+            GROUP BY fixture_id
+        ),
+        pairs AS (
+            SELECT ef.rule_id,
+                   ef.fixture_id,
+                   ef.should_trigger,
+                   MAX(af.did_trigger) AS did_trigger
+            FROM expected_findings ef
+            JOIN latest lr ON lr.fixture_id = ef.fixture_id
+            JOIN actual_findings af
+              ON af.fixture_id = ef.fixture_id
+             AND af.rule_id = ef.rule_id
+             AND af.run_id = lr.run_id
+            WHERE ef.is_inconclusive = 0
+            GROUP BY ef.rule_id, ef.fixture_id, ef.should_trigger
+        )
+        SELECT rule_id,
+               SUM(CASE WHEN should_trigger = 1 AND did_trigger = 1 THEN 1 ELSE 0 END) AS tp,
+               SUM(CASE WHEN should_trigger = 0 AND did_trigger = 1 THEN 1 ELSE 0 END) AS fp
+        FROM pairs
+        GROUP BY rule_id
+        """
+    ).fetchall()
+    gold: dict[str, str] = {}
+    for rule_id, tp, fp in gold_rows:
+        tp = int(tp or 0)
+        fp = int(fp or 0)
+        if tp + fp:
+            gold[rule_id] = pct_string(tp / (tp + fp)) or ""
+
+    con.close()
+    return triggers, gold
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", default=str(DEFAULT_DB))
+    parser.add_argument(
+        "--skip-if-missing-db",
+        action="store_true",
+        help="Exit 0 when agent corpus DB is absent (CI)",
+    )
+    args = parser.parse_args()
+
+    expected = parse_benchmark_table(BENCHMARK)
+    db_path = Path(args.db)
+    if not db_path.exists():
+        if args.skip_if_missing_db:
+            print(f"skip: corpus db not found at {db_path}")
+            return
+        raise SystemExit(f"Corpus DB not found: {db_path}")
+
+    triggers, gold = load_db_metrics(db_path)
+    errors: list[str] = []
+
+    for rule_id, exp in expected.items():
+        actual_trigger = triggers.get(rule_id)
+        if actual_trigger and exp["triggerPct"] != actual_trigger:
+            errors.append(
+                f"{rule_id} triggerPct page={exp['triggerPct']} db={actual_trigger}"
+            )
+        if exp.get("goldPrecision"):
+            actual_gold = gold.get(rule_id)
+            if actual_gold and exp["goldPrecision"] != actual_gold:
+                errors.append(
+                    f"{rule_id} goldPrecision page={exp['goldPrecision']} db={actual_gold}"
+                )
+
+    if errors:
+        for line in errors:
+            print(f"FAIL {line}", file=sys.stderr)
+        raise SystemExit(1)
+
+    print(f"OK benchmark discovery metrics match {db_path} ({len(expected)} rules)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh-agent-corpus.ps1
+++ b/scripts/refresh-agent-corpus.ps1
@@ -50,7 +50,7 @@ python (Join-Path $repo "scripts\build-rule-audit.py") --full-corpus 2>&1 |
     ForEach-Object { Write-Log $_ }
 
 Write-Log "Checking benchmark discovery metrics vs corpus DB"
-python (Join-Path $repo "scripts\check-benchmark-discovery-metrics.py") --db $corpus 2>&1 |
+python (Join-Path $repo "scripts\corpus-benchmark-discovery-drift.py") --db $corpus 2>&1 |
     ForEach-Object { Write-Log $_ }
 
 Write-Log "Corpus refresh complete"

--- a/scripts/refresh-agent-corpus.ps1
+++ b/scripts/refresh-agent-corpus.ps1
@@ -49,8 +49,8 @@ Write-Log "Regenerating eval/rule-audit.json"
 python (Join-Path $repo "scripts\build-rule-audit.py") --full-corpus 2>&1 |
     ForEach-Object { Write-Log $_ }
 
-Write-Log "Verifying benchmark discovery metrics vs corpus DB"
-python (Join-Path $repo "scripts\verify-benchmark-discovery-metrics.py") --db $corpus 2>&1 |
+Write-Log "Checking benchmark discovery metrics vs corpus DB"
+python (Join-Path $repo "scripts\check-benchmark-discovery-metrics.py") --db $corpus 2>&1 |
     ForEach-Object { Write-Log $_ }
 
 Write-Log "Corpus refresh complete"

--- a/scripts/refresh-agent-corpus.ps1
+++ b/scripts/refresh-agent-corpus.ps1
@@ -49,4 +49,8 @@ Write-Log "Regenerating eval/rule-audit.json"
 python (Join-Path $repo "scripts\build-rule-audit.py") --full-corpus 2>&1 |
     ForEach-Object { Write-Log $_ }
 
+Write-Log "Verifying benchmark discovery metrics vs corpus DB"
+python (Join-Path $repo "scripts\verify-benchmark-discovery-metrics.py") --db $corpus 2>&1 |
+    ForEach-Object { Write-Log $_ }
+
 Write-Log "Corpus refresh complete"


### PR DESCRIPTION
## Summary

- Add `scripts/verify-benchmark-discovery-metrics.py` to compare `/benchmark` discovery sweep constants to agent corpus DB.
- Wire into `refresh-agent-corpus.ps1` and document in `docs/rules.md`.
- Uses same gold-label JOIN query as `corpus-validation-summary.py` (matches public benchmark column).

## Test plan

- [x] `python scripts/verify-benchmark-discovery-metrics.py` OK on agent DB (5 rules)
- [x] `--skip-if-missing-db` exits 0 for CI