### PR TITLE
fix: refresh winget manifests and GitHub App Docker pin to 2.8.0

### DIFF
--- a/github-app-server/Dockerfile
+++ b/github-app-server/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl git gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && dotnet tool install -g GauntletCI --version 2.7.1 \
+    && dotnet tool install -g GauntletCI --version 2.8.0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/packaging/winget/EricCogen.GauntletCI.installer.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.installer.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: EricCogen.GauntletCI
-PackageVersion: 2.1.0
+PackageVersion: 2.8.0
 MinimumOSVersion: 10.0.17763.0
 InstallerType: zip
 InstallModes:
@@ -10,13 +10,13 @@ InstallModes:
 UpgradeBehavior: install
 Commands:
   - gauntletci
-ReleaseDate: 2025-04-29
+ReleaseDate: 2026-06-15
 Installers:
   - Architecture: x64
     Platform:
       - Windows.Desktop
-    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.1.0/gauntletci-win-x64-2.1.0.zip
-    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.8.0/gauntletci-win-x64-2.8.0.zip
+    InstallerSha256: b449f5a4f470d4f6617de8fc5ba523d70d2f41e9a518fa5279b538993fa70720
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: gauntletci.exe
@@ -24,8 +24,8 @@ Installers:
   - Architecture: arm64
     Platform:
       - Windows.Desktop
-    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.1.0/gauntletci-win-arm64-2.1.0.zip
-    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.8.0/gauntletci-win-arm64-2.8.0.zip
+    InstallerSha256: baccfc7dcb36e9e3a37e5e460005247fdf5bf7a163cb1568b552c7381d371efc
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: gauntletci.exe

--- a/packaging/winget/EricCogen.GauntletCI.locale.en-US.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 PackageIdentifier: EricCogen.GauntletCI
-PackageVersion: 2.1.0
+PackageVersion: 2.8.0
 PackageLocale: en-US
 Publisher: Eric Cogen
 PublisherUrl: https://github.com/EricCogen
@@ -24,6 +24,6 @@ Tags:
   - pre-commit
   - risk-detection
   - ci
-ReleaseNotesUrl: https://github.com/EricCogen/GauntletCI/releases
+ReleaseNotesUrl: https://github.com/EricCogen/GauntletCI/releases/tag/v2.8.0
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/packaging/winget/EricCogen.GauntletCI.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 PackageIdentifier: EricCogen.GauntletCI
-PackageVersion: 2.1.0
+PackageVersion: 2.8.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Sync \packaging/winget/\ manifests to **v2.8.0** with release URLs and SHA256 checksums from \checksums.txt\
- Bump \github-app-server/Dockerfile\ GauntletCI global tool install from 2.7.1 to 2.8.0 (README was already updated in #308)

## Related (outside this PR)
- Homebrew tap \EricCogen/homebrew-gauntletci\ updated directly to v2.8.0 (commit \8e62cd9\)

## Test plan
- [x] Manifest SHA256 values match v2.8.0 release \checksums.txt\
- [x] GauntletCI pre-commit on staged diff