### PR TITLE
Bump Microsoft.Extensions.Hosting to 10.0.9

### DIFF
--- a/src/GauntletCI.Cli/GauntletCI.Cli.csproj
+++ b/src/GauntletCI.Cli/GauntletCI.Cli.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <PackageReference Include="Spectre.Console" Version="0.57.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
Completes Dependabot #282 after merge conflict with #281. Patch bump 10.0.8 -> 10.0.9.