### PR TITLE
release: v2.8.1 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [2.8.1] - 2026-06-16
+
+### Fixed
+- **WinGet / package-manager validation**: `gauntletci` with no arguments now exits **0** (shows usage via `--help`) instead of exit code 1. Skips first-run telemetry prompt on bare `--version` / `--help` invocations.
+- **Post-release distribution**: Homebrew tap automation, winget manifest templates, and GitHub App Docker pin aligned to current release workflow (see #308, #309).
+
+---
+
 ## [2.8.0] - 2026-06-15
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.8.1</Version>
   </PropertyGroup>
 </Project>

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
   gauntletci-version:
     description: "The GauntletCI NuGet tool version to install."
     required: false
-    default: "2.8.0"
+    default: "2.8.1"
 
 outputs:
   findings-count:

--- a/github-app-server/Dockerfile
+++ b/github-app-server/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl git gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && dotnet tool install -g GauntletCI --version 2.8.0 \
+    && dotnet tool install -g GauntletCI --version 2.8.1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/github-app-server/README.md
+++ b/github-app-server/README.md
@@ -30,7 +30,7 @@ The host must have:
 Install GauntletCI on the host:
 
 ```bash
-dotnet tool install -g GauntletCI --version 2.8.0
+dotnet tool install -g GauntletCI --version 2.8.1
 ```
 
 ## Required GitHub App permissions

--- a/packaging/homebrew/gauntletci.rb
+++ b/packaging/homebrew/gauntletci.rb
@@ -1,7 +1,7 @@
 class Gauntletci < Formula
   desc "Deterministic pre-commit risk detection engine for git diffs"
   homepage "https://gauntletci.com"
-  version "2.8.0"
+  version "2.8.1"
   license "Elastic-2.0"
 
   # SHA256 values are updated automatically via the update-homebrew-tap.yml

--- a/packaging/winget/EricCogen.GauntletCI.installer.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.installer.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 PackageIdentifier: EricCogen.GauntletCI
-PackageVersion: 2.8.0
+PackageVersion: 2.8.1
 MinimumOSVersion: 10.0.17763.0
 InstallerType: zip
 InstallModes:
@@ -10,13 +10,13 @@ InstallModes:
 UpgradeBehavior: install
 Commands:
   - gauntletci
-ReleaseDate: 2026-06-15
+ReleaseDate: 2026-06-16
 Installers:
   - Architecture: x64
     Platform:
       - Windows.Desktop
-    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.8.0/gauntletci-win-x64-2.8.0.zip
-    InstallerSha256: b449f5a4f470d4f6617de8fc5ba523d70d2f41e9a518fa5279b538993fa70720
+    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.8.1/gauntletci-win-x64-2.8.1.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: gauntletci.exe
@@ -24,8 +24,8 @@ Installers:
   - Architecture: arm64
     Platform:
       - Windows.Desktop
-    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.8.0/gauntletci-win-arm64-2.8.0.zip
-    InstallerSha256: baccfc7dcb36e9e3a37e5e460005247fdf5bf7a163cb1568b552c7381d371efc
+    InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.8.1/gauntletci-win-arm64-2.8.1.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: gauntletci.exe

--- a/packaging/winget/EricCogen.GauntletCI.locale.en-US.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 PackageIdentifier: EricCogen.GauntletCI
-PackageVersion: 2.8.0
+PackageVersion: 2.8.1
 PackageLocale: en-US
 Publisher: Eric Cogen
 PublisherUrl: https://github.com/EricCogen
@@ -24,6 +24,6 @@ Tags:
   - pre-commit
   - risk-detection
   - ci
-ReleaseNotesUrl: https://github.com/EricCogen/GauntletCI/releases/tag/v2.8.0
+ReleaseNotesUrl: https://github.com/EricCogen/GauntletCI/releases/tag/v2.8.1
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0

--- a/packaging/winget/EricCogen.GauntletCI.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 PackageIdentifier: EricCogen.GauntletCI
-PackageVersion: 2.8.0
+PackageVersion: 2.8.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0

--- a/site/app/demo/github-checks-sarif/page.tsx
+++ b/site/app/demo/github-checks-sarif/page.tsx
@@ -36,7 +36,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Install GauntletCI
-        run: dotnet tool install -g GauntletCI --version 2.8.0
+        run: dotnet tool install -g GauntletCI --version 2.8.1
 
       - name: Post GitHub Checks annotations
         env:
@@ -71,7 +71,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Install GauntletCI
-        run: dotnet tool install -g GauntletCI --version 2.8.0
+        run: dotnet tool install -g GauntletCI --version 2.8.1
 
       - name: Generate SARIF
         run: |

--- a/site/app/docs/integrations/azure-devops/page.tsx
+++ b/site/app/docs/integrations/azure-devops/page.tsx
@@ -207,7 +207,7 @@ export default function AzureDevOpsPage() {
                   ["sensitivity", "balanced", "strict | balanced | permissive. Controls the confidence threshold for findings."],
                   ["failOnBlock", "true", "Set the task result to Failed when any Block-severity finding is produced."],
                   ["workingDirectory", "$(Build.SourcesDirectory)", "Root of the .NET repository. Passed as the working directory for the GauntletCI process."],
-                  ["gauntletciVersion", "latest", "NuGet version to install. Use 'latest' or pin to a specific version such as '2.8.0'."],
+                  ["gauntletciVersion", "latest", "NuGet version to install. Use 'latest' or pin to a specific version such as '2.8.1'."],
                 ].map(([name, def, desc]) => (
                   <tr key={name}>
                     <td className="px-4 py-2 font-mono text-xs text-cyan-400">{name}</td>

--- a/site/app/docs/integrations/bitbucket/page.tsx
+++ b/site/app/docs/integrations/bitbucket/page.tsx
@@ -165,7 +165,7 @@ export default function BitbucketPage() {
             </div>
             <div className="p-4 font-mono text-xs space-y-1">
               <p className="text-muted-foreground">+ gauntletci analyze --diff pr.diff --no-banner --ascii</p>
-              <p className="text-foreground mt-2">GauntletCI v2.8.0</p>
+              <p className="text-foreground mt-2">GauntletCI v2.8.1</p>
               <p className="text-foreground">Analyzed 3 files, 47 changed lines</p>
               <p className="text-foreground mt-1">
                 <span className="text-red-400">[BLOCK]</span>{" "}

--- a/site/app/docs/integrations/github-action/page.tsx
+++ b/site/app/docs/integrations/github-action/page.tsx
@@ -34,7 +34,7 @@ const faqSchema = buildFaqSchema([
   },
   {
     q: "Can I pin to a specific GauntletCI tool version?",
-    a: "Yes. Set gauntletci-version to the exact NuGet version you want, such as '2.8.0'. The default is the latest published version.",
+    a: "Yes. Set gauntletci-version to the exact NuGet version you want, such as '2.8.1'. The default is the latest published version.",
   },
 ]);
 
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: EricCogen/GauntletCI@v2.8.0`;
+      - uses: EricCogen/GauntletCI@v2.8.1`;
 
 const FULL_WORKFLOW = `name: GauntletCI
 
@@ -71,7 +71,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: EricCogen/GauntletCI@v2.8.0
+      - uses: EricCogen/GauntletCI@v2.8.1
         id: gauntlet
         with:
           sensitivity: 'balanced'
@@ -205,7 +205,7 @@ export default function GithubActionPage() {
                   ["ascii", '"true"', "Use ASCII-only output. Recommended for CI logs - avoids encoding issues."],
                   ["commit", '""', "Commit SHA to analyze. Defaults to the PR head commit (github.event.pull_request.head.sha)."],
                   ["dotnet-version", '"8.0.x"', "The .NET SDK version to install on the runner."],
-                  ["gauntletci-version", '"2.8.0"', "The GauntletCI NuGet tool version to install."],
+                  ["gauntletci-version", '"2.8.1"', "The GauntletCI NuGet tool version to install."],
                 ].map(([name, def, desc]) => (
                   <tr key={name}>
                     <td className="px-4 py-2 font-mono text-xs text-cyan-400">{name}</td>
@@ -292,7 +292,7 @@ export default function GithubActionPage() {
             always passes.
           </p>
           <div className="rounded-lg border border-border bg-card p-4 font-mono text-sm">
-            <pre className="text-foreground whitespace-pre">{`- uses: EricCogen/GauntletCI@v2.8.0
+            <pre className="text-foreground whitespace-pre">{`- uses: EricCogen/GauntletCI@v2.8.1
   with:
     fail-on-findings: 'false'
     inline-comments: 'true'

--- a/site/app/docs/integrations/page.tsx
+++ b/site/app/docs/integrations/page.tsx
@@ -185,7 +185,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: EricCogen/GauntletCI@v2.8.0
+      - uses: EricCogen/GauntletCI@v2.8.1
         with:
           sensitivity: 'balanced'
           inline-comments: 'true'

--- a/site/components/terminal-block.tsx
+++ b/site/components/terminal-block.tsx
@@ -10,7 +10,7 @@ interface OutputLine {
 const lines: OutputLine[] = [
   { type: "cmd",      text: "$ gauntletci analyze --staged" },
   { type: "blank",    text: "" },
-  { type: "dim",      text: "  GauntletCI v2.8.0, 39 rules, diff-scoped" },
+  { type: "dim",      text: "  GauntletCI v2.8.1, 39 rules, diff-scoped" },
   { type: "blank",    text: "" },
   { type: "critical", text: "  [BLOCK]  GCI0004  Breaking change in public API", annotation: 1 },
   { type: "dim",      text: "           OrderService.cs:142: ProcessPayment(decimal amount, string currency)" },


### PR DESCRIPTION
Patch release for WinGet validation fix (zero-arg CLI exit 0, #310). Bumps version, CHANGELOG, site integration docs, winget manifest templates, and GitHub App Docker pin. Winget installer SHA256 placeholders will be filled after release assets publish.