### PR TITLE
docs: update winget workflow notes after initial submission validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
   submit-winget:
     needs: release
     runs-on: windows-latest
+    # Set WINGET_SUBMIT_ENABLED=true after microsoft/winget-pkgs#388209 merges and WINGET_TOKEN is configured.
     if: vars.WINGET_SUBMIT_ENABLED == 'true'
     continue-on-error: true
     steps:

--- a/.github/workflows/submit-winget.yml
+++ b/.github/workflows/submit-winget.yml
@@ -14,9 +14,9 @@ on:
 # that has forked microsoft/winget-pkgs. The action submits a PR to the fork
 # and then opens a PR to microsoft/winget-pkgs from that fork.
 #
-# First-time setup: EricCogen.GauntletCI is not in winget-pkgs yet. Submit an
-# initial manifest PR manually (see packaging/winget/) before this workflow can
-# auto-bump versions. Until then, expect continue-on-error skips on release.
+# Initial package: microsoft/winget-pkgs#388209 (EricCogen.GauntletCI, validated).
+# After that PR merges, add WINGET_TOKEN and set repo variable
+# WINGET_SUBMIT_ENABLED=true so release publishes auto-open version bump PRs.
 jobs:
   winget:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
Initial WinGet package submission (microsoft/winget-pkgs#388209) passed Azure validation and awaits maintainer merge. Update workflow comments to reflect post-submission setup: add \WINGET_TOKEN\ and \WINGET_SUBMIT_ENABLED=true\ after merge for automated version bump PRs.

## Test plan
- [x] GauntletCI pre-commit on staged diff (no issues)
- [x] Comment-only workflow change