### PR TITLE
fix(eval): add rule-audit.json drift guard for CI

### DIFF
--- a/.github/workflows/benchmark-discovery-drift.yml
+++ b/.github/workflows/benchmark-discovery-drift.yml
@@ -7,9 +7,13 @@ on:
       - "site/app/benchmark/page.tsx"
       - "site/tsconfig.json"
       - "eval/benchmark-discovery-sweep.json"
+      - "eval/rule-audit.json"
       - "scripts/corpus-benchmark-discovery-drift.py"
+      - "scripts/corpus-rule-audit-drift.py"
       - "scripts/export-benchmark-discovery-sweep.py"
       - "scripts/benchmark_discovery_lib.py"
+      - "scripts/rule_audit_lib.py"
+      - "scripts/build-rule-audit.py"
       - "scripts/corpus_db_read.py"
       - "scripts/refresh-agent-corpus.ps1"
       - "docs/rules.md"
@@ -20,9 +24,13 @@ on:
       - "site/app/benchmark/page.tsx"
       - "site/tsconfig.json"
       - "eval/benchmark-discovery-sweep.json"
+      - "eval/rule-audit.json"
       - "scripts/corpus-benchmark-discovery-drift.py"
+      - "scripts/corpus-rule-audit-drift.py"
       - "scripts/export-benchmark-discovery-sweep.py"
       - "scripts/benchmark_discovery_lib.py"
+      - "scripts/rule_audit_lib.py"
+      - "scripts/build-rule-audit.py"
       - "scripts/corpus_db_read.py"
       - "scripts/refresh-agent-corpus.ps1"
       - "docs/rules.md"
@@ -40,3 +48,6 @@ jobs:
 
       - name: Validate sweep JSON schema (DB compare is local-only)
         run: python scripts/corpus-benchmark-discovery-drift.py --skip-if-missing-db
+
+      - name: Validate rule-audit JSON schema (DB compare is local-only)
+        run: python scripts/corpus-rule-audit-drift.py --skip-if-missing-db

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -100,7 +100,7 @@ Ground-truth labels live in the agent corpus at `%USERPROFILE%\.gauntletci\corpu
 3. `gauntletci corpus score --db %USERPROFILE%\.gauntletci\corpus.db`
 4. `python scripts/corpus-validation-summary.py` — update this section from the JSON output
 5. `gauntletci corpus audit-snapshot --db <path>` (or `python scripts/corpus-audit-snapshot.py`) — refresh `audit_snapshots`
-6. `python scripts/build-rule-audit.py --full-corpus` — regenerate `eval/rule-audit.json` (uses `corpus_db_read` indexes; ~10s on agent DB)
+6. `python scripts/build-rule-audit.py --full-corpus` then `python scripts/corpus-rule-audit-drift.py` — regenerate and verify `eval/rule-audit.json` labeled metrics (~10s on agent DB)
 7. `python scripts/export-benchmark-discovery-sweep.py` then `python scripts/corpus-benchmark-discovery-drift.py` — refresh `eval/benchmark-discovery-sweep.json` and verify vs agent DB (CI: `.github/workflows/benchmark-discovery-drift.yml` with `--skip-if-missing-db`)
 
 The public [benchmark page](https://gauntletci.com/benchmark) keeps Silver P/R on rule cards and adds **agent gold precision** (where 414 human labels exist) plus a separate discovery-sweep table. Do not treat those as Silver metrics.

--- a/scripts/corpus-rule-audit-drift.py
+++ b/scripts/corpus-rule-audit-drift.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Check eval/rule-audit.json labeled metrics match agent corpus DB (when present)."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DB = Path.home() / ".gauntletci" / "corpus.db"
+
+sys.path.insert(0, str(REPO / "scripts"))
+from rule_audit_lib import (  # noqa: E402
+    RULE_AUDIT_JSON,
+    extract_labeled_metrics,
+    load_db_labeled_metrics,
+    load_rule_audit_json,
+    validate_rule_audit_json,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", default=str(DEFAULT_DB))
+    parser.add_argument(
+        "--json",
+        default=str(RULE_AUDIT_JSON),
+        help="Rule audit JSON path",
+    )
+    parser.add_argument(
+        "--skip-if-missing-db",
+        action="store_true",
+        help="Exit 0 when agent corpus DB is absent (CI)",
+    )
+    args = parser.parse_args()
+
+    json_path = Path(args.json)
+    if not json_path.exists():
+        raise SystemExit(f"Missing rule audit JSON: {json_path}")
+
+    doc = load_rule_audit_json(json_path)
+    schema_errors = validate_rule_audit_json(doc)
+    if schema_errors:
+        for line in schema_errors:
+            print(f"FAIL {line}", file=sys.stderr)
+        raise SystemExit(1)
+
+    expected = extract_labeled_metrics(doc)
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        if args.skip_if_missing_db:
+            print(
+                f"OK rule audit JSON schema ({len(doc.get('rules', []))} rules, "
+                f"{len(expected)} with labeled metrics); skip DB compare (no agent corpus in CI)"
+            )
+            return
+        raise SystemExit(f"Corpus DB not found: {db_path}")
+
+    actual = load_db_labeled_metrics(db_path)
+    errors: list[str] = []
+
+    for rule_id, exp in expected.items():
+        db_entry = actual.get(rule_id)
+        if not db_entry:
+            continue
+        for field in ("labeled_tp", "labeled_fp", "labeled_fn", "labeled_precision"):
+            if field not in exp:
+                continue
+            exp_val = exp[field]
+            db_val = db_entry.get(field)
+            if db_val is None and field == "labeled_precision" and exp_val == 0:
+                continue
+            if db_val is not None and exp_val != db_val:
+                errors.append(f"{rule_id} {field} json={exp_val} db={db_val}")
+
+    if errors:
+        for line in errors:
+            print(f"FAIL {line}", file=sys.stderr)
+        print(
+            "Regenerate with: python scripts/build-rule-audit.py --full-corpus",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    print(
+        f"OK rule audit labeled metrics match {db_path} "
+        f"({len(expected)} rules with labeled corpus metrics)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh-agent-corpus.ps1
+++ b/scripts/refresh-agent-corpus.ps1
@@ -57,4 +57,8 @@ Write-Log "Checking benchmark discovery metrics vs corpus DB"
 python (Join-Path $repo "scripts\corpus-benchmark-discovery-drift.py") --db $corpus 2>&1 |
     ForEach-Object { Write-Log $_ }
 
+Write-Log "Checking rule audit labeled metrics vs corpus DB"
+python (Join-Path $repo "scripts\corpus-rule-audit-drift.py") --db $corpus 2>&1 |
+    ForEach-Object { Write-Log $_ }
+
 Write-Log "Corpus refresh complete"

--- a/scripts/rule_audit_lib.py
+++ b/scripts/rule_audit_lib.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Shared helpers for eval/rule-audit.json export and drift checks."""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+RULE_AUDIT_JSON = REPO / "eval" / "rule-audit.json"
+
+RULE_ID_RE = re.compile(r"^GCI\d{4}$")
+
+
+def load_rule_audit_json(path: Path = RULE_AUDIT_JSON) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_rule_audit_json(doc: dict) -> list[str]:
+    """Structural checks for eval/rule-audit.json (CI-safe, no DB)."""
+    errors: list[str] = []
+
+    schema_version = doc.get("schema_version")
+    if not isinstance(schema_version, str) or not schema_version:
+        errors.append("schema_version must be a non-empty string")
+
+    if not isinstance(doc.get("generated_at"), str) or not doc["generated_at"]:
+        errors.append("generated_at must be a non-empty ISO timestamp string")
+
+    rule_count = doc.get("rule_count")
+    rules = doc.get("rules")
+    if not isinstance(rules, list) or not rules:
+        errors.append("rules must be a non-empty list")
+    else:
+        if isinstance(rule_count, int) and rule_count != len(rules):
+            errors.append(f"rule_count ({rule_count}) must match len(rules) ({len(rules)})")
+
+        seen_ids: set[str] = set()
+        for index, rule in enumerate(rules):
+            if not isinstance(rule, dict):
+                errors.append(f"rules[{index}] must be an object")
+                continue
+            rule_id = rule.get("rule_id")
+            if not isinstance(rule_id, str) or not RULE_ID_RE.match(rule_id):
+                errors.append(f"rules[{index}].rule_id must match GCI####")
+            elif rule_id in seen_ids:
+                errors.append(f"duplicate rules rule_id {rule_id}")
+            else:
+                seen_ids.add(rule_id)
+
+            corpus = rule.get("corpus")
+            if corpus is not None and not isinstance(corpus, dict):
+                errors.append(f"rules[{index}].corpus must be an object when present")
+
+            labeled_precision = (corpus or {}).get("labeled_precision")
+            if labeled_precision is not None and not isinstance(labeled_precision, (int, float)):
+                errors.append(f"rules[{index}].corpus.labeled_precision must be numeric")
+
+    return errors
+
+
+def extract_labeled_metrics(doc: dict) -> dict[str, dict]:
+    """Labeled TP/FP/FN/precision from each rule's corpus block."""
+    metrics: dict[str, dict] = {}
+    for rule in doc.get("rules", []):
+        if not isinstance(rule, dict):
+            continue
+        rule_id = rule.get("rule_id")
+        corpus = rule.get("corpus")
+        if not isinstance(rule_id, str) or not isinstance(corpus, dict):
+            continue
+        if corpus.get("labeled") is None and corpus.get("labeled_tp") is None:
+            continue
+        entry: dict = {}
+        for key in ("labeled", "labeled_tp", "labeled_fp", "labeled_fn", "labeled_precision"):
+            if key in corpus and corpus[key] is not None:
+                entry[key] = corpus[key]
+        if entry:
+            metrics[rule_id] = entry
+    return metrics
+
+
+def load_db_labeled_metrics(db_path: Path) -> dict[str, dict]:
+    import sys
+
+    sys.path.insert(0, str(REPO / "scripts"))
+    from corpus_db_read import compute_labeled_rule_metrics, ensure_read_indexes  # noqa: E402
+
+    con = sqlite3.connect(db_path)
+    ensure_read_indexes(con)
+    labeled = compute_labeled_rule_metrics(con.cursor())
+    con.close()
+    return labeled


### PR DESCRIPTION
## Summary
- Adds corpus-rule-audit-drift.py + rule_audit_lib.py to validate eval/rule-audit.json schema in CI and compare labeled TP/FP/FN/precision vs agent DB locally.
- Extends benchmark-discovery-drift workflow with a second step.
- Wires drift check into refresh-agent-corpus.ps1 and docs/rules.md refresh procedure.

Prevents stale public metrics (e.g. GCI0003 75% vs 93%) from shipping again after #303.

## Test plan
- [x] python scripts/corpus-rule-audit-drift.py --skip-if-missing-db
- [x] python scripts/corpus-rule-audit-drift.py --db %USERPROFILE%\.gauntletci\corpus.db (22 rules OK)