### PR TITLE
fix: exit 0 when CLI invoked with no args (winget validation)

### DIFF
--- a/src/GauntletCI.Cli/Program.cs
+++ b/src/GauntletCI.Cli/Program.cs
@@ -14,10 +14,13 @@ if (args is ["__llm-daemon"])
 var isInitCommand = args.Any(a => string.Equals(a, "init", StringComparison.OrdinalIgnoreCase));
 var isTelemetryCommand = args.Any(a => string.Equals(a, "telemetry", StringComparison.OrdinalIgnoreCase));
 var isMcpServe = args.Any(a => string.Equals(a, "mcp", StringComparison.OrdinalIgnoreCase));
+var isMetaInvocation = args.Length == 0
+    || args.Any(static a => a is "--version" or "-?" or "-h" or "--help");
 
 // First-run prompt for non-init paths (init handles its own prompt and supports --no-telemetry)
 // Skip for mcp serve: stdout is the MCP protocol channel and must not be polluted
-if (!isInitCommand && !isTelemetryCommand && !isMcpServe)
+// Skip for bare/meta invocations (winget and package managers run the binary with no args or --version)
+if (!isInitCommand && !isTelemetryCommand && !isMcpServe && !isMetaInvocation)
     TelemetryConsent.PromptIfNeeded();
 
 var rootCommand = new RootCommand("GauntletCI: deterministic pre-commit risk detection engine");
@@ -37,5 +40,8 @@ rootCommand.AddCommand(PostmortemCommand.Create());
 rootCommand.AddCommand(TraceCommand.Create());
 rootCommand.AddCommand(FeedbackCommand.Create());
 rootCommand.AddCommand(TelemetryCommand.Create());
+
+if (args.Length == 0)
+    return await rootCommand.InvokeAsync(["--help"]);
 
 return await rootCommand.InvokeAsync(args);

--- a/tests/GauntletCI.Tests/EndToEndTests.cs
+++ b/tests/GauntletCI.Tests/EndToEndTests.cs
@@ -205,4 +205,16 @@ public class EndToEndTests
         Assert.Equal(0, exitCode);
         Assert.Matches(@"\d+\.\d+", stdout + stderr);
     }
+
+    [Fact]
+    public async Task NoArgs_ReturnsSuccessAndShowsUsage()
+    {
+        var (dll, skip) = GetCliDll();
+        if (skip) return;
+
+        var (stdout, stderr, exitCode) = await RunCliAsync(dll, string.Empty);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage:", stdout + stderr, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
WinGet validation runs gauntletci.exe with no arguments and requires exit code 0. Route zero-arg invocations to --help and skip telemetry prompt on meta flags. Follow-up: ship in v2.8.1 and update winget-pkgs PR 388209.