### PR TITLE
CI: benchmark discovery drift check on path changes

### DIFF
--- a/.github/workflows/benchmark-discovery-drift.yml
+++ b/.github/workflows/benchmark-discovery-drift.yml
@@ -1,0 +1,34 @@
+name: Benchmark Discovery Drift
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "site/app/benchmark/page.tsx"
+      - "scripts/corpus-benchmark-discovery-drift.py"
+      - "scripts/corpus_db_read.py"
+      - "scripts/refresh-agent-corpus.ps1"
+      - "docs/rules.md"
+      - ".github/workflows/benchmark-discovery-drift.yml"
+  push:
+    branches: [main]
+    paths:
+      - "site/app/benchmark/page.tsx"
+      - "scripts/corpus-benchmark-discovery-drift.py"
+      - "scripts/corpus_db_read.py"
+      - "scripts/refresh-agent-corpus.ps1"
+      - "docs/rules.md"
+      - ".github/workflows/benchmark-discovery-drift.yml"
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Parse benchmark discovery table (skip agent DB in CI)
+        run: python scripts/corpus-benchmark-discovery-drift.py --skip-if-missing-db

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -98,7 +98,7 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 4. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
 5. `python scripts/corpus-audit-snapshot.py` — refresh `audit_snapshots`
 6. `python scripts/build-rule-audit.py --full-corpus` — regenerate `eval/rule-audit.json` (uses `corpus_db_read` indexes; ~10s on agent DB)
-7. `python scripts/corpus-benchmark-discovery-drift.py` — benchmark page discovery table vs agent DB (skip in CI with `--skip-if-missing-db`)
+7. `python scripts/corpus-benchmark-discovery-drift.py` — benchmark page discovery table vs agent DB (CI: `.github/workflows/benchmark-discovery-drift.yml` with `--skip-if-missing-db`; full compare when agent DB present locally)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/benchmark-discovery-drift.yml` triggered when benchmark page or drift script changes
- Runs `corpus-benchmark-discovery-drift.py --skip-if-missing-db` (validates page parse; skips DB compare in CI)
- Documents CI workflow in corpus refresh step 7 in `docs/rules.md`

## Test plan
- [x] Local `--skip-if-missing-db` exits 0 when DB absent
- [x] Local full check OK against agent corpus DB
- [ ] CI workflow passes on this PR