### PR TITLE
Add corpus audit-snapshot product CLI command

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -96,7 +96,7 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 2. `gauntletci corpus run-all --tier discovery --db %USERPROFILE%\.gauntletci\corpus.db`
 3. `gauntletci corpus score --db %USERPROFILE%\.gauntletci\corpus.db`
 4. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
-5. `python scripts/corpus-audit-snapshot.py` — refresh `audit_snapshots`
+5. `gauntletci corpus audit-snapshot --db <path>` (or `python scripts/corpus-audit-snapshot.py`) — refresh `audit_snapshots`
 6. `python scripts/build-rule-audit.py --full-corpus` — regenerate `eval/rule-audit.json` (uses `corpus_db_read` indexes; ~10s on agent DB)
 7. `python scripts/corpus-benchmark-discovery-drift.py` — benchmark page discovery table vs agent DB (CI: `.github/workflows/benchmark-discovery-drift.yml` with `--skip-if-missing-db`; full compare when agent DB present locally)
 

--- a/scripts/refresh-agent-corpus.ps1
+++ b/scripts/refresh-agent-corpus.ps1
@@ -42,7 +42,7 @@ python (Join-Path $repo "scripts\corpus-validation-summary.py") --db $corpus 2>&
     ForEach-Object { Write-Log $_ }
 
 Write-Log "Writing audit snapshot"
-python (Join-Path $repo "scripts\corpus-audit-snapshot.py") --db $corpus 2>&1 |
+dotnet run --project src/GauntletCI.Cli -- corpus audit-snapshot --db $corpus 2>&1 |
     ForEach-Object { Write-Log $_ }
 
 Write-Log "Regenerating eval/rule-audit.json"

--- a/src/GauntletCI.Cli/Commands/CorpusCommand.cs
+++ b/src/GauntletCI.Cli/Commands/CorpusCommand.cs
@@ -38,7 +38,8 @@ public static class CorpusCommand
               3. corpus label-all --tier discovery
               4. corpus run-all --tier discovery
               5. corpus score
-              6. corpus report
+              6. corpus audit-snapshot
+              7. corpus report
             """);
 
         // Operations commands
@@ -66,6 +67,7 @@ public static class CorpusCommand
         corpus.AddCommand(utilityFactory.CreateErrors());
         corpus.AddCommand(utilityFactory.CreateRejectedRepos());
         corpus.AddCommand(utilityFactory.CreateDoctor());
+        corpus.AddCommand(utilityFactory.CreateAuditSnapshot());
 
         var issues = new Command("issues", "GitHub Issues corpus operations");
         issues.AddCommand(CreateIssueSearch());

--- a/src/GauntletCI.Cli/Commands/Factories/CorpusUtilityFactory.cs
+++ b/src/GauntletCI.Cli/Commands/Factories/CorpusUtilityFactory.cs
@@ -2,6 +2,7 @@
 using System.CommandLine;
 using GauntletCI.Corpus;
 using GauntletCI.Corpus.Models;
+using GauntletCI.Corpus.Scoring;
 using GauntletCI.Corpus.Storage;
 
 namespace GauntletCI.Cli.Commands.Factories;
@@ -448,6 +449,74 @@ public static class CorpusUtilityFactory
                         Console.WriteLine("✓ Corpus is healthy");
                     else
                         Console.WriteLine("⚠ Issues detected - review above warnings");
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[corpus] Error: {ex.Message}");
+                    ctx.ExitCode = 1;
+                }
+            }
+        });
+
+        return cmd;
+    }
+
+    /// <summary>
+    /// Create the 'audit-snapshot' command: persist labeled TP/FP/FN metrics for all rules.
+    /// Command: corpus audit-snapshot [--db] [--notes] [--dry-run]
+    /// </summary>
+    public static Command CreateAuditSnapshot()
+    {
+        var dbOpt = new Option<string>("--db", () => "./data/gauntletci-corpus.db", "Path to corpus SQLite database");
+        var notesOpt = new Option<string>("--notes", () => "post run-all labeled metrics", "Note stored on audit_snapshots.notes");
+        var dryRunOpt = new Option<bool>("--dry-run", () => false, "Print top rows only; do not insert");
+
+        var cmd = new Command(
+            "audit-snapshot",
+            "Insert labeled TP/FP/FN audit snapshot (expected_findings vs latest completed run)");
+        cmd.AddOption(dbOpt);
+        cmd.AddOption(notesOpt);
+        cmd.AddOption(dryRunOpt);
+
+        cmd.SetHandler(async (ctx) =>
+        {
+            var dbPath = ctx.ParseResult.GetValueForOption(dbOpt)!;
+            var notes = ctx.ParseResult.GetValueForOption(notesOpt);
+            var dryRun = ctx.ParseResult.GetValueForOption(dryRunOpt);
+            var ct = ctx.GetCancellationToken();
+
+            var db = new CorpusDb(dbPath);
+            await db.InitializeAsync(ct);
+            using (db)
+            {
+                try
+                {
+                    var rows = await LabeledRuleMetricsReader.ReadAsync(db.Connection, ct);
+                    var usefulness = await LabeledRuleMetricsReader.ReadUsefulnessAsync(db.Connection, ct);
+
+                    Console.WriteLine($"rules_with_labels={rows.Count}");
+
+                    var top = rows
+                        .Where(r => r.Tp > 0 || r.Fp > 0 || r.Fn > 0)
+                        .OrderByDescending(r => r.Fp)
+                        .ThenByDescending(r => r.Fn)
+                        .ThenBy(r => r.Tp)
+                        .Take(8);
+
+                    foreach (var row in top)
+                    {
+                        Console.WriteLine(
+                            $"{row.RuleId,-10} labeled={row.Labeled,3} " +
+                            $"tp={row.Tp,3} fp={row.Fp,3} fn={row.Fn,3} " +
+                            $"prec={row.PrecisionScore?.ToString() ?? string.Empty}");
+                    }
+
+                    if (dryRun)
+                        return;
+
+                    var snapshotId = await AuditSnapshotWriter.InsertAsync(
+                        db.Connection, rows, usefulness, notes, ct);
+                    Console.WriteLine($"snapshot_id={snapshotId} rows={rows.Count}");
                 }
                 catch (Exception ex)
                 {

--- a/src/GauntletCI.Cli/Commands/Factories/ICommandFactory.cs
+++ b/src/GauntletCI.Cli/Commands/Factories/ICommandFactory.cs
@@ -55,6 +55,7 @@ public interface ICorpusUtilityFactory : ICommandFactory
     Command CreateErrors();
     Command CreateRejectedRepos();
     Command CreateDoctor();
+    Command CreateAuditSnapshot();
 }
 
 /// <summary>
@@ -102,4 +103,5 @@ internal class CorpusUtilityFactoryImpl : ICorpusUtilityFactory
     public Command CreateErrors() => CorpusUtilityFactory.CreateErrors();
     public Command CreateRejectedRepos() => CorpusUtilityFactory.CreateRejectedRepos();
     public Command CreateDoctor() => CorpusUtilityFactory.CreateDoctor();
+    public Command CreateAuditSnapshot() => CorpusUtilityFactory.CreateAuditSnapshot();
 }

--- a/src/GauntletCI.Corpus/Scoring/LabeledRuleMetricsReader.cs
+++ b/src/GauntletCI.Corpus/Scoring/LabeledRuleMetricsReader.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Elastic-2.0
+using Microsoft.Data.Sqlite;
+
+namespace GauntletCI.Corpus.Scoring;
+
+/// <summary>
+/// Labeled TP/FP/FN per rule from <c>expected_findings</c> vs latest completed run.
+/// Matches agent script <c>corpus_db_read.compute_labeled_rule_metrics</c> (EvaluationClassifier parity).
+/// </summary>
+public sealed record LabeledRuleMetric(
+    string RuleId,
+    int Labeled,
+    int Tp,
+    int Fp,
+    int Fn,
+    double? PrecisionScore,
+    double? RecallScore);
+
+public static class LabeledRuleMetricsReader
+{
+    private const string LatestRunCte = """
+        WITH latest AS (
+            SELECT fixture_id, id AS run_id
+            FROM (
+                SELECT fixture_id,
+                       id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY fixture_id
+                           ORDER BY completed_at_utc DESC, id DESC
+                       ) AS rn
+                FROM rule_runs
+                WHERE UPPER(status) = 'COMPLETED'
+            )
+            WHERE rn = 1
+        )
+        """;
+
+    private const string MetricsSql = """
+        , pairs AS (
+            SELECT ef.rule_id,
+                   ef.fixture_id,
+                   ef.should_trigger,
+                   COALESCE(MAX(af.did_trigger), 0) AS did_trigger
+            FROM expected_findings ef
+            INNER JOIN latest lr ON lr.fixture_id = ef.fixture_id
+            LEFT JOIN actual_findings af
+              ON af.fixture_id = ef.fixture_id
+             AND af.rule_id = ef.rule_id
+             AND af.run_id = lr.run_id
+            WHERE COALESCE(ef.is_inconclusive, 0) = 0
+            GROUP BY ef.rule_id, ef.fixture_id, ef.should_trigger
+        )
+        SELECT rule_id,
+               COUNT(*) AS labeled,
+               SUM(CASE WHEN should_trigger = 1 AND did_trigger = 1 THEN 1 ELSE 0 END) AS tp,
+               SUM(CASE WHEN should_trigger = 0 AND did_trigger = 1 THEN 1 ELSE 0 END) AS fp,
+               SUM(CASE WHEN should_trigger = 1 AND did_trigger = 0 THEN 1 ELSE 0 END) AS fn
+        FROM pairs
+        GROUP BY rule_id
+        ORDER BY rule_id
+        """;
+
+    public static async Task<IReadOnlyList<LabeledRuleMetric>> ReadAsync(
+        SqliteConnection connection,
+        CancellationToken ct = default)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = LatestRunCte + MetricsSql;
+
+        var rows = new List<LabeledRuleMetric>();
+        using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var ruleId = reader.GetString(0);
+            var labeled = reader.GetInt32(1);
+            var tp = reader.GetInt32(2);
+            var fp = reader.GetInt32(3);
+            var fn = reader.GetInt32(4);
+
+            double? precision = tp + fp > 0 ? Math.Round(tp / (double)(tp + fp), 3) : null;
+            double? recall = tp + fn > 0 ? Math.Round(tp / (double)(tp + fn), 3) : null;
+
+            rows.Add(new LabeledRuleMetric(ruleId, labeled, tp, fp, fn, precision, recall));
+        }
+
+        return rows;
+    }
+
+    public static async Task<IReadOnlyDictionary<string, double?>> ReadUsefulnessAsync(
+        SqliteConnection connection,
+        CancellationToken ct = default)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT rule_id, AVG(usefulness)
+            FROM evaluations
+            GROUP BY rule_id
+            """;
+
+        var map = new Dictionary<string, double?>(StringComparer.Ordinal);
+        using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var ruleId = reader.GetString(0);
+            double? usefulness = reader.IsDBNull(1) ? null : Math.Round(reader.GetDouble(1), 3);
+            map[ruleId] = usefulness;
+        }
+
+        return map;
+    }
+}

--- a/src/GauntletCI.Corpus/Storage/AuditSnapshotWriter.cs
+++ b/src/GauntletCI.Corpus/Storage/AuditSnapshotWriter.cs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Scoring;
+using Microsoft.Data.Sqlite;
+
+namespace GauntletCI.Corpus.Storage;
+
+/// <summary>
+/// Persists labeled rule metrics into <c>audit_snapshots</c> / <c>audit_snapshot_rows</c>.
+/// </summary>
+public static class AuditSnapshotWriter
+{
+    public static async Task<int> InsertAsync(
+        SqliteConnection connection,
+        IReadOnlyList<LabeledRuleMetric> rows,
+        IReadOnlyDictionary<string, double?> usefulness,
+        string? notes,
+        CancellationToken ct = default)
+    {
+        var snappedAt = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
+
+        using var insertSnapshot = connection.CreateCommand();
+        insertSnapshot.CommandText = """
+            INSERT INTO audit_snapshots (snapped_at_utc, rules_snapped, notes)
+            VALUES ($snappedAt, $rulesSnapped, $notes)
+            """;
+        insertSnapshot.Parameters.AddWithValue("$snappedAt", snappedAt);
+        insertSnapshot.Parameters.AddWithValue("$rulesSnapped", rows.Count);
+        insertSnapshot.Parameters.AddWithValue("$notes", (object?)notes ?? DBNull.Value);
+        await insertSnapshot.ExecuteNonQueryAsync(ct);
+
+        using var idCmd = connection.CreateCommand();
+        idCmd.CommandText = "SELECT last_insert_rowid()";
+        var snapshotIdObj = await idCmd.ExecuteScalarAsync(ct);
+        var snapshotId = Convert.ToInt32(snapshotIdObj);
+
+        using var insertRow = connection.CreateCommand();
+        insertRow.CommandText = """
+            INSERT INTO audit_snapshot_rows (
+                snapshot_id, rule_id, labeled, tp, fp, fn,
+                precision_score, recall_score, usefulness_score
+            ) VALUES (
+                $snapshotId, $ruleId, $labeled, $tp, $fp, $fn,
+                $precision, $recall, $usefulness
+            )
+            """;
+
+        var snapshotParam = insertRow.Parameters.Add("$snapshotId", SqliteType.Integer);
+        var ruleParam = insertRow.Parameters.Add("$ruleId", SqliteType.Text);
+        var labeledParam = insertRow.Parameters.Add("$labeled", SqliteType.Integer);
+        var tpParam = insertRow.Parameters.Add("$tp", SqliteType.Integer);
+        var fpParam = insertRow.Parameters.Add("$fp", SqliteType.Integer);
+        var fnParam = insertRow.Parameters.Add("$fn", SqliteType.Integer);
+        var precisionParam = insertRow.Parameters.Add("$precision", SqliteType.Real);
+        var recallParam = insertRow.Parameters.Add("$recall", SqliteType.Real);
+        var usefulnessParam = insertRow.Parameters.Add("$usefulness", SqliteType.Real);
+
+        snapshotParam.Value = snapshotId;
+
+        foreach (var row in rows)
+        {
+            usefulness.TryGetValue(row.RuleId, out var usefulnessScore);
+
+            ruleParam.Value = row.RuleId;
+            labeledParam.Value = row.Labeled;
+            tpParam.Value = row.Tp;
+            fpParam.Value = row.Fp;
+            fnParam.Value = row.Fn;
+            precisionParam.Value = row.PrecisionScore.HasValue ? row.PrecisionScore.Value : DBNull.Value;
+            recallParam.Value = row.RecallScore.HasValue ? row.RecallScore.Value : DBNull.Value;
+            usefulnessParam.Value = usefulnessScore.HasValue ? usefulnessScore.Value : DBNull.Value;
+
+            await insertRow.ExecuteNonQueryAsync(ct);
+        }
+
+        return snapshotId;
+    }
+}

--- a/src/GauntletCI.Corpus/Storage/CorpusDb.cs
+++ b/src/GauntletCI.Corpus/Storage/CorpusDb.cs
@@ -434,5 +434,28 @@ internal static class SchemaInitializer
         "CREATE INDEX IF NOT EXISTS idx_actual_findings_run_trigger ON actual_findings(run_id, did_trigger)",
         "CREATE INDEX IF NOT EXISTS idx_rule_runs_fixture_completed ON rule_runs(fixture_id, completed_at_utc)",
         "CREATE INDEX IF NOT EXISTS idx_expected_findings_fixture_rule ON expected_findings(fixture_id, rule_id)",
+        """
+        CREATE TABLE IF NOT EXISTS audit_snapshots (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            snapped_at_utc TEXT NOT NULL,
+            rules_snapped  INTEGER NOT NULL,
+            notes          TEXT
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS audit_snapshot_rows (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            snapshot_id       INTEGER NOT NULL REFERENCES audit_snapshots(id),
+            rule_id           TEXT NOT NULL,
+            labeled           INTEGER NOT NULL DEFAULT 0,
+            tp                INTEGER NOT NULL DEFAULT 0,
+            fp                INTEGER NOT NULL DEFAULT 0,
+            fn                INTEGER NOT NULL DEFAULT 0,
+            precision_score   REAL,
+            recall_score      REAL,
+            usefulness_score  REAL
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS idx_audit_snapshot_rows_snapshot ON audit_snapshot_rows(snapshot_id)",
     ];
 }

--- a/tests/GauntletCI.Tests/Corpus/AuditSnapshotTests.cs
+++ b/tests/GauntletCI.Tests/Corpus/AuditSnapshotTests.cs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Corpus.Scoring;
+using GauntletCI.Corpus.Storage;
+using Microsoft.Data.Sqlite;
+
+namespace GauntletCI.Tests.Corpus;
+
+public class AuditSnapshotTests
+{
+    [Fact]
+    public async Task LabeledRuleMetricsReader_ComputesTpFpFn_FromLatestCompletedRun()
+    {
+        var tempDir = CreateTempDir();
+        try
+        {
+            var db = new CorpusDb(Path.Combine(tempDir, "corpus.db"));
+            await db.InitializeAsync(CancellationToken.None);
+            using (db)
+            {
+                await SeedMinimalFixtureAsync(db.Connection);
+
+                var metrics = await LabeledRuleMetricsReader.ReadAsync(db.Connection);
+                var gci0004 = Assert.Single(metrics, m => m.RuleId == "GCI0004");
+
+                Assert.Equal(2, gci0004.Labeled);
+                Assert.Equal(1, gci0004.Tp);
+                Assert.Equal(1, gci0004.Fp);
+                Assert.Equal(0, gci0004.Fn);
+                Assert.Equal(0.5, gci0004.PrecisionScore);
+                Assert.Equal(1.0, gci0004.RecallScore);
+            }
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task AuditSnapshotWriter_InsertsSnapshotAndRows()
+    {
+        var tempDir = CreateTempDir();
+        try
+        {
+            var db = new CorpusDb(Path.Combine(tempDir, "corpus.db"));
+            await db.InitializeAsync(CancellationToken.None);
+            using (db)
+            {
+                await SeedMinimalFixtureAsync(db.Connection);
+
+                var rows = await LabeledRuleMetricsReader.ReadAsync(db.Connection);
+                var usefulness = await LabeledRuleMetricsReader.ReadUsefulnessAsync(db.Connection);
+
+                var snapshotId = await AuditSnapshotWriter.InsertAsync(
+                    db.Connection,
+                    rows,
+                    usefulness,
+                    "unit test",
+                    CancellationToken.None);
+
+                Assert.True(snapshotId > 0);
+
+                using var countCmd = db.Connection.CreateCommand();
+                countCmd.CommandText = "SELECT COUNT(*) FROM audit_snapshot_rows WHERE snapshot_id = $id";
+                countCmd.Parameters.AddWithValue("$id", snapshotId);
+                var rowCount = Convert.ToInt32(await countCmd.ExecuteScalarAsync());
+                Assert.Equal(rows.Count, rowCount);
+            }
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+
+    private static void CleanupTempDir(string tempDir)
+    {
+        SqliteConnection.ClearAllPools();
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, recursive: true);
+    }
+
+    private static async Task SeedMinimalFixtureAsync(SqliteConnection connection)
+    {
+        using var tx = connection.BeginTransaction();
+
+        InsertFixture(connection, "fix1", "discovery", "org/repo", 1);
+        InsertRuleRun(connection, "run-old", "fix1", "2026-06-01T00:00:00Z", "Completed");
+        InsertRuleRun(connection, "run-new", "fix1", "2026-06-02T00:00:00Z", "Completed");
+
+        InsertExpected(connection, "ef1", "fix1", "GCI0004", shouldTrigger: 1);
+        InsertExpected(connection, "ef2", "fix1", "GCI0004", shouldTrigger: 0);
+
+        InsertActual(connection, "af1", "fix1", "run-new", "GCI0004", didTrigger: 1);
+        InsertActual(connection, "af2", "fix1", "run-new", "GCI0004", didTrigger: 1);
+
+        await tx.CommitAsync();
+    }
+
+    private static void InsertFixture(SqliteConnection connection, string fixtureId, string tier, string repo, int prNumber)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO fixtures (id, fixture_id, tier, repo, pr_number)
+            VALUES ($id, $fixtureId, $tier, $repo, $prNumber)
+            """;
+        cmd.Parameters.AddWithValue("$id", fixtureId);
+        cmd.Parameters.AddWithValue("$fixtureId", fixtureId);
+        cmd.Parameters.AddWithValue("$tier", tier);
+        cmd.Parameters.AddWithValue("$repo", repo);
+        cmd.Parameters.AddWithValue("$prNumber", prNumber);
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void InsertRuleRun(
+        SqliteConnection connection,
+        string runId,
+        string fixtureId,
+        string completedAtUtc,
+        string status)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO rule_runs (id, fixture_id, started_at_utc, completed_at_utc, status)
+            VALUES ($id, $fixtureId, $started, $completed, $status)
+            """;
+        cmd.Parameters.AddWithValue("$id", runId);
+        cmd.Parameters.AddWithValue("$fixtureId", fixtureId);
+        cmd.Parameters.AddWithValue("$started", completedAtUtc);
+        cmd.Parameters.AddWithValue("$completed", completedAtUtc);
+        cmd.Parameters.AddWithValue("$status", status);
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void InsertExpected(
+        SqliteConnection connection,
+        string id,
+        string fixtureId,
+        string ruleId,
+        int shouldTrigger)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO expected_findings (id, fixture_id, rule_id, should_trigger, is_inconclusive)
+            VALUES ($id, $fixtureId, $ruleId, $shouldTrigger, 0)
+            """;
+        cmd.Parameters.AddWithValue("$id", id);
+        cmd.Parameters.AddWithValue("$fixtureId", fixtureId);
+        cmd.Parameters.AddWithValue("$ruleId", ruleId);
+        cmd.Parameters.AddWithValue("$shouldTrigger", shouldTrigger);
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void InsertActual(
+        SqliteConnection connection,
+        string id,
+        string fixtureId,
+        string runId,
+        string ruleId,
+        int didTrigger)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO actual_findings (id, fixture_id, run_id, rule_id, did_trigger)
+            VALUES ($id, $fixtureId, $runId, $ruleId, $didTrigger)
+            """;
+        cmd.Parameters.AddWithValue("$id", id);
+        cmd.Parameters.AddWithValue("$fixtureId", fixtureId);
+        cmd.Parameters.AddWithValue("$runId", runId);
+        cmd.Parameters.AddWithValue("$ruleId", ruleId);
+        cmd.Parameters.AddWithValue("$didTrigger", didTrigger);
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/tests/GauntletCI.Tests/CorpusCommandFactoriesTests.cs
+++ b/tests/GauntletCI.Tests/CorpusCommandFactoriesTests.cs
@@ -238,6 +238,18 @@ public class CorpusUtilityFactoryTests
         Assert.NotNull(cmd.Description);
         Assert.NotEmpty(cmd.Description);
     }
+
+    [Fact]
+    public void CreateAuditSnapshot_ReturnsValidCommand()
+    {
+        var cmd = CorpusUtilityFactory.CreateAuditSnapshot();
+
+        Assert.NotNull(cmd);
+        Assert.Equal("audit-snapshot", cmd.Name);
+        Assert.NotNull(cmd.Description);
+        Assert.NotEmpty(cmd.Description);
+        Assert.Contains(cmd.Options, o => o.Name == "dry-run");
+    }
 }
 
 public class CommandFactoryDiTests
@@ -386,6 +398,7 @@ public class CorpusCommandIntegrationTests
         Assert.Contains("errors", subcommands);
         Assert.Contains("rejected-repos", subcommands);
         Assert.Contains("doctor", subcommands);
+        Assert.Contains("audit-snapshot", subcommands);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds `gauntletci corpus audit-snapshot` with `--db`, `--notes`, and `--dry-run`
- Core: `LabeledRuleMetricsReader` + `AuditSnapshotWriter` (same labeled TP/FP/FN SQL as agent `corpus_db_read.py`)
- CorpusDb migration creates `audit_snapshots` / `audit_snapshot_rows` on product DBs
- Agent refresh pipeline uses CLI instead of Python for step 5

## Test plan
- [x] Unit tests for metrics reader and snapshot writer
- [x] Factory/integration tests for command registration
- [x] Dry-run against agent corpus DB (38 rules)
- [ ] Full CI