### PR TITLE
fix: fill winget installer SHA256 for v2.8.1

### DIFF
--- a/packaging/winget/EricCogen.GauntletCI.installer.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.installer.yaml
@@ -16,7 +16,7 @@ Installers:
     Platform:
       - Windows.Desktop
     InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.8.1/gauntletci-win-x64-2.8.1.zip
-    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    InstallerSha256: 86a138a25892a7033bdca07d8156a92d34f1b18ad7906ad96e8ba92d4efcad49
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: gauntletci.exe
@@ -25,7 +25,7 @@ Installers:
     Platform:
       - Windows.Desktop
     InstallerUrl: https://github.com/EricCogen/GauntletCI/releases/download/v2.8.1/gauntletci-win-arm64-2.8.1.zip
-    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    InstallerSha256: c5857786e4314f5b3ae452fea5c9bb095396ac75dbf2bcd76ac5ffaab5d3fbb4
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: gauntletci.exe


### PR DESCRIPTION
Post-release checksum sync from v2.8.1 checksums.txt.