### PR TITLE
Fix worker esbuild Dependabot alerts and enable npm Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,30 @@ updates:
     labels:
       - "dependencies"
 
+  - package-ecosystem: "npm"
+    directory: "/worker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/github-app-server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -67,6 +67,40 @@ jobs:
       - name: Audit npm dependencies
         run: pnpm audit --audit-level moderate
 
+  npm-audit-worker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: worker
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      - run: npm ci
+      - run: npm audit --audit-level moderate
+
+  npm-audit-github-app-server:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: github-app-server
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: github-app-server/package-lock.json
+
+      - run: npm ci
+      - run: npm audit --audit-level moderate
+
   dependency-review:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'

--- a/github-app-server/package-lock.json
+++ b/github-app-server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^22.10.0",
+        "esbuild": "0.28.1",
         "tsx": "^4.20.6",
         "typescript": "^5.7.3"
       }

--- a/github-app-server/package.json
+++ b/github-app-server/package.json
@@ -12,7 +12,11 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^22.10.0",
+    "esbuild": "0.28.1",
     "tsx": "^4.20.6",
     "typescript": "^5.7.3"
+  },
+  "overrides": {
+    "esbuild": "0.28.1"
   }
 }

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240725.0",
+        "esbuild": "0.28.1",
         "typescript": "^5.5.0",
         "wrangler": "^4.84.1"
       }
@@ -1490,9 +1491,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -9,11 +9,13 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240725.0",
+    "esbuild": "0.28.1",
     "typescript": "^5.5.0",
     "wrangler": "^4.84.1"
   },
   "overrides": {
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "ws": "8.21.0"
   },
   "dependencies": {
     "jose": "^5.9.3"


### PR DESCRIPTION
## Summary
- **Root cause:** `worker/` pulls `esbuild@0.27.3` via `wrangler`; npm overrides alone did not satisfy GitHub Dependabot graph scanning.
- Pin `esbuild@0.28.1` as a direct devDependency plus npm overrides (fixes GHSA-gv7w-rqvm-qjhr and GHSA-g7r4-m6w7-qqqr).
- Override transitive `ws` to `8.21.0` (miniflare/wrangler GHSA-96hv-2xvq-fx4p).
- Add npm ecosystems to `.github/dependabot.yml` for `worker/`, `github-app-server/`, and `site/` so security updates can open PRs.
- Extend `security.yml` with `npm audit` jobs for worker and github-app-server.

## Test plan
- [x] `cd worker && npm audit` — 0 vulnerabilities
- [x] `cd github-app-server && npm audit` — 0 vulnerabilities