### PR TITLE
fix: add winget InstallationMetadata --version for portable validation

### DIFF
--- a/packaging/winget/EricCogen.GauntletCI.installer.yaml
+++ b/packaging/winget/EricCogen.GauntletCI.installer.yaml
@@ -21,6 +21,11 @@ Installers:
     NestedInstallerFiles:
       - RelativeFilePath: gauntletci.exe
         PortableCommandAlias: gauntletci
+    InstallationMetadata:
+      Files:
+        - RelativeFilePath: gauntletci.exe
+          FileType: launch
+          InvocationParameter: --version
   - Architecture: arm64
     Platform:
       - Windows.Desktop
@@ -30,5 +35,10 @@ Installers:
     NestedInstallerFiles:
       - RelativeFilePath: gauntletci.exe
         PortableCommandAlias: gauntletci
+    InstallationMetadata:
+      Files:
+        - RelativeFilePath: gauntletci.exe
+          FileType: launch
+          InvocationParameter: --version
 ManifestType: installer
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
WinGet portable validation invokes the installed executable. Add explicit InstallationMetadata with \--version\ on both win-x64 and win-arm64 zip installers (mirrors fork update on microsoft/winget-pkgs#388209).

## Test plan
- [x] GauntletCI pre-commit on staged diff (no issues)
- [ ] Synced to EricCogen/winget-pkgs fork branch