### PR TITLE
fix(site): update integration docs to NuGet 2.7.1 and action v2.7.1

### DIFF
--- a/site/app/demo/github-checks-sarif/page.tsx
+++ b/site/app/demo/github-checks-sarif/page.tsx
@@ -36,7 +36,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Install GauntletCI
-        run: dotnet tool install -g GauntletCI --version 2.1.1
+        run: dotnet tool install -g GauntletCI --version 2.7.1
 
       - name: Post GitHub Checks annotations
         env:
@@ -71,7 +71,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Install GauntletCI
-        run: dotnet tool install -g GauntletCI --version 2.1.1
+        run: dotnet tool install -g GauntletCI --version 2.7.1
 
       - name: Generate SARIF
         run: |

--- a/site/app/docs/integrations/azure-devops/page.tsx
+++ b/site/app/docs/integrations/azure-devops/page.tsx
@@ -207,7 +207,7 @@ export default function AzureDevOpsPage() {
                   ["sensitivity", "balanced", "strict | balanced | permissive. Controls the confidence threshold for findings."],
                   ["failOnBlock", "true", "Set the task result to Failed when any Block-severity finding is produced."],
                   ["workingDirectory", "$(Build.SourcesDirectory)", "Root of the .NET repository. Passed as the working directory for the GauntletCI process."],
-                  ["gauntletciVersion", "latest", "NuGet version to install. Use 'latest' or pin to a specific version such as '2.1.1'."],
+                  ["gauntletciVersion", "latest", "NuGet version to install. Use 'latest' or pin to a specific version such as '2.7.1'."],
                 ].map(([name, def, desc]) => (
                   <tr key={name}>
                     <td className="px-4 py-2 font-mono text-xs text-cyan-400">{name}</td>

--- a/site/app/docs/integrations/bitbucket/page.tsx
+++ b/site/app/docs/integrations/bitbucket/page.tsx
@@ -165,7 +165,7 @@ export default function BitbucketPage() {
             </div>
             <div className="p-4 font-mono text-xs space-y-1">
               <p className="text-muted-foreground">+ gauntletci analyze --diff pr.diff --no-banner --ascii</p>
-              <p className="text-foreground mt-2">GauntletCI v2.1.2</p>
+              <p className="text-foreground mt-2">GauntletCI v2.7.1</p>
               <p className="text-foreground">Analyzed 3 files, 47 changed lines</p>
               <p className="text-foreground mt-1">
                 <span className="text-red-400">[BLOCK]</span>{" "}

--- a/site/app/docs/integrations/github-action/page.tsx
+++ b/site/app/docs/integrations/github-action/page.tsx
@@ -34,7 +34,7 @@ const faqSchema = buildFaqSchema([
   },
   {
     q: "Can I pin to a specific GauntletCI tool version?",
-    a: "Yes. Set gauntletci-version to the exact NuGet version you want, such as '2.1.0'. The default is the latest published version.",
+    a: "Yes. Set gauntletci-version to the exact NuGet version you want, such as '2.7.1'. The default is the latest published version.",
   },
 ]);
 
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: EricCogen/GauntletCI@v2.1.2`;
+      - uses: EricCogen/GauntletCI@v2.7.1`;
 
 const FULL_WORKFLOW = `name: GauntletCI
 
@@ -71,7 +71,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: EricCogen/GauntletCI@v2.1.2
+      - uses: EricCogen/GauntletCI@v2.7.1
         id: gauntlet
         with:
           sensitivity: 'balanced'
@@ -205,7 +205,7 @@ export default function GithubActionPage() {
                   ["ascii", '"true"', "Use ASCII-only output. Recommended for CI logs - avoids encoding issues."],
                   ["commit", '""', "Commit SHA to analyze. Defaults to the PR head commit (github.event.pull_request.head.sha)."],
                   ["dotnet-version", '"8.0.x"', "The .NET SDK version to install on the runner."],
-                  ["gauntletci-version", '"2.1.1"', "The GauntletCI NuGet tool version to install."],
+                  ["gauntletci-version", '"2.7.1"', "The GauntletCI NuGet tool version to install."],
                 ].map(([name, def, desc]) => (
                   <tr key={name}>
                     <td className="px-4 py-2 font-mono text-xs text-cyan-400">{name}</td>
@@ -292,7 +292,7 @@ export default function GithubActionPage() {
             always passes.
           </p>
           <div className="rounded-lg border border-border bg-card p-4 font-mono text-sm">
-            <pre className="text-foreground whitespace-pre">{`- uses: EricCogen/GauntletCI@v2.1.2
+            <pre className="text-foreground whitespace-pre">{`- uses: EricCogen/GauntletCI@v2.7.1
   with:
     fail-on-findings: 'false'
     inline-comments: 'true'

--- a/site/app/docs/integrations/page.tsx
+++ b/site/app/docs/integrations/page.tsx
@@ -185,7 +185,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: EricCogen/GauntletCI@v2.1.2
+      - uses: EricCogen/GauntletCI@v2.7.1
         with:
           sensitivity: 'balanced'
           inline-comments: 'true'

--- a/site/components/terminal-block.tsx
+++ b/site/components/terminal-block.tsx
@@ -10,7 +10,7 @@ interface OutputLine {
 const lines: OutputLine[] = [
   { type: "cmd",      text: "$ gauntletci analyze --staged" },
   { type: "blank",    text: "" },
-  { type: "dim",      text: "  GauntletCI v2.1.0, 39 rules, diff-scoped" },
+  { type: "dim",      text: "  GauntletCI v2.7.1, 39 rules, diff-scoped" },
   { type: "blank",    text: "" },
   { type: "critical", text: "  [BLOCK]  GCI0004  Breaking change in public API", annotation: 1 },
   { type: "dim",      text: "           OrderService.cs:142: ProcessPayment(decimal amount, string currency)" },


### PR DESCRIPTION
## Summary
- Replace stale 2.1.x version examples on integration and demo pages.
- GitHub Action composite ref: @v2.7.1 (latest release tag).
- NuGet pin examples: 2.7.1 (latest on nuget.org, verified).

## Test plan
- [x] npm run build (site)
- [x] GauntletCI pre-commit clean