### PR TITLE
fix: post-release distribution gaps and stale 2.8.0 copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
 
@@ -115,6 +117,9 @@ jobs:
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v3
         with:
+          # Optional RELEASE_PAT (repo contents:write) so release:published
+          # triggers standalone Homebrew/winget workflows. Falls back to GITHUB_TOKEN.
+          token: ${{ secrets.RELEASE_PAT != '' && secrets.RELEASE_PAT || github.token }}
           tag_name: ${{ steps.version.outputs.tag }}
           generate_release_notes: true
           files: |
@@ -123,6 +128,67 @@ jobs:
             artifacts/packages/*.tar.gz
             artifacts/packages/checksums.txt
 
+      - name: Upload release checksums
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-checksums
+          path: artifacts/packages/checksums.txt
+          retention-days: 1
+
       - name: Push to NuGet.org
         if: ${{ vars.NUGET_PUSH_ENABLED == 'true' }}
         run: dotnet nuget push artifacts/release/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+  update-homebrew-tap:
+    needs: release
+    runs-on: ubuntu-latest
+    if: vars.HOMEBREW_TAP_ENABLED == 'true'
+    steps:
+      - name: Download checksums
+        uses: actions/download-artifact@v4
+        with:
+          name: release-checksums
+          path: .
+
+      - name: Checkout GauntletCI update script
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: gauntletci-src
+          sparse-checkout: scripts/update-homebrew-tap-formula.py
+          sparse-checkout-cone-mode: false
+
+      - name: Checkout tap repo
+        uses: actions/checkout@v6
+        with:
+          repository: EricCogen/homebrew-gauntletci
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        run: |
+          python3 ../gauntletci-src/scripts/update-homebrew-tap-formula.py \
+            ../checksums.txt Formula/gauntletci.rb "${{ needs.release.outputs.version }}"
+        working-directory: homebrew-tap
+
+      - name: Commit and push
+        working-directory: homebrew-tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/gauntletci.rb
+          git diff --cached --quiet || \
+            git commit -m "Update GauntletCI formula to v${{ needs.release.outputs.version }}"
+          git push
+
+  submit-winget:
+    needs: release
+    runs-on: windows-latest
+    if: vars.WINGET_SUBMIT_ENABLED == 'true'
+    continue-on-error: true
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: EricCogen.GauntletCI
+          installers-regex: '^gauntletci-win-(x64|arm64)-.*\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/submit-winget.yml
+++ b/.github/workflows/submit-winget.yml
@@ -3,10 +3,20 @@ name: Submit to winget
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without leading v (e.g. 2.8.0)"
+        required: true
+        type: string
 
 # Requires WINGET_TOKEN secret: a PAT with public_repo scope on an account
 # that has forked microsoft/winget-pkgs. The action submits a PR to the fork
 # and then opens a PR to microsoft/winget-pkgs from that fork.
+#
+# First-time setup: EricCogen.GauntletCI is not in winget-pkgs yet. Submit an
+# initial manifest PR manually (see packaging/winget/) before this workflow can
+# auto-bump versions. Until then, expect continue-on-error skips on release.
 jobs:
   winget:
     runs-on: windows-latest

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -3,6 +3,12 @@ name: Update Homebrew Tap
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without leading v (e.g. 2.8.0)"
+        required: true
+        type: string
 
 jobs:
   update-tap:
@@ -10,7 +16,12 @@ jobs:
     steps:
       - name: Resolve version
         id: ver
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download checksums
         run: |
@@ -20,58 +31,30 @@ jobs:
             -o checksums.txt
           cat checksums.txt
 
-      - name: Parse SHA256 values
-        id: sha
-        run: |
-          VERSION="${{ steps.ver.outputs.version }}"
-          sha() { grep "$1" checksums.txt | awk '{print $1}'; }
-          echo "osx_arm64=$(sha "gauntletci-osx-arm64-${VERSION}.tar.gz")" >> "$GITHUB_OUTPUT"
-          echo "osx_x64=$(sha "gauntletci-osx-x64-${VERSION}.tar.gz")"     >> "$GITHUB_OUTPUT"
-          echo "linux_arm64=$(sha "gauntletci-linux-arm64-${VERSION}.tar.gz")" >> "$GITHUB_OUTPUT"
-          echo "linux_x64=$(sha "gauntletci-linux-x64-${VERSION}.tar.gz")"  >> "$GITHUB_OUTPUT"
+      - name: Checkout GauntletCI update script
+        uses: actions/checkout@v6
+        with:
+          repository: EricCogen/GauntletCI
+          ref: main
+          path: gauntletci-src
+          sparse-checkout: scripts/update-homebrew-tap-formula.py
+          sparse-checkout-cone-mode: false
 
       - name: Checkout tap repo
         uses: actions/checkout@v6
         with:
           repository: EricCogen/homebrew-gauntletci
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
 
       - name: Update formula
-        env:
-          VERSION: ${{ steps.ver.outputs.version }}
-          SHA_OSX_ARM64: ${{ steps.sha.outputs.osx_arm64 }}
-          SHA_OSX_X64: ${{ steps.sha.outputs.osx_x64 }}
-          SHA_LINUX_ARM64: ${{ steps.sha.outputs.linux_arm64 }}
-          SHA_LINUX_X64: ${{ steps.sha.outputs.linux_x64 }}
         run: |
-          cat > /tmp/update_formula.py << 'PYEOF'
-          import os, re
-
-          version    = os.environ["VERSION"]
-          sha_map = {
-              "osx-arm64":   os.environ["SHA_OSX_ARM64"],
-              "osx-x64":     os.environ["SHA_OSX_X64"],
-              "linux-arm64": os.environ["SHA_LINUX_ARM64"],
-              "linux-x64":   os.environ["SHA_LINUX_X64"],
-          }
-
-          with open("Formula/gauntletci.rb") as f:
-              content = f.read()
-
-          content = re.sub(r'version "[^"]*"', f'version "{version}"', content)
-
-          for platform, sha in sha_map.items():
-              pattern = rf'(url "[^"]*{re.escape(platform)}[^"]*"\n\s*sha256 ")[^"]*(")'
-              content = re.sub(pattern, rf'\g<1>{sha}\g<2>', content)
-
-          with open("Formula/gauntletci.rb", "w") as f:
-              f.write(content)
-
-          print(open("Formula/gauntletci.rb").read())
-          PYEOF
-          python3 /tmp/update_formula.py
+          python3 ../gauntletci-src/scripts/update-homebrew-tap-formula.py \
+            ../checksums.txt Formula/gauntletci.rb "${{ steps.ver.outputs.version }}"
+        working-directory: homebrew-tap
 
       - name: Commit and push
+        working-directory: homebrew-tap
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/github-app-server/README.md
+++ b/github-app-server/README.md
@@ -30,7 +30,7 @@ The host must have:
 Install GauntletCI on the host:
 
 ```bash
-dotnet tool install -g GauntletCI --version 2.7.1
+dotnet tool install -g GauntletCI --version 2.8.0
 ```
 
 ## Required GitHub App permissions

--- a/packaging/homebrew/gauntletci.rb
+++ b/packaging/homebrew/gauntletci.rb
@@ -1,7 +1,7 @@
 class Gauntletci < Formula
   desc "Deterministic pre-commit risk detection engine for git diffs"
   homepage "https://gauntletci.com"
-  version "2.1.0"
+  version "2.8.0"
   license "Elastic-2.0"
 
   # SHA256 values are updated automatically via the update-homebrew-tap.yml
@@ -9,22 +9,22 @@ class Gauntletci < Formula
   on_macos do
     on_arm do
       url "https://github.com/EricCogen/GauntletCI/releases/download/v#{version}/gauntletci-osx-arm64-#{version}.tar.gz"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+      sha256 "939d4916fc9c4f56dddb155fb6a7564f7643ad6fe4e18ba3eb93467a91d20418"
     end
     on_intel do
       url "https://github.com/EricCogen/GauntletCI/releases/download/v#{version}/gauntletci-osx-x64-#{version}.tar.gz"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+      sha256 "71d92ae3c08a39b37f1a71de425ff82fd6f0419485e591f586b830eb4f678073"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/EricCogen/GauntletCI/releases/download/v#{version}/gauntletci-linux-arm64-#{version}.tar.gz"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+      sha256 "e71be039ba2cbc5e3690cafff9b5f54135ed32c68d156822975ff0df0c3d3c15"
     end
     on_intel do
       url "https://github.com/EricCogen/GauntletCI/releases/download/v#{version}/gauntletci-linux-x64-#{version}.tar.gz"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+      sha256 "a84a9d54b9ae7aceb97cfb9cb352af46b1d9e757314ac48947ed9f594e525c45"
     end
   end
 

--- a/scripts/update-homebrew-tap-formula.py
+++ b/scripts/update-homebrew-tap-formula.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Update Formula/gauntletci.rb version and platform SHA256 lines from checksums.txt."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def parse_checksums(checksums_path: Path) -> dict[str, str]:
+    sha_map: dict[str, str] = {}
+    for line in checksums_path.read_text(encoding="utf-8").splitlines():
+        parts = line.strip().split()
+        if len(parts) != 2:
+            continue
+        sha, filename = parts
+        for platform in ("osx-arm64", "osx-x64", "linux-arm64", "linux-x64"):
+            if platform in filename:
+                sha_map[platform] = sha
+                break
+    return sha_map
+
+
+def update_formula(formula_path: Path, version: str, sha_map: dict[str, str]) -> None:
+    content = formula_path.read_text(encoding="utf-8")
+    content = re.sub(r'version "[^"]*"', f'version "{version}"', content)
+    for platform, sha in sha_map.items():
+        pattern = rf'(url "[^"]*{re.escape(platform)}[^"]*"\n\s*sha256 ")[^"]*(")'
+        content = re.sub(pattern, rf"\g<1>{sha}\g<2>", content)
+    formula_path.write_text(content, encoding="utf-8")
+    print(formula_path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(
+            "Usage: update-homebrew-tap-formula.py <checksums.txt> <Formula/gauntletci.rb> <version>",
+            file=sys.stderr,
+        )
+        return 2
+
+    checksums_path = Path(sys.argv[1])
+    formula_path = Path(sys.argv[2])
+    version = sys.argv[3]
+
+    sha_map = parse_checksums(checksums_path)
+    required = ("osx-arm64", "osx-x64", "linux-arm64", "linux-x64")
+    missing = [platform for platform in required if platform not in sha_map]
+    if missing:
+        print(f"Missing SHA256 entries for: {', '.join(missing)}", file=sys.stderr)
+        return 1
+
+    update_formula(formula_path, version, sha_map)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/app/articles/azure-sdk-pr-57223-risk-analysis/page.tsx
+++ b/site/app/articles/azure-sdk-pr-57223-risk-analysis/page.tsx
@@ -402,7 +402,7 @@ export default function AzureSDKAnalysisPage() {
             <section className="mb-12">
               <h2 className="text-2xl font-bold mb-4">Methodology & Data</h2>
               <p className="mb-4">
-                This analysis is based on Azure/azure-sdk-for-net PR #57223, which is a publicly available, already-merged PR. GauntletCI 2.8.0-alpha analyzed the full diff.
+                This analysis is based on Azure/azure-sdk-for-net PR #57223, which is a publicly available, already-merged PR. GauntletCI 2.8.0 analyzed the full diff.
               </p>
               <p className="mb-4">
                 <strong>Raw findings:</strong> 40,155 signals across 13 distinct rule types


### PR DESCRIPTION
## Summary
- Refresh Azure SDK article footnote and github-app-server install pin from stale 2.8.0-alpha / 2.7.1 to **2.8.0**
- Run Homebrew tap update from the Release workflow using uploaded checksums (avoids curl race on \elease: published\)
- Add \workflow_dispatch\ on tap/winget workflows for manual backfill (e.g. v2.8.0)
- Optional \RELEASE_PAT\ on gh-release so standalone release-triggered workflows can fire on future tags
- Extract \scripts/update-homebrew-tap-formula.py\; sync packaging/homebrew template SHAs for 2.8.0

## Test plan
- [x] \python scripts/update-homebrew-tap-formula.py\ against v2.8.0 checksums
- [x] \
pm run build\ (site)
- [ ] CI on PR