### PR TITLE
Fix benchmark gold metrics: latest completed run, not MAX(uuid)

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -41,7 +41,7 @@ Sections marked **Status: Not yet implemented** describe planned behavior only. 
 
 Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpus.db` (not the empty `./data/gauntletci-corpus.db` shell).
 
-**Last queried:** 2026-06-13 (`python scripts/corpus-validation-summary.py` after discovery `run-all` + `corpus score`).
+**Last queried:** 2026-06-15 (`python scripts/corpus-validation-summary.py` after audit-pass2 latest-run query fix + snapshot #18).
 
 | Metric | Value |
 |--------|------:|
@@ -50,30 +50,33 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 | Distinct rules with gold labels | 41 |
 | Rule runs stored | 6,162 |
 | `aggregates` table last updated | 2026-06-13 |
-| Audit snapshot last taken | 2026-06-13 |
+| Audit snapshot last taken | 2026-06-15 (snapshot #18) |
 
-**Audit snapshot (labeled subset):** tp/fp/fn from `expected_findings` vs latest completed run (`audit_snapshot_rows` snapshot #17).
+**Latest-run selection:** `rule_runs.id` is a UUID string. Gold metrics and `eval/benchmark-discovery-sweep.json` use the latest **completed** run per fixture (`ORDER BY completed_at_utc DESC, id DESC`). Do not use `MAX(id)` on UUIDs.
+
+**Audit snapshot (labeled subset):** tp/fp/fn from `expected_findings` vs latest completed run (`audit_snapshot_rows` snapshot #18).
 
 | Rule | Labeled | TP | FP | FN | Precision |
 |------|--------:|---:|---:|---:|----------:|
-| GCI0004 | 53 | 31 | 11 | 3 | 0.74 |
-| GCI0003 | 44 | 27 | 9 | 0 | 0.75 |
-| GCI0006 | 29 | 17 | 4 | 0 | 0.81 |
-| GCI0015 | 26 | 11 | 5 | 0 | 0.69 |
-| GCI0024 | 19 | 2 | 7 | 0 | 0.22 |
-| GCI0010 | 19 | 1 | 6 | 1 | 0.14 |
+| GCI0004 | 53 | 6 | 1 | 28 | 0.86 |
+| GCI0003 | 44 | 13 | 1 | 14 | 0.93 |
+| GCI0006 | 29 | 10 | 1 | 7 | 0.91 |
+| GCI0015 | 26 | 1 | 0 | 10 | 1.00 |
+| GCI0016 | 15 | 2 | 0 | 4 | 1.00 |
+| GCI0036 | 16 | 1 | 0 | 3 | 1.00 |
+| GCI0010 | 19 | 0 | 0 | 2 | — |
+| GCI0024 | 19 | 0 | 0 | 2 | — |
 
 **Gold labels vs latest run** (414 `expected_findings` rows in DB; min 3 labeled pairs per rule):
 
 | Rule | TP | FP | FN | Precision |
 |------|---:|---:|---:|----------:|
-| GCI0004 | 31 | 11 | 0 | 0.74 |
-| GCI0003 | 27 | 9 | 0 | 0.75 |
-| GCI0006 | 17 | 4 | 0 | 0.81 |
-| GCI0015 | 11 | 5 | 0 | 0.69 |
-| GCI0010 | 1 | 6 | 0 | 0.14 |
-| GCI0024 | 2 | 7 | 0 | 0.22 |
-| GCI0016 | 6 | 0 | 0 | 1.00 |
+| GCI0004 | 6 | 1 | 28 | 0.86 |
+| GCI0003 | 13 | 1 | 14 | 0.93 |
+| GCI0006 | 10 | 1 | 7 | 0.91 |
+| GCI0015 | 1 | 0 | 10 | 1.00 |
+| GCI0016 | 2 | 0 | 4 | 1.00 |
+| GCI0036 | 1 | 0 | 3 | 1.00 |
 
 **Discovery-tier trigger rates** (606-fixture sweep; scored 2026-06-13). Per-fixture `expected.json` exists on only ~24 fixtures, so `aggregates.precision_score` for Discovery is mostly 0 — use the gold-label table above for labeled precision.
 
@@ -88,7 +91,7 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 | GCI0043 | 0.06 |
 | GCI0032 | 0.06 |
 
-**High trigger, low gold precision (noise candidates):** GCI0019 (22% trigger, unlabeled discovery), GCI0010 (0.14 gold precision), GCI0024 (0.22). GCI0001 trigger dropped to 8% post-#264 companion-file fix (was ~48% in April aggregates).
+**High trigger, low gold precision (noise candidates):** GCI0019 (22% trigger, unlabeled discovery). On the latest completed discovery run, GCI0010 and GCI0024 show recall gaps (FN on labeled fixtures, no FP on latest run). Prior aggregate snapshots showed lower precision when stale runs were selected via `MAX(id)` on UUID run IDs (fixed in pass-2 audit).
 
 **Refresh after rule changes:**
 

--- a/eval/benchmark-discovery-sweep.json
+++ b/eval/benchmark-discovery-sweep.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "generatedUtc": "2026-06-14T01:30:02Z",
-  "corpusNote": "606 discovery fixtures; agent corpus only. Regenerate with scripts/export-benchmark-discovery-sweep.py",
+  "generatedUtc": "2026-06-15T14:59:44Z",
+  "corpusNote": "608 total fixtures (606 discovery); agent corpus only. Regenerate with scripts/export-benchmark-discovery-sweep.py",
   "discoveryRows": [
     {
       "id": "GCI0019",
@@ -12,19 +12,18 @@
       "id": "GCI0003",
       "name": "Behavioral Change Detection",
       "triggerPct": "18%",
-      "goldPrecision": "75%"
+      "goldPrecision": "93%"
     },
     {
       "id": "GCI0006",
       "name": "Edge Case Handling",
       "triggerPct": "12%",
-      "goldPrecision": "81%"
+      "goldPrecision": "91%"
     },
     {
       "id": "GCI0024",
       "name": "Resource Lifecycle",
-      "triggerPct": "9%",
-      "goldPrecision": "22%"
+      "triggerPct": "9%"
     },
     {
       "id": "GCI0001",
@@ -42,30 +41,27 @@
       "id": "GCI0004",
       "name": "Breaking Change Risk",
       "triggerPct": "4%",
-      "goldPrecision": "74%"
+      "goldPrecision": "86%"
     },
     {
       "id": "GCI0010",
       "name": "Hardcoding and Configuration",
       "triggerPct": "0%",
-      "goldPrecision": "14%",
       "note": "Silver card has no P/R; gold labels on agent corpus only"
     },
     {
       "id": "GCI0015",
       "name": "Data Integrity Risk",
       "triggerPct": "0%",
-      "goldPrecision": "69%",
+      "goldPrecision": "100%",
       "note": "Not on Silver benchmark cards yet"
     }
   ],
   "ruleCardAgentGold": {
-    "GCI0003": "75%",
-    "GCI0004": "74%",
-    "GCI0006": "81%",
-    "GCI0010": "14%",
-    "GCI0016": "100%",
-    "GCI0024": "22%"
+    "GCI0003": "93%",
+    "GCI0004": "86%",
+    "GCI0006": "91%",
+    "GCI0016": "100%"
   },
   "fixtureCount": 608
 }

--- a/scripts/benchmark_discovery_lib.py
+++ b/scripts/benchmark_discovery_lib.py
@@ -26,7 +26,7 @@ def load_db_metrics(db_path: Path) -> tuple[dict[str, str], dict[str, str], int]
         sys.path.insert(0, str(REPO / "scripts"))
         sys_path_inserted = True
 
-    from corpus_db_read import ensure_read_indexes  # noqa: E402
+    from corpus_db_read import compute_labeled_rule_metrics, ensure_read_indexes  # noqa: E402
 
     con = sqlite3.connect(db_path)
     ensure_read_indexes(con)
@@ -45,40 +45,13 @@ def load_db_metrics(db_path: Path) -> tuple[dict[str, str], dict[str, str], int]
     ).fetchall()
     triggers = {rid: pct_string(rate) for rid, rate in trigger_rows if rate is not None}
 
-    gold_rows = cur.execute(
-        """
-        WITH latest AS (
-            SELECT fixture_id, MAX(id) AS run_id
-            FROM rule_runs
-            GROUP BY fixture_id
-        ),
-        pairs AS (
-            SELECT ef.rule_id,
-                   ef.fixture_id,
-                   ef.should_trigger,
-                   MAX(af.did_trigger) AS did_trigger
-            FROM expected_findings ef
-            JOIN latest lr ON lr.fixture_id = ef.fixture_id
-            JOIN actual_findings af
-              ON af.fixture_id = ef.fixture_id
-             AND af.rule_id = ef.rule_id
-             AND af.run_id = lr.run_id
-            WHERE ef.is_inconclusive = 0
-            GROUP BY ef.rule_id, ef.fixture_id, ef.should_trigger
-        )
-        SELECT rule_id,
-               SUM(CASE WHEN should_trigger = 1 AND did_trigger = 1 THEN 1 ELSE 0 END) AS tp,
-               SUM(CASE WHEN should_trigger = 0 AND did_trigger = 1 THEN 1 ELSE 0 END) AS fp
-        FROM pairs
-        GROUP BY rule_id
-        """
-    ).fetchall()
+    # Same latest-run + LEFT JOIN logic as LabeledRuleMetricsReader / audit-snapshot CLI.
+    labeled = compute_labeled_rule_metrics(cur)
     gold: dict[str, str] = {}
-    for rule_id, tp, fp in gold_rows:
-        tp = int(tp or 0)
-        fp = int(fp or 0)
-        if tp + fp:
-            gold[rule_id] = pct_string(tp / (tp + fp)) or ""
+    for rule_id, entry in labeled.items():
+        precision = entry.get("labeled_precision")
+        if precision is not None:
+            gold[rule_id] = pct_string(precision) or ""
 
     con.close()
     return triggers, gold, fixture_count

--- a/scripts/export-benchmark-discovery-sweep.py
+++ b/scripts/export-benchmark-discovery-sweep.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sqlite3
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,6 +35,8 @@ def refresh_metrics(doc: dict, triggers: dict[str, str], gold: dict[str, str]) -
     for rule_id in list(card_gold.keys()):
         if rule_id in gold:
             card_gold[rule_id] = gold[rule_id]
+        else:
+            del card_gold[rule_id]
 
     doc["generatedUtc"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     return doc
@@ -62,6 +65,16 @@ def main() -> None:
     triggers, gold, fixture_count = load_db_metrics(db_path)
     doc = refresh_metrics(doc, triggers, gold)
     doc["fixtureCount"] = fixture_count
+
+    con = sqlite3.connect(db_path)
+    discovery_count = int(
+        con.execute("SELECT COUNT(*) FROM fixtures WHERE tier = 'Discovery'").fetchone()[0]
+    )
+    con.close()
+    doc["corpusNote"] = (
+        f"{fixture_count} total fixtures ({discovery_count} discovery); agent corpus only. "
+        "Regenerate with scripts/export-benchmark-discovery-sweep.py"
+    )
 
     payload = json.dumps(doc, indent=2) + "\n"
     if args.dry_run:

--- a/site/app/docs/privacy-modes/page.tsx
+++ b/site/app/docs/privacy-modes/page.tsx
@@ -51,7 +51,7 @@ export default function PrivacyModesPage() {
                 <div>
                   <p className="font-semibold text-foreground mb-1">✓ What's enabled:</p>
                   <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-                    <li>37 built-in deterministic rules (GCI0001-GCI0037)</li>
+                    <li>37 active deterministic rules (39 implemented in Core; see Rule Reference)</li>
                     <li>Diff-based change detection</li>
                     <li>Local AST analysis (Roslyn syntax trees)</li>
                     <li>Pre-commit hook integration</li>


### PR DESCRIPTION
## Summary
- Replace broken `MAX(id)` on UUID `rule_runs.id` in `benchmark_discovery_lib.py` with shared `compute_labeled_rule_metrics` (same query as audit-snapshot CLI and `LabeledRuleMetricsReader`).
- Re-export `eval/benchmark-discovery-sweep.json` from agent corpus (e.g. GCI0003 agent gold 75% -> 93%).
- Refresh `docs/rules.md` corpus validation tables for audit snapshot #18 and document latest-run selection.
- Fix privacy-modes page rule count copy (37 active, not GCI0001-GCI0037).
- Export script now prunes stale `ruleCardAgentGold` keys and sets accurate `corpusNote`.

## Test plan
- [x] `dotnet build` + `dotnet test GauntletCI.slnx` (1942 passed)
- [x] `python scripts/corpus-benchmark-discovery-drift.py --db ~/.gauntletci/corpus.db`
- [x] `gauntletci corpus audit-snapshot` -> snapshot #18
- [x] `cd site && npm run build`
- [x] Pre-commit GauntletCI analyze on staged diff