### PR TITLE
Trust transparency, evidence promotion rollout, and MCP analyze parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,18 @@ jobs:
       - name: Build
         run: dotnet build GauntletCI.slnx --no-restore --configuration Release
 
+      - name: Pack GauntletCI tool
+        run: dotnet pack src/GauntletCI.Cli/GauntletCI.Cli.csproj -c Release --no-build -o ./artifacts/nupkg -p:PackageVersion=0.0.0-ci.${{ github.run_number }}
+
+      - name: Install GauntletCI from local pack
+        run: dotnet tool install -g GauntletCI --add-source ./artifacts/nupkg --version 0.0.0-ci.${{ github.run_number }}
+
       - name: Run GauntletCI on last commit
         id: analyze
         run: |
           git diff HEAD~1..HEAD > main.diff
           set +e
-          OUTPUT=$(dotnet run --project src/GauntletCI.Cli --no-build --configuration Release -- \
-            analyze --no-banner --ascii < main.diff 2>&1)
+          OUTPUT=$(gauntletci analyze --no-banner --ascii < main.diff 2>&1)
           EXIT_CODE=$?
           set -e
           FINDINGS=$(echo "$OUTPUT" | grep -oP 'Findings\s+:\s+\K\d+' || echo "0")
@@ -122,6 +127,12 @@ jobs:
       - name: Build
         run: dotnet build GauntletCI.slnx --no-restore --configuration Release
 
+      - name: Pack GauntletCI tool
+        run: dotnet pack src/GauntletCI.Cli/GauntletCI.Cli.csproj -c Release --no-build -o ./artifacts/nupkg -p:PackageVersion=0.0.0-ci.${{ github.run_number }}
+
+      - name: Install GauntletCI from local pack
+        run: dotnet tool install -g GauntletCI --add-source ./artifacts/nupkg --version 0.0.0-ci.${{ github.run_number }}
+
       - name: Generate PR diff
         run: git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} > pr.diff
 
@@ -134,8 +145,7 @@ jobs:
         run: |
           set -o pipefail
           set +e
-          dotnet run --project src/GauntletCI.Cli --no-build --configuration Release -- \
-            analyze --no-banner --ascii --github-annotations --pr-comment-suggest --repo . \
+          gauntletci analyze --no-banner --ascii --github-annotations --pr-comment-suggest --repo . \
             --severity warn --sensitivity balanced --no-baseline < pr.diff
           exit_code=$?
           set -e

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,24 +79,32 @@ gauntletci analyze [options]
         │                  Each rule runs with a 30-second per-rule timeout.
         │
         ▼
-5. Post-processing          RuleOrchestrator.PostProcess()
-        │                  GCI0019: large-diff warning based on total line count.
-        │                  Severity overrides from config applied to all findings.
-        │                  IgnoreList suppressions applied.
-        │                  When 4+ distinct rules fire, ConsoleReporter emits a
-        │                  compound-risk header note (not a separate finding).
+5. Post-processing          IgnoreList suppressions; IPostProcessor rules (e.g. GCI0019).
+        │                  Per-finding severity from ConfigurationService (json >
+        │                  .editorconfig > DefaultSeverities). Compound-risk header
+        │                  note when 4+ distinct rules fire (display only).
         │
         ▼
-6. LLM enrichment           LlmEngineSelector.ResolveAsync()  [opt-in: --with-llm]
+6. Trust filters            ProvenanceFindingProcessor → SemanticFindingProcessor
+        │                  → DomainFindingProcessor (each may drop or boost findings).
+        │
+        ▼
+7. Delivery                 FindingDeliveryProcessor (coordination boosts, file-level
+        │                  demotion, per-rule/per-file caps, ranked global cap).
+        │                  DeliverySummary counts what was dropped and why.
+        │
+        ▼
+8. LLM enrichment           LlmEngineSelector.ResolveAsync()  [opt-in: --with-llm]
         │                  Enriches High-confidence findings with a natural-language
         │                  explanation via Phi-4 Mini ONNX or a CI endpoint (see below).
         │
         ▼
-7. Output                   ConsoleReporter (text) | JsonSerializer (--output json)
+9. Output                   ConsoleReporter (text) | JsonSerializer (--output json)
         │                  GitHubAnnotationWriter (--github-annotations)
+        │                  SensitivityFilter applied at display/exit time (--sensitivity).
         │
         ▼
-8. Telemetry                TelemetryCollector.CollectAsync()
+10. Telemetry               TelemetryCollector.CollectAsync()
                            Anonymous events written to ~/.gauntletci/telemetry.ndjson.
                            Background HTTP upload in Shared mode only.
 ```
@@ -156,9 +164,90 @@ Rules are configured via `.gauntletci.json`:
 }
 ```
 
-`severity` overrides the rule's default `Confidence` level. Valid values: `"High"`, `"Medium"`, `"Low"`.
+`severity` overrides the rule's effective `RuleSeverity` (Block, Warn, Advisory, Info, or None to disable). Valid string values match `.editorconfig` conventions: `"error"`, `"warning"`, `"suggestion"`, `"none"`, etc.
 
-### Rule interdependencies and self-interference
+Each rule also sets a default `Confidence` (High, Medium, Low) when it calls `CreateFinding(...)`. Confidence and severity are independent dimensions used together in delivery ranking and display filtering (see [Finding trust and delivery](#finding-trust-and-delivery)).
+
+---
+
+## Finding trust and delivery
+
+GauntletCI separates **what a rule detected** from **what the user sees**. Several layers run after rule evaluation; each layer is deterministic and configurable. JSON output (`--output json`) and MCP analyze tools include a `delivery` block with drop counts so hidden findings are not silent.
+
+### Two axes: severity and confidence
+
+| Axis | Set by | Purpose |
+| --- | --- | --- |
+| **Severity** (`RuleSeverity`) | `ConfigurationService` priority chain: `.gauntletci.json` → `.editorconfig` → `DefaultSeverities` | CI gate (`--exit-on`), grouping in console output, delivery ranking |
+| **Confidence** (`Confidence`) | Rule implementation via `CreateFinding(...)`; may be boosted by coordination or semantic witnesses | Delivery ranking; `--sensitivity` display filter; LLM enrichment eligibility |
+
+`SeverityOverride` on a finding (when present) wins over config for that instance.
+
+### Pipeline order (after rules fire)
+
+1. **Ignore list** — `.gauntletci-ignore` suppressions by rule ID and file path.
+2. **Post-processors** — `IPostProcessor` rules (e.g. GCI0019 large-diff synthesis).
+3. **Provenance filter** — `ProvenanceFindingProcessor` drops findings inconsistent with diff provenance (`provenance` config block).
+4. **Semantic witnesses** — `SemanticFindingProcessor` may boost confidence when patch semantics support a finding (`semantics` config block).
+5. **Domain filter** — `DomainFindingProcessor` drops findings outside the classified repo domain profile (`domain` config block).
+6. **Delivery** — `FindingDeliveryProcessor` (see below). Output is the **delivered** finding list stored in `EvaluationResult.Findings`.
+
+LLM enrichment (`--with-llm`) runs **after** delivery, only on `High`-confidence delivered findings.
+
+### Delivery processor (`FindingDeliveryProcessor`)
+
+Controlled by `output.delivery` in `.gauntletci.json` (`FindingDeliveryConfig`). Default: enabled, global max **25**, default **5** findings per (rule, file) group.
+
+Steps (in order):
+
+1. **Coordination boosts** — `FindingCoordinationEngine` raises confidence when compound-risk patterns appear (e.g. GCI0016 present → boost GCI0039/GCI0044; GCI0032 + GCI0003 → boost both). Mutates confidence in a cloned working set only.
+2. **File-level demotion** — For rules in `FileLevelRulesToDemote` (default: GCI0001, GCI0003), file-scoped findings with no line number are dropped when any line-anchored finding exists in the run.
+3. **Per-rule per-file caps** — Groups by `(RuleId, FilePath)`. Within each group, **all Block findings are kept**; remaining slots up to the cap are filled by highest delivery score among non-Block findings. Per-rule overrides exist for noisy rules (e.g. GCI0038, GCI0043 → cap 3).
+4. **Global ranking and cap** — All kept findings sorted by delivery score; global max applied with the same Block-first reservation.
+
+**Delivery score** (higher surfaces first):
+
+```
+severity tier (Block=1000, Warn=100, Advisory=50, Info=10)
++ 50 if line-anchored
++ 10 if file path present
++ confidence tier (High=30, Medium=20, Low=0)
+```
+
+`FindingDeliverySummary` reports `inputCount`, `outputCount`, and drops by cap, demotion, provenance, and domain filter. Console output prints a yellow delivery notice when findings were hidden; JSON/MCP expose the same fields.
+
+Set `output.delivery.enabled: false` to bypass coordination and caps (full raw list after trust filters).
+
+### Display-time sensitivity (`SensitivityFilter`)
+
+Separate from delivery. `--sensitivity` (`strict` | `balanced` | `permissive`, default `balanced`) filters which **delivered** findings appear in console output and count toward `--exit-on`:
+
+| Threshold | Shown |
+| --- | --- |
+| **Strict** | Block + Medium or High confidence only |
+| **Balanced** (default) | All Block; Warn + Medium or High confidence |
+| **Permissive** | All Block and Warn |
+| **Advisory** | Always shown at any threshold |
+| **Info** | Permissive only; use `--verbose` for explicit Info in other modes |
+
+JSON output includes all delivered findings regardless of sensitivity; the CLI applies sensitivity when rendering text and when computing exit codes.
+
+### Evidence promotion (regex → Roslyn)
+
+Several rules use regex only as a **candidate detector**. Before emitting a finding, `RegexEvidencePromotion` confirms the match against Roslyn syntax (comment/string suppression, member access, object creation, `System.IO.File` sync calls, etc.). GCI0006, GCI0010, GCI0024, GCI0048, GCI0049, and GCI0057 use this path when a syntax tree is available. Diff-only mode (no repo path) falls back to regex guards documented per rule.
+
+### Deterministic vs LLM boundary
+
+| Stage | Deterministic | LLM (opt-in) |
+| --- | --- | --- |
+| Rule evaluation | Yes | No |
+| Trust filters and delivery | Yes | No |
+| `--with-llm` explanation text | No | Yes (append-only on High confidence) |
+| Corpus labeling / silver labels | Heuristic | Separate offline path |
+
+Product claims about precision should cite **labeled corpus metrics** (`corpus audit-snapshot`, `LabeledRuleMetricsReader`), not discovery-tier trigger rates alone.
+
+---
 
 Because GauntletCI is analyzed by its own rules during development and in CI, some rules fire on the files that implement other rules. This is called **self-interference**: a rule detecting a pattern inside the implementation of another (or the same) rule.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,7 +112,7 @@ public interface IRule
 {
     string Id   { get; }
     string Name { get; }
-    Task<List<Finding>> EvaluateAsync(DiffContext diff, AnalyzerResult? staticAnalysis, CancellationToken ct);
+    Task<List<Finding>> EvaluateAsync(AnalysisContext context, CancellationToken ct = default);
 }
 ```
 
@@ -137,7 +137,7 @@ Adding a new rule requires only dropping a new `IRule` class into the assembly: 
 
 ### Rule IDs
 
-Rules span `GCI0001`-`GCI0053`. `GCI0028` is reserved (never issued).
+39 rule implementations ship in Core; **37 are active by default** (GCI0054 and GCI0055 disabled as duplicates). IDs span `GCI0001`–`GCI0059` with gaps in the sequence. `GCI0028` is reserved (never issued).
 
 ### Per-rule timeout
 

--- a/packaging/GauntletCI.nuspec
+++ b/packaging/GauntletCI.nuspec
@@ -4,7 +4,7 @@
 
     <!-- Identity -->
     <id>GauntletCI</id>
-    <version>2.1.1</version>
+    <version>2.8.1</version>
     <authors>Eric Cogen</authors>
     <owners>Eric Cogen</owners>
 
@@ -35,7 +35,7 @@
 
     <!-- Summary (shown in search results — keep under 160 chars) -->
     <summary>
-      Deterministic .NET pre-commit gate. 42 behavioral-change rules, optional Ollama LLM enrichment,
+      Deterministic .NET pre-commit gate. 37 active behavioral-change rules (39 implementations), optional Ollama LLM enrichment,
       built-in MCP server. Catches unvalidated changes, missing tests, and security risks before merge.
     </summary>
 
@@ -50,7 +50,7 @@
     -->
     <description>
 GauntletCI is a .NET pre-commit and PR integration gate that evaluates diffs against a configurable
-set of 42 behavioral-change rules — catching unvalidated changes, missing tests, and security risks
+set of 37 active behavioral-change rules (39 implementations) — catching unvalidated changes, missing tests, and security risks
 before code is committed or merged.
 
 ## What It Does
@@ -68,7 +68,7 @@ It analyzes only what changed in a diff and fires structured findings when it de
 - Data schema compatibility and idempotency/retry safety gaps
 - Structured logging gaps and rollback safety issues
 
-Each finding includes a rule ID (GCI0001–GCI0042), confidence level (High/Medium/Low), file path,
+Each finding includes a rule ID (GCI0001–GCI0059; 37 active by default), confidence level (High/Medium/Low), file path,
 line number, and a suggested action. High-confidence findings can be optionally enriched with a
 locally running Ollama LLM explanation and expert knowledge citations from a local vector store.
 
@@ -84,7 +84,7 @@ LLM enrichment is optional and additive: deterministic rules fire first, LLM exp
 
 ## Key Features
 
-- **42 built-in rules** covering behavioral change, security, async safety, resource lifecycle,
+- **37 active rules** (39 implementations) covering behavioral change, security, async safety, resource lifecycle,
   architecture discipline, test quality, and more
 - **Optional local LLM enrichment** via Ollama (fully offline — no data leaves your machine)
 - **Expert knowledge distillery** — seed a local SQLite vector store with expert .NET facts

--- a/site/app/docs/integrations/_components/integration-status-banner.tsx
+++ b/site/app/docs/integrations/_components/integration-status-banner.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from "react";
+
 type IntegrationStatusBannerProps = {
   title: string;
-  children: string;
+  children: ReactNode;
 };
 
 export function IntegrationStatusBanner({ title, children }: IntegrationStatusBannerProps) {

--- a/site/app/docs/integrations/azure-devops/page.tsx
+++ b/site/app/docs/integrations/azure-devops/page.tsx
@@ -151,7 +151,7 @@ export default function AzureDevOpsPage() {
               <div className="flex items-start gap-2">
                 <span className="text-muted-foreground/50 text-xs w-5 shrink-0">00:01</span>
                 <span className="text-foreground">
-                  GauntletCI: 3 finding(s) from 42 rules evaluated.
+                  GauntletCI: 3 finding(s) from 37 rules evaluated.
                 </span>
               </div>
               <div className="flex items-start gap-2">

--- a/site/app/docs/integrations/mcp/page.tsx
+++ b/site/app/docs/integrations/mcp/page.tsx
@@ -87,16 +87,10 @@ export default function McpPage() {
           </p>
         </div>
 
-        <IntegrationStatusBanner title="Coming soon: npm package">
-          The MCP server source repository exists, but the @ericcogen/gauntletci-mcp package is not
-          published to npm yet. Use the clone-and-build path below until the package is released.
-        </IntegrationStatusBanner>
-
         <section>
-          <h2 className="text-2xl font-semibold mb-3">Built-in MCP server (CLI)</h2>
+          <h2 className="text-2xl font-semibold mb-3">Built-in MCP server (recommended)</h2>
           <p className="text-muted-foreground mb-3 text-sm">
-            If you already have the GauntletCI CLI installed, you can start an MCP server without
-            cloning the separate Node repository:
+            The GauntletCI CLI ships a stdio MCP server today. No separate Node repository is required:
           </p>
           <div className="rounded-lg border border-border bg-card p-4 font-mono text-sm">
             <span className="text-cyan-400">$</span>{" "}
@@ -104,10 +98,20 @@ export default function McpPage() {
           </div>
           <p className="text-muted-foreground mt-3 text-sm">
             Point your MCP client at that command (stdio). Requires a Pro license for MCP features.
-            The standalone <code className="bg-muted px-1 rounded text-xs">GauntletCI-MCP</code>{" "}
-            repository remains the path for npm distribution once published.
+            Exposes <code className="bg-muted px-1 rounded text-xs">analyze_staged</code>,{" "}
+            <code className="bg-muted px-1 rounded text-xs">analyze_diff</code>,{" "}
+            <code className="bg-muted px-1 rounded text-xs">analyze_commit</code>,{" "}
+            <code className="bg-muted px-1 rounded text-xs">list_rules</code>, and{" "}
+            <code className="bg-muted px-1 rounded text-xs">audit_stats</code>.
           </p>
         </section>
+
+        <IntegrationStatusBanner title="Optional: npm wrapper (coming soon)">
+          The standalone <code className="bg-muted px-1 rounded text-xs">GauntletCI-MCP</code> Node
+          repository is an optional wrapper for npm distribution. Use{" "}
+          <code className="bg-muted px-1 rounded text-xs">gauntletci mcp serve</code> until{" "}
+          <code className="bg-muted px-1 rounded text-xs">@ericcogen/gauntletci-mcp</code> is published.
+        </IntegrationStatusBanner>
 
         <section>
           <h2 className="text-2xl font-semibold mb-3">How it works</h2>

--- a/site/app/docs/integrations/page.tsx
+++ b/site/app/docs/integrations/page.tsx
@@ -127,7 +127,7 @@ export default function IntegrationsPage() {
             {
               href: "/docs/integrations/mcp",
               label: "MCP Server",
-              desc: "Source build available today; npm package distribution is coming soon.",
+              desc: "Built-in via gauntletci mcp serve (Pro). Optional npm wrapper coming soon.",
               tag: "AI",
               status: "Coming soon",
             },

--- a/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
+++ b/src/GauntletCI.Cli/Commands/AnalyzeCommand.cs
@@ -481,9 +481,14 @@ public static class AnalyzeCommand
                             {
                                 result.DeliverySummary.InputCount,
                                 result.DeliverySummary.OutputCount,
+                                NotShown = result.DeliverySummary.InputCount - result.DeliverySummary.OutputCount,
                                 result.DeliverySummary.DroppedByGlobalCap,
                                 result.DeliverySummary.DroppedByPerRuleCap,
                                 result.DeliverySummary.DroppedByFileLevelDemotion,
+                                result.DeliverySummary.DroppedByProvenanceFilter,
+                                result.DeliverySummary.DroppedByDomainFilter,
+                                result.DeliverySummary.CoordinationBoostsApplied,
+                                result.DeliverySummary.SemanticsBoostsApplied,
                             },
                         };
                         var json = JsonSerializer.Serialize(jsonResult, new JsonSerializerOptions { WriteIndented = true });

--- a/src/GauntletCI.Cli/Mcp/GauntletMcpServer.cs
+++ b/src/GauntletCI.Cli/Mcp/GauntletMcpServer.cs
@@ -41,7 +41,7 @@ public static class GauntletTools
         try
         {
             var diff = await DiffParser.FromStagedAsync(repoPath);
-            var result = await RuleOrchestrator.CreateDefault().RunAsync(diff);
+            var result = await McpAnalysisPipeline.RunAsync(diff, repoPath);
             await EnrichHighFindingsAsync(result.Findings);
             return SerializeFindings(result);
         }
@@ -62,7 +62,7 @@ public static class GauntletTools
         try
         {
             var diffContext = DiffParser.Parse(diff);
-            var result = await RuleOrchestrator.CreateDefault().RunAsync(diffContext);
+            var result = await McpAnalysisPipeline.RunAsync(diffContext);
             await EnrichHighFindingsAsync(result.Findings);
             return SerializeFindings(result);
         }
@@ -80,7 +80,7 @@ public static class GauntletTools
         try
         {
             var diff = await DiffParser.FromGitAsync(repo, commit);
-            var result = await RuleOrchestrator.CreateDefault().RunAsync(diff);
+            var result = await McpAnalysisPipeline.RunAsync(diff, repo);
             await EnrichHighFindingsAsync(result.Findings);
             return SerializeFindings(result);
         }
@@ -152,6 +152,15 @@ public static class GauntletTools
         {
             hasFindings = result.HasFindings,
             findingCount = result.Findings.Count,
+            delivery = result.DeliverySummary is null ? null : new
+            {
+                inputCount = result.DeliverySummary.InputCount,
+                outputCount = result.DeliverySummary.OutputCount,
+                notShown = result.DeliverySummary.InputCount - result.DeliverySummary.OutputCount,
+                droppedByPerRuleCap = result.DeliverySummary.DroppedByPerRuleCap,
+                droppedByGlobalCap = result.DeliverySummary.DroppedByGlobalCap,
+                droppedByFileLevelDemotion = result.DeliverySummary.DroppedByFileLevelDemotion,
+            },
             findings = result.Findings.Select(f => new
             {
                 ruleId = f.RuleId,

--- a/src/GauntletCI.Cli/Mcp/McpAnalysisPipeline.cs
+++ b/src/GauntletCI.Cli/Mcp/McpAnalysisPipeline.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Configuration;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Rules;
+using GauntletCI.Core.StaticAnalysis;
+
+namespace GauntletCI.Cli.Mcp;
+
+/// <summary>
+/// Shared analyze pipeline for MCP tools: config, ignore list, Roslyn/static analysis, orchestrator.
+/// Matches the core path in <c>gauntletci analyze</c> before LLM enrichment and output formatting.
+/// </summary>
+internal static class McpAnalysisPipeline
+{
+    public static async Task<EvaluationResult> RunAsync(
+        DiffContext diff,
+        string? repoPath = null,
+        CancellationToken ct = default)
+    {
+        GauntletConfig config;
+        IgnoreList? ignoreList = null;
+
+        if (!string.IsNullOrWhiteSpace(repoPath))
+        {
+            config = ConfigLoader.Load(repoPath);
+            ignoreList = IgnoreList.Load(repoPath);
+        }
+        else
+        {
+            config = new GauntletConfig();
+        }
+
+        var orchestrator = RuleOrchestrator.CreateDefault(config, repoPath: repoPath);
+        var staticAnalysis = await StaticAnalysisRunner.RunAsync(diff, repoPath, ct).ConfigureAwait(false);
+        return await orchestrator.RunAsync(diff, staticAnalysis, ignoreList, ct).ConfigureAwait(false);
+    }
+}

--- a/src/GauntletCI.Cli/Output/ConsoleReporter.cs
+++ b/src/GauntletCI.Cli/Output/ConsoleReporter.cs
@@ -2,6 +2,7 @@
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.Rules;
+using GauntletCI.Core.Rules.Delivery;
 using Spectre.Console;
 using System.Linq;
 
@@ -31,6 +32,51 @@ public static class ConsoleReporter
     {
         var idx = evidence.IndexOf(": ", StringComparison.Ordinal);
         return idx >= 0 ? $"{evidence[..(idx + 2)]}[REDACTED]" : evidence;
+    }
+
+    /// <summary>
+    /// Formats delivery cap and demotion summary for console output.
+    /// Returns null when delivery did not hide or reshape findings.
+    /// </summary>
+    public static string? BuildDeliveryNotice(FindingDeliverySummary delivery)
+    {
+        var notShown = delivery.InputCount - delivery.OutputCount;
+        if (notShown <= 0)
+            return null;
+
+        var reasons = new List<string>();
+        if (delivery.DroppedByPerRuleCap > 0)
+            reasons.Add($"{delivery.DroppedByPerRuleCap} per-rule cap");
+        if (delivery.DroppedByGlobalCap > 0)
+            reasons.Add($"{delivery.DroppedByGlobalCap} global cap");
+        if (delivery.DroppedByFileLevelDemotion > 0)
+            reasons.Add($"{delivery.DroppedByFileLevelDemotion} file-level demotion");
+        if (delivery.DroppedByProvenanceFilter > 0)
+            reasons.Add($"{delivery.DroppedByProvenanceFilter} provenance filter");
+        if (delivery.DroppedByDomainFilter > 0)
+            reasons.Add($"{delivery.DroppedByDomainFilter} domain filter");
+
+        var reasonText = reasons.Count > 0 ? string.Join(", ", reasons) : "delivery policy";
+        return $"  Delivery    : {notShown} finding(s) not shown ({reasonText}; {delivery.InputCount} raw -> {delivery.OutputCount} delivered)";
+    }
+
+    private static void WriteDeliverySummary(FindingDeliverySummary delivery)
+    {
+        var notice = BuildDeliveryNotice(delivery);
+        if (notice is not null)
+            AnsiConsole.MarkupLine($"[yellow]{notice}[/]");
+
+        if (delivery.CoordinationBoostsApplied > 0)
+        {
+            AnsiConsole.MarkupLine(
+                $"[dim]  ({delivery.CoordinationBoostsApplied} finding(s) boosted by rule coordination)[/]");
+        }
+
+        if (delivery.SemanticsBoostsApplied > 0)
+        {
+            AnsiConsole.MarkupLine(
+                $"[dim]  ({delivery.SemanticsBoostsApplied} finding(s) boosted by semantic witnesses)[/]");
+        }
     }
 
     /// <summary>
@@ -83,13 +129,8 @@ public static class ConsoleReporter
         if (suppressedBySensitivity > 0)
             AnsiConsole.MarkupLine($"[dim]  ({suppressedBySensitivity} hidden by {sensitivity.ToString().ToLowerInvariant()} sensitivity - use --sensitivity permissive to see all)[/]");
 
-        if (result.DeliverySummary is { } delivery
-            && (delivery.DroppedByGlobalCap > 0 || delivery.DroppedByPerRuleCap > 0))
-        {
-            var dropped = delivery.DroppedByGlobalCap + delivery.DroppedByPerRuleCap;
-            AnsiConsole.MarkupLine(
-                $"[yellow]  Delivery    : {dropped} finding(s) dropped by output caps ({delivery.InputCount} evaluated, {delivery.OutputCount} shown)[/]");
-        }
+        if (result.DeliverySummary is { } delivery)
+            WriteDeliverySummary(delivery);
 
         var distinctRules = filteredFindings
             .Where(f => f.Severity is RuleSeverity.Block or RuleSeverity.Warn)

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0006_EdgeCaseHandling.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0006_EdgeCaseHandling.cs
@@ -27,15 +27,16 @@ public class GCI0006_EdgeCaseHandling : RuleBase
         var diff = context.Diff;
         var findings = new List<Finding>();
 
-        CheckNullDereferences(diff, findings);
+        CheckNullDereferences(context, findings);
         CheckMissingParameterValidation(diff, findings);
         AddRoslynFindings(context.StaticAnalysis, findings);
 
         return Task.FromResult(findings);
     }
 
-    private void CheckNullDereferences(DiffContext diff, List<Finding> findings)
+    private void CheckNullDereferences(AnalysisContext context, List<Finding> findings)
     {
+        var diff = context.Diff;
         foreach (var file in diff.Files)
         {
             if (WellKnownPatterns.IsTestFile(file.NewPath) || WellKnownPatterns.IsGeneratedFile(file.NewPath)) continue;
@@ -46,11 +47,22 @@ public class GCI0006_EdgeCaseHandling : RuleBase
 
             for (int i = 0; i < addedLines.Count; i++)
             {
-                var content = addedLines[i].Content;
-                if (!HasUnsafeValueAccess(content)) continue;
+                var line = addedLines[i];
+                var content = line.Content;
+                if (!TryGetUnsafeValueAccessIndex(content, out int valueIndex)) continue;
 
                 // Skip comment lines: .Value in a comment is not executable code
                 if (WellKnownPatterns.GuardPatterns.IsCommentLine(content)) continue;
+
+                if (!RegexEvidencePromotion.PassesCodeCandidateValidation(
+                        context,
+                        file.NewPath,
+                        line,
+                        valueIndex,
+                        confirmSemantic: syntax =>
+                            syntax.IsConfirmedMemberAccess(file.NewPath, line.LineNumber, "Value", valueIndex),
+                        allowWhenNoSyntaxTree: c => !WellKnownPatterns.GuardPatterns.IsCommentLine(c)))
+                    continue;
 
                 // Skip expression-bodied property/method declarations: the .Value access IS
                 // the declaration body (e.g. public override object? Value => _inner.Value;)
@@ -223,8 +235,9 @@ public class GCI0006_EdgeCaseHandling : RuleBase
     //   ?.Value   -- null-conditional access preceding .Value
     //   .Value?.  -- null-conditional after .Value (developer handles null result)
     //   .Values   -- a different property; word-boundary check excludes .Values, .ValueOrDefault, etc.
-    private static bool HasUnsafeValueAccess(string content)
+    private static bool TryGetUnsafeValueAccessIndex(string content, out int matchIndex)
     {
+        matchIndex = -1;
         int pos = 0;
         while (pos < content.Length)
         {
@@ -274,8 +287,10 @@ public class GCI0006_EdgeCaseHandling : RuleBase
                 continue;
             }
 
+            matchIndex = idx + 1;
             return true;
         }
+
         return false;
     }
 

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0010_HardcodingAndConfiguration.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0010_HardcodingAndConfiguration.cs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Elastic-2.0
+using System.Globalization;
 using System.Text.RegularExpressions;
 using GauntletCI.Core.Analysis;
 using GauntletCI.Core.Diff;
@@ -59,11 +60,11 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
         {
             if (WellKnownPatterns.IsTestFile(file.NewPath)) continue;
             if (WellKnownPatterns.IsGeneratedFile(file.NewPath)) continue;
-            CheckIpAddress(file, findings);
-            CheckHardcodedUrl(file, findings);
-            CheckConnectionString(file, findings);
-            CheckHardcodedPorts(file, findings);
-            CheckEnvironmentNames(file, findings);
+            CheckIpAddress(file, context, findings);
+            CheckHardcodedUrl(file, context, findings);
+            CheckConnectionString(file, context, findings);
+            CheckHardcodedPorts(file, context, findings);
+            CheckEnvironmentNames(file, context, findings);
         }
 
         AddRoslynFindings(context.StaticAnalysis, findings);
@@ -71,7 +72,7 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
         return Task.FromResult(findings);
     }
 
-    private void CheckIpAddress(DiffFile file, List<Finding> findings)
+    private void CheckIpAddress(DiffFile file, AnalysisContext context, List<Finding> findings)
     {
         // Skip test and infrastructure files - they often have hardcoded localhost/test IPs
         if (WellKnownPatterns.IsTestFile(file.NewPath)) return;
@@ -83,45 +84,20 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
             var trimmed = content.Trim();
             if (WellKnownPatterns.IsCommentLine(trimmed)) continue;
 
-            // Check for IP address assignment patterns (e.g., var ip = "192.168.1.1")
-            if (content.Contains("=") && BareIpAddressRegex.IsMatch(trimmed.Split('=').LastOrDefault()?.Trim() ?? ""))
-            {
-                findings.Add(CreateFinding(
-                    file,
-                    summary: "Hardcoded IP address assignment detected.",
-                    evidence: $"Line {line.LineNumber}: {content.Trim()}",
-                    whyItMatters: "Hardcoded IPs break across environments and make infrastructure changes require code changes.",
-                    suggestedAction: "Move the IP to configuration (appsettings.json, environment variable, etc.).",
-                    confidence: Confidence.Medium));
+            if (!HasHardcodedLiteral(context, file, line, IsHardcodedIpLiteral))
                 continue;
-            }
 
-            // Scope to string literals only: prevents matching version strings like "1.0.0.0"
-            // in XML, NuGet manifests, and assembly attributes.
-            var literals = ExtractStringLiterals(content);
-            if (literals.Count == 0) continue;
-
-            foreach (var literal in literals)
-            {
-                // Skip if this is a URL: CheckHardcodedUrl already handles that case.
-                if (literal.Contains("://", StringComparison.Ordinal)) continue;
-
-                var match = BareIpAddressRegex.Match(literal.Trim());
-                if (!match.Success) continue;
-
-                findings.Add(CreateFinding(
-                    file,
-                    summary: $"Hardcoded IP address in string literal: {match.Value}",
-                    evidence: $"Line {line.LineNumber}: {content.Trim()}",
-                    whyItMatters: "Hardcoded IPs break across environments and make infrastructure changes require code changes.",
-                    suggestedAction: "Move the IP to configuration (appsettings.json, environment variable, etc.).",
-                    confidence: Confidence.Medium));
-                break;
-            }
+            findings.Add(CreateFinding(
+                file,
+                summary: "Hardcoded IP address in string literal.",
+                evidence: $"Line {line.LineNumber}: {content.Trim()}",
+                whyItMatters: "Hardcoded IPs break across environments and make infrastructure changes require code changes.",
+                suggestedAction: "Move the IP to configuration (appsettings.json, environment variable, etc.).",
+                confidence: Confidence.Medium));
         }
     }
 
-    private void CheckHardcodedUrl(DiffFile file, List<Finding> findings)
+    private void CheckHardcodedUrl(DiffFile file, AnalysisContext context, List<Finding> findings)
     {
         // Skip test and infrastructure files - they often have hardcoded localhost URLs
         if (WellKnownPatterns.IsTestFile(file.NewPath)) return;
@@ -134,17 +110,8 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
 
             if (WellKnownPatterns.IsCommentLine(trimmed)) continue;
 
-            var literals = ExtractStringLiterals(content);
-            if (literals.Count == 0) continue;
-
-            // Only fire on localhost/IP URLs: public URLs (docs, CDN, GitHub, etc.) are
-            // intentional references, not hardcoded configuration. CheckIpAddress covers
-            // the IP-in-URL case; this check adds non-IP localhost specifically.
-            bool hasPrivateUrl = literals.Any(l =>
-                HardcodedUrlRegex.IsMatch(l) &&
-                !SafeUrlPrefixes.Any(s => l.StartsWith(s, StringComparison.OrdinalIgnoreCase)));
-
-            if (!hasPrivateUrl) continue;
+            if (!HasHardcodedLiteral(context, file, line, IsHardcodedPrivateUrlLiteral))
+                continue;
 
             findings.Add(CreateFinding(
                 file,
@@ -156,7 +123,7 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
         }
     }
 
-    private void CheckConnectionString(DiffFile file, List<Finding> findings)
+    private void CheckConnectionString(DiffFile file, AnalysisContext context, List<Finding> findings)
     {
         // Phase 17a: GCI0010 ↔ GCI0021 Coordination
         // Skip connection strings in infrastructure/migration files (GCI0021 owns schema context).
@@ -167,71 +134,60 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
         {
             var content = line.Content;
             if (WellKnownPatterns.IsCommentLine(content.Trim())) continue;
-            var literals = ExtractStringLiterals(content);
-            if (literals.Count == 0) continue;
 
-            foreach (var marker in WellKnownPatterns.ConnectionStringMarkers)
+            if (!HasHardcodedLiteral(context, file, line, ContainsConnectionStringMarker))
+                continue;
+
+            findings.Add(CreateFinding(
+                file,
+                summary: "Hardcoded connection string detected.",
+                evidence: $"Line {line.LineNumber}: {content.Trim()}",
+                whyItMatters: "Connection strings in source code expose credentials and prevent per-environment configuration.",
+                suggestedAction: "Use IConfiguration, Secret Manager, or environment variables for connection strings.",
+                confidence: Confidence.High));
+        }
+    }
+
+    private void CheckHardcodedPorts(DiffFile file, AnalysisContext context, List<Finding> findings)
+    {
+        foreach (var line in file.AddedLines)
+        {
+            var content = line.Content;
+            if (WellKnownPatterns.IsCommentLine(content.Trim())) continue;
+
+            foreach (var port in KnownPorts)
             {
-                if (!literals.Any(l => l.Contains(marker, StringComparison.OrdinalIgnoreCase))) continue;
+                if (!HasHardcodedPort(context, file, line, port))
+                    continue;
 
                 findings.Add(CreateFinding(
                     file,
-                    summary: "Hardcoded connection string detected.",
+                    summary: $"Hardcoded port number {port} detected.",
                     evidence: $"Line {line.LineNumber}: {content.Trim()}",
-                    whyItMatters: "Connection strings in source code expose credentials and prevent per-environment configuration.",
-                    suggestedAction: "Use IConfiguration, Secret Manager, or environment variables for connection strings.",
-                    confidence: Confidence.High));
+                    whyItMatters: "Hardcoded ports create conflicts and are inflexible across environments.",
+                    suggestedAction: "Externalize port configuration via configuration files or environment variables.",
+                    confidence: Confidence.Medium));
                 break;
             }
         }
     }
 
-    private void CheckHardcodedPorts(DiffFile file, List<Finding> findings)
+    private void CheckEnvironmentNames(DiffFile file, AnalysisContext context, List<Finding> findings)
     {
         foreach (var line in file.AddedLines)
         {
             var content = line.Content;
             if (WellKnownPatterns.IsCommentLine(content.Trim())) continue;
-            var literals = ExtractStringLiterals(content);
 
-            foreach (var port in KnownPorts)
-            {
-                if (content.Contains($": {port}") || content.Contains($"Port = {port}") || content.Contains($"port = {port}") ||
-                    literals.Any(l => l.Contains($":{port}", StringComparison.Ordinal)))
-                {
-                    findings.Add(CreateFinding(
-                        file,
-                        summary: $"Hardcoded port number {port} detected.",
-                        evidence: $"Line {line.LineNumber}: {content.Trim()}",
-                        whyItMatters: "Hardcoded ports create conflicts and are inflexible across environments.",
-                        suggestedAction: "Externalize port configuration via configuration files or environment variables.",
-                        confidence: Confidence.Medium));
-                    break;
-                }
-            }
-        }
-    }
-
-    private void CheckEnvironmentNames(DiffFile file, List<Finding> findings)
-    {
-        foreach (var line in file.AddedLines)
-        {
-            var content = line.Content;
-            if (WellKnownPatterns.IsCommentLine(content.Trim())) continue;
-            var literals = ExtractStringLiterals(content);
-            if (literals.Count == 0) continue;
+            // Skip IHostEnvironment fluent calls: IsProduction() etc. are the correct pattern
+            if (content.Contains(".IsProduction()", StringComparison.OrdinalIgnoreCase) ||
+                content.Contains(".IsStaging()", StringComparison.OrdinalIgnoreCase) ||
+                content.Contains(".IsDevelopment()", StringComparison.OrdinalIgnoreCase))
+                continue;
 
             foreach (var env in EnvironmentNames)
             {
-                if (!literals.Any(l => string.Equals(l, env, StringComparison.OrdinalIgnoreCase) ||
-                                       string.Equals(l, $"ASPNETCORE_ENVIRONMENT={env}", StringComparison.OrdinalIgnoreCase) ||
-                                       string.Equals(l, $"DOTNET_ENVIRONMENT={env}", StringComparison.OrdinalIgnoreCase)))
-                    continue;
-
-                // Skip IHostEnvironment fluent calls: IsProduction() etc. are the correct pattern
-                if (content.Contains(".IsProduction()", StringComparison.OrdinalIgnoreCase) ||
-                    content.Contains(".IsStaging()", StringComparison.OrdinalIgnoreCase) ||
-                    content.Contains(".IsDevelopment()", StringComparison.OrdinalIgnoreCase))
+                if (!HasHardcodedLiteral(context, file, line, literal => MatchesEnvironmentLiteral(literal, env)))
                     continue;
 
                 findings.Add(CreateFinding(
@@ -244,6 +200,69 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
                 break;
             }
         }
+    }
+
+    private static bool HasHardcodedLiteral(
+        AnalysisContext context,
+        DiffFile file,
+        DiffLine line,
+        Func<string, bool> literalPredicate) =>
+        RegexEvidencePromotion.PassesLiteralCandidateValidation(
+            context,
+            file.NewPath,
+            line,
+            literalPredicate,
+            ExtractStringLiterals);
+
+    private static bool IsHardcodedIpLiteral(string literal)
+    {
+        if (literal.Contains("://", StringComparison.Ordinal)) return false;
+        if (IsLikelyVersionLiteral(literal)) return false;
+        return BareIpAddressRegex.IsMatch(literal.Trim());
+    }
+
+    private static bool IsHardcodedPrivateUrlLiteral(string literal) =>
+        HardcodedUrlRegex.IsMatch(literal) &&
+        !SafeUrlPrefixes.Any(s => literal.StartsWith(s, StringComparison.OrdinalIgnoreCase));
+
+    private static bool ContainsConnectionStringMarker(string literal) =>
+        ConnectionStringMarkers.Any(marker =>
+            literal.Contains(marker, StringComparison.OrdinalIgnoreCase));
+
+    private static bool HasHardcodedPort(AnalysisContext context, DiffFile file, DiffLine line, int port)
+    {
+        if (context.Syntax is not null)
+        {
+            return HasHardcodedLiteral(
+                context,
+                file,
+                line,
+                literal => literal.Contains($":{port}", StringComparison.Ordinal));
+        }
+
+        var content = line.Content;
+        var literals = ExtractStringLiterals(content);
+        return content.Contains($": {port}", StringComparison.Ordinal)
+            || content.Contains($"Port = {port}", StringComparison.Ordinal)
+            || content.Contains($"port = {port}", StringComparison.Ordinal)
+            || literals.Any(l => l.Contains($":{port}", StringComparison.Ordinal));
+    }
+
+    private static bool MatchesEnvironmentLiteral(string literal, string env) =>
+        string.Equals(literal, env, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(literal, $"ASPNETCORE_ENVIRONMENT={env}", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(literal, $"DOTNET_ENVIRONMENT={env}", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsLikelyVersionLiteral(string literal)
+    {
+        var trimmed = literal.Trim();
+        if (!BareIpAddressRegex.IsMatch(trimmed)) return false;
+
+        var parts = trimmed.Split('.');
+        if (parts.Length != 4) return false;
+        if (!parts.All(p => int.TryParse(p, out var n) && n >= 0 && n <= 255)) return false;
+
+        return parts.All(p => p.Length <= 2 && int.Parse(p, CultureInfo.InvariantCulture) <= 99);
     }
 
 

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
@@ -33,7 +33,7 @@ public class GCI0024_ResourceLifecycle : RuleBase
 
         foreach (var file in diff.Files)
         {
-            CheckUnguardedDisposables(file, findings);
+            CheckUnguardedDisposables(file, context, findings);
         }
 
         AddRoslynFindings(context.StaticAnalysis, findings);
@@ -41,7 +41,7 @@ public class GCI0024_ResourceLifecycle : RuleBase
         return Task.FromResult(findings);
     }
 
-    private void CheckUnguardedDisposables(DiffFile file, List<Finding> findings)
+    private void CheckUnguardedDisposables(DiffFile file, AnalysisContext context, List<Finding> findings)
     {
         if (WellKnownPatterns.IsTestFile(file.NewPath)) return;
         if (WellKnownPatterns.IsGeneratedFile(file.NewPath)) return;
@@ -59,6 +59,10 @@ public class GCI0024_ResourceLifecycle : RuleBase
 
             var (typeName, isExplicit) = MatchDisposableType(content);
             if (typeName is null) continue;
+
+            if (context.Syntax is { } syntax &&
+                !syntax.IsConfirmedObjectCreation(file.NewPath, line.LineNumber, typeName))
+                continue;
 
             // Defer to the owning rule (GCI0039) rather than double-reporting.
             if (WellKnownPatterns.ResourcePatterns.OwnedByOtherRules.Contains(typeName)) continue;

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0048_InsecureRandomInSecurityContext.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0048_InsecureRandomInSecurityContext.cs
@@ -60,13 +60,15 @@ public class GCI0048_InsecureRandomInSecurityContext : RuleBase
                 var match = NewRandomRegex.Match(line.Content);
                 if (!match.Success) continue;
 
-                // Syntax guard: suppress if the match position is inside a comment or string literal.
-                if (context.Syntax?.IsInCommentOrStringLiteral(file.NewPath, line.LineNumber, match.Index) == true)
+                if (!RegexEvidencePromotion.PassesCodeCandidateValidation(
+                        context,
+                        file.NewPath,
+                        line,
+                        match.Index,
+                        confirmSemantic: syntax =>
+                            syntax.IsConfirmedObjectCreation(file.NewPath, line.LineNumber, "Random"),
+                        allowWhenNoSyntaxTree: content => !IsAfterLineComment(content, match.Index)))
                     continue;
-
-                // Lightweight fallback for raw-diff analysis (no syntax tree):
-                // suppress when the match falls after a // comment marker on the same line.
-                if (IsAfterLineComment(line.Content, match.Index)) continue;
 
                 // Check ±5 surrounding added lines for security-sensitive identifiers
                 int start = Math.Max(0, i - 5);

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0049_FloatDoubleEqualityComparison.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0049_FloatDoubleEqualityComparison.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using GauntletCI.Core.Analysis;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
+using GauntletCI.Core.StaticAnalysis;
 
 namespace GauntletCI.Core.Rules.Implementations;
 
@@ -33,15 +34,21 @@ public class GCI0049_FloatDoubleEqualityComparison : RuleBase
             foreach (var line in file.AddedLines)
             {
                 var content = line.Content;
-
-                // Skip comment lines (simple prefix check)
                 var trimmed = content.TrimStart();
-                if (trimmed.StartsWith("//") || trimmed.StartsWith("*") || trimmed.StartsWith("/*"))
-                    continue;
+                int operatorIndex = GetFirstOperatorIndex(content);
 
-                // Syntax guard: suppress if the first operator position is inside a comment or string literal.
-                if (context.Syntax?.IsInCommentOrStringLiteral(
-                        file.NewPath, line.LineNumber, GetFirstOperatorIndex(content)) == true)
+                if (!RegexEvidencePromotion.PassesCodeCandidateValidation(
+                        context,
+                        file.NewPath,
+                        line,
+                        operatorIndex,
+                        allowWhenNoSyntaxTree: c =>
+                        {
+                            var t = c.TrimStart();
+                            return !t.StartsWith("//", StringComparison.Ordinal)
+                                && !t.StartsWith("*", StringComparison.Ordinal)
+                                && !t.StartsWith("/*", StringComparison.Ordinal);
+                        }))
                     continue;
 
                 // When the line is an integer zero-guard ternary (e.g. count == 0 ? 0.0 : (double)a/b),

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0057_BlockingAsyncViolation.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0057_BlockingAsyncViolation.cs
@@ -44,13 +44,13 @@ public class GCI0057_BlockingAsyncViolation : RuleBase
             if (WellKnownPatterns.IsTestFile(file.NewPath))
                 continue;
 
-            CheckSyncFileIo(file, findings);
+            CheckSyncFileIo(file, context, findings);
         }
 
         return Task.FromResult(findings);
     }
 
-    private void CheckSyncFileIo(DiffFile file, List<Finding> findings)
+    private void CheckSyncFileIo(DiffFile file, AnalysisContext context, List<Finding> findings)
     {
         var fileName = Path.GetFileName(file.NewPath);
         if (SyncFileIoExemptFiles.Any(f => f.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
@@ -60,17 +60,15 @@ public class GCI0057_BlockingAsyncViolation : RuleBase
 
         foreach (var line in file.AddedLines)
         {
-            if (!SyncFileIoPattern.IsMatch(line.Content))
-                continue;
-
-            if (IsInStringOrComment(line.Content))
-                continue;
-
             var match = SyncFileIoPattern.Match(line.Content);
             if (!match.Success || match.Groups.Count < 2)
                 continue;
 
             var method = match.Groups[1].Value;
+
+            if (!PassesEvidenceValidation(file, line, method, match.Index, context))
+                continue;
+
             var confidence = DetermineFileIoConfidence(allLines, line);
 
             var suggestion = method.Equals("Copy", StringComparison.OrdinalIgnoreCase)
@@ -86,6 +84,24 @@ public class GCI0057_BlockingAsyncViolation : RuleBase
                 confidence: confidence,
                 line: line));
         }
+    }
+
+    private static bool PassesEvidenceValidation(
+        DiffFile file,
+        DiffLine line,
+        string method,
+        int matchIndex,
+        AnalysisContext context)
+    {
+        if (context.Syntax is { } syntax)
+        {
+            if (syntax.IsInCommentOrStringLiteral(file.NewPath, line.LineNumber, matchIndex))
+                return false;
+
+            return syntax.IsConfirmedSystemIoFileSyncInvocation(file.NewPath, line.LineNumber, method);
+        }
+
+        return !IsInStringOrComment(line.Content);
     }
 
     private static Confidence DetermineFileIoConfidence(List<DiffLine> allLines, DiffLine targetLine)

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0057_BlockingAsyncViolation.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0057_BlockingAsyncViolation.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using GauntletCI.Core.Analysis;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
+using GauntletCI.Core.StaticAnalysis;
 
 namespace GauntletCI.Core.Rules.Implementations;
 
@@ -91,18 +92,14 @@ public class GCI0057_BlockingAsyncViolation : RuleBase
         DiffLine line,
         string method,
         int matchIndex,
-        AnalysisContext context)
-    {
-        if (context.Syntax is { } syntax)
-        {
-            if (syntax.IsInCommentOrStringLiteral(file.NewPath, line.LineNumber, matchIndex))
-                return false;
-
-            return syntax.IsConfirmedSystemIoFileSyncInvocation(file.NewPath, line.LineNumber, method);
-        }
-
-        return !IsInStringOrComment(line.Content);
-    }
+        AnalysisContext context) =>
+        RegexEvidencePromotion.PassesCodeCandidateValidation(
+            context,
+            file.NewPath,
+            line,
+            matchIndex,
+            confirmSemantic: syntax => syntax.IsConfirmedSystemIoFileSyncInvocation(file.NewPath, line.LineNumber, method),
+            allowWhenNoSyntaxTree: content => !IsInStringOrComment(content));
 
     private static Confidence DetermineFileIoConfidence(List<DiffLine> allLines, DiffLine targetLine)
     {

--- a/src/GauntletCI.Core/StaticAnalysis/RegexEvidencePromotion.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/RegexEvidencePromotion.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+
+namespace GauntletCI.Core.StaticAnalysis;
+
+/// <summary>
+/// Shared regex-to-finding pipeline helpers: comment/string suppression, optional semantic
+/// confirmation, and literal-site promotion for configuration-style rules.
+/// </summary>
+public static class RegexEvidencePromotion
+{
+    /// <summary>
+    /// Validates a regex hit on executable code (e.g. method calls, object creation).
+    /// Stage 3: suppress comment/string false positives. Stage 4: optional semantic confirm.
+    /// </summary>
+    public static bool PassesCodeCandidateValidation(
+        AnalysisContext context,
+        string filePath,
+        DiffLine line,
+        int matchIndex,
+        Func<SyntaxContext, bool>? confirmSemantic = null,
+        Func<string, bool>? allowWhenNoSyntaxTree = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(filePath);
+        ArgumentNullException.ThrowIfNull(line);
+
+        if (context.Syntax is { } syntax)
+        {
+            if (syntax.IsInCommentOrStringLiteral(filePath, line.LineNumber, matchIndex))
+                return false;
+
+            return confirmSemantic?.Invoke(syntax) ?? true;
+        }
+
+        if (allowWhenNoSyntaxTree is not null)
+            return allowWhenNoSyntaxTree(line.Content);
+
+        return !IsWholeLineComment(line.Content);
+    }
+
+    /// <summary>
+    /// Validates that a candidate value appears in a Roslyn-confirmed string literal on the line.
+    /// Pass-through when no syntax tree is available (uses <paramref name="extractLiteralsWhenNoTree"/>).
+    /// </summary>
+    public static bool PassesLiteralCandidateValidation(
+        AnalysisContext context,
+        string filePath,
+        DiffLine line,
+        Func<string, bool> literalPredicate,
+        Func<string, IReadOnlyList<string>>? extractLiteralsWhenNoTree = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(filePath);
+        ArgumentNullException.ThrowIfNull(line);
+        ArgumentNullException.ThrowIfNull(literalPredicate);
+
+        if (context.Syntax is { } syntax)
+            return syntax.HasStringLiteralMatching(filePath, line.LineNumber, literalPredicate);
+
+        if (extractLiteralsWhenNoTree is not null)
+            return extractLiteralsWhenNoTree(line.Content).Any(literalPredicate);
+
+        return true;
+    }
+
+    private static bool IsWholeLineComment(string content)
+    {
+        var trimmed = content.Trim();
+        return trimmed.StartsWith("//", StringComparison.Ordinal)
+            || trimmed.StartsWith("/*", StringComparison.Ordinal)
+            || trimmed.StartsWith("*", StringComparison.Ordinal);
+    }
+}

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
@@ -13,6 +13,8 @@ namespace GauntletCI.Core.StaticAnalysis;
 ///   <item><description><see cref="IsConfirmedObjectCreation"/> returns <c>true</c> (don't suppress: no evidence to filter).</description></item>
 ///   <item><description><see cref="IsInCommentOrStringLiteral"/> returns <c>false</c> (don't suppress: no evidence to suppress).</description></item>
 ///   <item><description><see cref="IsConfirmedSystemIoFileSyncInvocation"/> returns <c>true</c> (allow regex candidate when no tree).</description></item>
+///   <item><description><see cref="HasStringLiteralMatching"/> returns <c>true</c> (allow literal candidate when no tree).</description></item>
+///   <item><description><see cref="IsConfirmedMemberAccess"/> returns <c>true</c> (allow regex candidate when no tree).</description></item>
 /// </list>
 /// </para>
 /// </summary>
@@ -60,6 +62,30 @@ public sealed class SyntaxContext
         ArgumentNullException.ThrowIfNull(methodName);
         if (!TryGetTree(filePath, out var tree)) return true;
         return SyntaxGuard.HasSystemIoFileSyncInvocation(tree!, lineNumber, methodName);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when a string literal on the line satisfies <paramref name="predicate"/>,
+    /// or when no syntax tree is available (pass-through).
+    /// </summary>
+    public bool HasStringLiteralMatching(string filePath, int lineNumber, Func<string, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        ArgumentNullException.ThrowIfNull(predicate);
+        if (!TryGetTree(filePath, out var tree)) return true;
+        return SyntaxGuard.HasStringLiteralMatching(tree!, lineNumber, predicate);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when Roslyn confirms a member access named <paramref name="memberName"/>
+    /// at <paramref name="columnOffset"/> on the line, or when no syntax tree is available (pass-through).
+    /// </summary>
+    public bool IsConfirmedMemberAccess(string filePath, int lineNumber, string memberName, int columnOffset)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        ArgumentNullException.ThrowIfNull(memberName);
+        if (!TryGetTree(filePath, out var tree)) return true;
+        return SyntaxGuard.HasMemberAccessAtPosition(tree!, lineNumber, memberName, columnOffset);
     }
 
     private bool TryGetTree(string filePath, out SyntaxTree? tree)

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
@@ -12,6 +12,7 @@ namespace GauntletCI.Core.StaticAnalysis;
 /// <list type="bullet">
 ///   <item><description><see cref="IsConfirmedObjectCreation"/> returns <c>true</c> (don't suppress: no evidence to filter).</description></item>
 ///   <item><description><see cref="IsInCommentOrStringLiteral"/> returns <c>false</c> (don't suppress: no evidence to suppress).</description></item>
+///   <item><description><see cref="IsConfirmedSystemIoFileSyncInvocation"/> returns <c>true</c> (allow regex candidate when no tree).</description></item>
 /// </list>
 /// </para>
 /// </summary>
@@ -47,6 +48,18 @@ public sealed class SyntaxContext
         ArgumentNullException.ThrowIfNull(filePath);
         if (!TryGetTree(filePath, out var tree)) return false;
         return SyntaxGuard.IsInCommentOrStringLiteral(tree!, lineNumber, columnOffset);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when Roslyn confirms a synchronous <c>System.IO.File</c> invocation
+    /// for <paramref name="methodName"/> on the line, or when no syntax tree is available (pass-through).
+    /// </summary>
+    public bool IsConfirmedSystemIoFileSyncInvocation(string filePath, int lineNumber, string methodName)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        ArgumentNullException.ThrowIfNull(methodName);
+        if (!TryGetTree(filePath, out var tree)) return true;
+        return SyntaxGuard.HasSystemIoFileSyncInvocation(tree!, lineNumber, methodName);
     }
 
     private bool TryGetTree(string filePath, out SyntaxTree? tree)

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using System.Runtime.InteropServices;
 
 namespace GauntletCI.Core.StaticAnalysis;
@@ -102,6 +103,61 @@ public static class SyntaxGuard
              or SyntaxKind.MultiLineCommentTrivia
              or SyntaxKind.SingleLineDocumentationCommentTrivia
              or SyntaxKind.MultiLineDocumentationCommentTrivia;
+
+    /// <summary>
+    /// Returns <c>true</c> when a plain string literal on the line satisfies <paramref name="predicate"/>.
+    /// </summary>
+    public static bool HasStringLiteralMatching(SyntaxTree tree, int lineNumber, Func<string, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(tree);
+        ArgumentNullException.ThrowIfNull(predicate);
+        var text = tree.GetText();
+        if (lineNumber < 1 || lineNumber > text.Lines.Count) return false;
+
+        var lineSpan = text.Lines[lineNumber - 1].Span;
+        return tree.GetRoot()
+            .DescendantNodes(lineSpan)
+            .OfType<LiteralExpressionSyntax>()
+            .Where(n => n.IsKind(SyntaxKind.StringLiteralExpression))
+            .Any(n => predicate(n.Token.ValueText));
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="columnOffset"/> falls on a
+    /// <see cref="MemberAccessExpressionSyntax"/> whose member name matches <paramref name="memberName"/>.
+    /// </summary>
+    public static bool HasMemberAccessAtPosition(
+        SyntaxTree tree,
+        int lineNumber,
+        string memberName,
+        int columnOffset)
+    {
+        ArgumentNullException.ThrowIfNull(tree);
+        ArgumentNullException.ThrowIfNull(memberName);
+        var text = tree.GetText();
+        if (lineNumber < 1 || lineNumber > text.Lines.Count) return false;
+
+        var line = text.Lines[lineNumber - 1];
+        if (line.Span.IsEmpty) return false;
+        if (columnOffset < 0) columnOffset = 0;
+        var position = line.Start + Math.Min(columnOffset, line.Span.Length - 1);
+
+        for (var node = tree.GetRoot().FindNode(new TextSpan(position, 0)); node is not null; node = node.Parent)
+        {
+            if (node is not MemberAccessExpressionSyntax memberAccess)
+                continue;
+
+            if (!memberAccess.Name.Identifier.Text.Equals(memberName, StringComparison.Ordinal))
+                continue;
+
+            if (!memberAccess.Name.Span.Contains(position))
+                continue;
+
+            return true;
+        }
+
+        return false;
+    }
 
     private static readonly HashSet<string> SystemIoFileSyncMethods = new(StringComparer.OrdinalIgnoreCase)
     {

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxGuard.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Runtime.InteropServices;
 
 namespace GauntletCI.Core.StaticAnalysis;
 
@@ -101,6 +102,109 @@ public static class SyntaxGuard
              or SyntaxKind.MultiLineCommentTrivia
              or SyntaxKind.SingleLineDocumentationCommentTrivia
              or SyntaxKind.MultiLineDocumentationCommentTrivia;
+
+    private static readonly HashSet<string> SystemIoFileSyncMethods = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ReadAllText",
+        "ReadAllLines",
+        "WriteAllText",
+        "WriteAllLines",
+        "Copy",
+        "ReadAllBytes",
+        "WriteAllBytes",
+    };
+
+    /// <summary>
+    /// Returns <c>true</c> when the line contains a confirmed <c>System.IO.File</c> synchronous
+    /// method invocation matching <paramref name="methodName"/>.
+    /// Uses syntax structure first, then a lightweight semantic bind when compilation succeeds.
+    /// </summary>
+    public static bool HasSystemIoFileSyncInvocation(SyntaxTree tree, int lineNumber, string methodName)
+    {
+        ArgumentNullException.ThrowIfNull(tree);
+        ArgumentNullException.ThrowIfNull(methodName);
+        if (!SystemIoFileSyncMethods.Contains(methodName))
+            return false;
+
+        var text = tree.GetText();
+        if (lineNumber < 1 || lineNumber > text.Lines.Count)
+            return false;
+
+        var lineSpan = text.Lines[lineNumber - 1].Span;
+        foreach (var invocation in tree.GetRoot().DescendantNodes(lineSpan).OfType<InvocationExpressionSyntax>())
+        {
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+                continue;
+
+            if (!memberAccess.Name.Identifier.Text.Equals(methodName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!IsSystemIoFileExpression(memberAccess.Expression))
+                continue;
+
+            if (!IsSemanticallySystemIoFile(tree, invocation))
+                continue;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsSystemIoFileExpression(ExpressionSyntax? expression) =>
+        expression switch
+        {
+            IdentifierNameSyntax { Identifier.Text: "File" } => true,
+            QualifiedNameSyntax qualified when qualified.Right.Identifier.Text == "File" =>
+                IsSystemIoNamespace(qualified.Left),
+            AliasQualifiedNameSyntax aliased => IsSystemIoFileExpression(aliased.Name),
+            MemberAccessExpressionSyntax member when member.Name.Identifier.Text == "File" =>
+                IsSystemIoNamespace(member.Expression),
+            _ => false,
+        };
+
+    private static bool IsSystemIoNamespace(ExpressionSyntax expression)
+    {
+        var text = expression.ToString();
+        return text.Equals("System.IO", StringComparison.Ordinal)
+            || text.EndsWith(".System.IO", StringComparison.Ordinal);
+    }
+
+    private static bool IsSemanticallySystemIoFile(SyntaxTree tree, InvocationExpressionSyntax invocation)
+    {
+        try
+        {
+            var compilation = CreateMiniCompilation(tree);
+            var model = compilation.GetSemanticModel(tree);
+            if (model.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method)
+                return true;
+
+            var containingType = method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return containingType is "global::System.IO.File" or "System.IO.File";
+        }
+        catch (Exception)
+        {
+            return true;
+        }
+    }
+
+    private static CSharpCompilation CreateMiniCompilation(SyntaxTree tree)
+    {
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        var references = new List<MetadataReference>();
+        foreach (var dll in new[] { "System.Runtime.dll", "System.Private.CoreLib.dll", "netstandard.dll" })
+        {
+            var path = Path.Combine(runtimeDir, dll);
+            if (File.Exists(path))
+                references.Add(MetadataReference.CreateFromFile(path));
+        }
+
+        return CSharpCompilation.Create(
+            assemblyName: "GauntletCI.SyntaxGuard",
+            syntaxTrees: [tree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
 
     private static string GetSimpleTypeName(TypeSyntax type) => type switch
     {

--- a/tests/GauntletCI.Core.Tests/Rules/GCI0006_EdgeCaseHandlingEvidenceTests.cs
+++ b/tests/GauntletCI.Core.Tests/Rules/GCI0006_EdgeCaseHandlingEvidenceTests.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Rules;
+using GauntletCI.Core.Rules.Implementations;
+using GauntletCI.Core.StaticAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace GauntletCI.Core.Tests.Rules;
+
+public class GCI0006_EdgeCaseHandlingEvidenceTests
+{
+    private readonly GCI0006_EdgeCaseHandling _rule = new(new DefaultPatternProvider());
+    private const string FilePath = "src/Service.cs";
+
+    private static AnalysisContext CreateContext(DiffContext diff, SyntaxContext? syntax = null) => new()
+    {
+        EligibleFiles = [],
+        SkippedFiles = [],
+        Diff = diff,
+        Syntax = syntax,
+    };
+
+    private static SyntaxContext CreateSyntaxContext(string filePath, string sourceLine, int lineNumber)
+    {
+        var lines = Enumerable.Repeat("// existing", lineNumber - 1).Append(sourceLine);
+        var tree = CSharpSyntaxTree.ParseText(SourceText.From(string.Join('\n', lines)));
+        return new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            [filePath] = tree
+        });
+    }
+
+    private static DiffContext CreateDiffAtLine(string filePath, int lineNumber, string content) =>
+        new()
+        {
+            Files =
+            [
+                new DiffFile
+                {
+                    NewPath = filePath,
+                    OldPath = string.Empty,
+                    IsAdded = true,
+                    Hunks =
+                    [
+                        new DiffHunk
+                        {
+                            OldStartLine = 1,
+                            NewStartLine = 1,
+                            Lines =
+                            [
+                                new DiffLine
+                                {
+                                    Kind = DiffLineKind.Added,
+                                    LineNumber = lineNumber,
+                                    Content = content
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+    [Fact]
+    public async Task ValueAccessInStringLiteral_WithSyntaxTree_ShouldNotFlag()
+    {
+        const string addedLine = "    var hint = \"access maybe.Value safely\";";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var syntax = CreateSyntaxContext(FilePath, addedLine, 2);
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("null dereference"));
+    }
+
+    [Fact]
+    public async Task ValueAccessInLiveCode_WithSyntaxTree_ShouldFlag()
+    {
+        const string addedLine = "    var result = maybe.Value;";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var syntax = CreateSyntaxContext(FilePath, addedLine, 2);
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.Contains(findings, f => f.Summary.Contains("null dereference"));
+    }
+}

--- a/tests/GauntletCI.Core.Tests/Rules/GCI0010_HardcodingAndConfigurationTests.cs
+++ b/tests/GauntletCI.Core.Tests/Rules/GCI0010_HardcodingAndConfigurationTests.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Rules;
+using GauntletCI.Core.Rules.Implementations;
+using GauntletCI.Core.StaticAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace GauntletCI.Core.Tests.Rules;
+
+public class GCI0010_HardcodingAndConfigurationTests
+{
+    private readonly GCI0010_HardcodingAndConfiguration _rule = new(new DefaultPatternProvider());
+    private const string FilePath = "src/Config.cs";
+
+    private static AnalysisContext CreateContext(DiffContext diff, SyntaxContext? syntax = null) => new()
+    {
+        EligibleFiles = [],
+        SkippedFiles = [],
+        Diff = diff,
+        Syntax = syntax,
+    };
+
+    private static SyntaxContext CreateSyntaxContext(string filePath, string sourceLine, int lineNumber)
+    {
+        var lines = Enumerable.Repeat("// existing", lineNumber - 1).Append(sourceLine);
+        var tree = CSharpSyntaxTree.ParseText(SourceText.From(string.Join('\n', lines)));
+        return new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            [filePath] = tree
+        });
+    }
+
+    private static DiffContext CreateDiffAtLine(string filePath, int lineNumber, string content)
+    {
+        var line = new DiffLine
+        {
+            Kind = DiffLineKind.Added,
+            LineNumber = lineNumber,
+            Content = content
+        };
+
+        return new DiffContext
+        {
+            Files =
+            [
+                new DiffFile
+                {
+                    NewPath = filePath,
+                    OldPath = string.Empty,
+                    IsAdded = true,
+                    Hunks =
+                    [
+                        new DiffHunk
+                        {
+                            OldStartLine = 1,
+                            NewStartLine = 1,
+                            Lines = [line]
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    [Fact]
+    public async Task AssemblyVersionLiteral_WithSyntaxTree_ShouldNotFlagIpFinding()
+    {
+        const string addedLine = "[assembly: AssemblyVersion(\"1.0.0.0\")]";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var syntax = CreateSyntaxContext(FilePath, addedLine, 2);
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("IP address"));
+    }
+
+    [Fact]
+    public async Task HardcodedIpLiteral_WithSyntaxTree_ShouldFlag()
+    {
+        const string addedLine = "    var host = \"192.168.1.100\";";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var syntax = CreateSyntaxContext(FilePath, addedLine, 2);
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.Contains(findings, f => f.Summary.Contains("IP address"));
+    }
+
+    [Fact]
+    public async Task IpInComment_WithSyntaxTree_ShouldNotFlag()
+    {
+        const string addedLine = "// Old server was at 192.168.1.100";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var syntax = CreateSyntaxContext(FilePath, addedLine, 2);
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("IP address"));
+    }
+}

--- a/tests/GauntletCI.Core.Tests/Rules/GCI0024_ResourceLifecycleEvidenceTests.cs
+++ b/tests/GauntletCI.Core.Tests/Rules/GCI0024_ResourceLifecycleEvidenceTests.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Elastic-2.0
+using GauntletCI.Core.Analysis;
+using GauntletCI.Core.Diff;
+using GauntletCI.Core.Rules;
+using GauntletCI.Core.Rules.Implementations;
+using GauntletCI.Core.StaticAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace GauntletCI.Core.Tests.Rules;
+
+public class GCI0024_ResourceLifecycleEvidenceTests
+{
+    private readonly GCI0024_ResourceLifecycle _rule = new(new DefaultPatternProvider());
+    private const string FilePath = "src/FileProcessor.cs";
+
+    private static AnalysisContext CreateContext(DiffContext diff, SyntaxContext? syntax = null) => new()
+    {
+        EligibleFiles = [],
+        SkippedFiles = [],
+        Diff = diff,
+        Syntax = syntax,
+    };
+
+    private static SyntaxContext CreateSyntaxContext(string filePath, string sourceLine, int lineNumber)
+    {
+        var lines = Enumerable.Repeat("public class FileProcessor {", lineNumber - 1).Append(sourceLine);
+        var tree = CSharpSyntaxTree.ParseText(SourceText.From(string.Join('\n', lines)));
+        return new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            [filePath] = tree
+        });
+    }
+
+    private static DiffContext CreateDiffAtLine(string filePath, int lineNumber, string content)
+    {
+        return new DiffContext
+        {
+            Files =
+            [
+                new DiffFile
+                {
+                    NewPath = filePath,
+                    OldPath = string.Empty,
+                    IsAdded = true,
+                    Hunks =
+                    [
+                        new DiffHunk
+                        {
+                            OldStartLine = 1,
+                            NewStartLine = 1,
+                            Lines =
+                            [
+                                new DiffLine
+                                {
+                                    Kind = DiffLineKind.Added,
+                                    LineNumber = lineNumber,
+                                    Content = content
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    [Fact]
+    public async Task FileStreamMentionInStringLiteral_WithSyntaxTree_ShouldNotFlag()
+    {
+        const string addedLine = "    var hint = \"use new FileStream(path)\";";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var syntax = CreateSyntaxContext(FilePath, addedLine, 2);
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("FileStream"));
+    }
+
+    [Fact]
+    public async Task FileStreamObjectCreation_WithSyntaxTree_ShouldFlag()
+    {
+        const string addedLine = "    var stream = new FileStream(\"data.bin\", FileMode.Open);";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var syntax = CreateSyntaxContext(FilePath, addedLine, 2);
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.Contains(findings, f => f.Summary.Contains("FileStream"));
+    }
+}

--- a/tests/GauntletCI.Core.Tests/Rules/GCI0057_BlockingAsyncViolationTests.cs
+++ b/tests/GauntletCI.Core.Tests/Rules/GCI0057_BlockingAsyncViolationTests.cs
@@ -4,6 +4,7 @@ using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.Rules;
 using GauntletCI.Core.Rules.Implementations;
+using GauntletCI.Core.StaticAnalysis;
 
 namespace GauntletCI.Core.Tests.Rules;
 
@@ -40,12 +41,89 @@ public class GCI0057_BlockingAsyncViolationTests
         return new DiffContext { Files = new List<DiffFile> { file } };
     }
 
-    private static AnalysisContext CreateContext(DiffContext diff) => new()
+    private static AnalysisContext CreateContext(DiffContext diff, SyntaxContext? syntax = null) => new()
     {
         EligibleFiles = [],
         SkippedFiles = [],
-        Diff = diff
+        Diff = diff,
+        Syntax = syntax,
     };
+
+    private static SyntaxContext CreateSyntaxContext(string filePath, string sourceLine, int lineNumber)
+    {
+        var lines = Enumerable.Repeat("// existing", lineNumber - 1).Append(sourceLine);
+        var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
+            Microsoft.CodeAnalysis.Text.SourceText.From(string.Join('\n', lines)));
+        return new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            [filePath] = tree
+        });
+    }
+
+    private static DiffContext CreateDiffAtLine(string filePath, int lineNumber, string content)
+    {
+        var line = new DiffLine
+        {
+            Kind = DiffLineKind.Added,
+            LineNumber = lineNumber,
+            Content = content
+        };
+
+        var hunk = new DiffHunk
+        {
+            OldStartLine = 1,
+            NewStartLine = 1,
+            Lines = new List<DiffLine> { line }
+        };
+
+        var file = new DiffFile
+        {
+            NewPath = filePath,
+            OldPath = string.Empty,
+            IsAdded = true,
+            Hunks = new List<DiffHunk> { hunk }
+        };
+
+        return new DiffContext { Files = new List<DiffFile> { file } };
+    }
+
+    [Fact]
+    public async Task NoFinding_WhenMatchIsInsideStringLiteral_WithSyntaxTree()
+    {
+        const string line = "var hint = \"File.ReadAllText(path)\";";
+        const int lineNumber = 2;
+        var diff = CreateDiffAtLine("src/Service.cs", lineNumber, line);
+        var findings = await _rule.EvaluateAsync(
+            CreateContext(diff, CreateSyntaxContext("src/Service.cs", line, lineNumber)));
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task NoFinding_WhenShadowFileType_WithSyntaxTree()
+    {
+        const string line = "    public void Load() => File.ReadAllText(\"x\");";
+        const int lineNumber = 8;
+        const string source = """
+            class Store
+            {
+                private class File
+                {
+                    public static string ReadAllText(string path) => path;
+                }
+
+                public void Load() => File.ReadAllText("x");
+            }
+            """;
+        var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
+            Microsoft.CodeAnalysis.Text.SourceText.From(source));
+        var diff = CreateDiffAtLine("src/Service.cs", lineNumber, line);
+        var syntax = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            ["src/Service.cs"] = tree
+        });
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+        Assert.Empty(findings);
+    }
 
     [Fact]
     public async Task NoFinding_WhenBlockingAsyncOnly_GCI0016OwnsThatPattern()

--- a/tests/GauntletCI.Tests/CliOutputTests.cs
+++ b/tests/GauntletCI.Tests/CliOutputTests.cs
@@ -2,6 +2,7 @@
 using GauntletCI.Cli.Output;
 using GauntletCI.Core.Model;
 using GauntletCI.Core.Rules;
+using GauntletCI.Core.Rules.Delivery;
 
 namespace GauntletCI.Tests;
 
@@ -50,6 +51,33 @@ public class ConsoleReporterTests
     {
         var result = ConsoleReporter.MaskEvidenceSnippet("http://example.com/path");
         Assert.Equal("http://example.com/path", result);
+    }
+
+    [Fact]
+    public void BuildDeliveryNotice_GlobalAndPerRuleCaps_ListsBothReasons()
+    {
+        var summary = new FindingDeliverySummary
+        {
+            InputCount = 30,
+            OutputCount = 22,
+            DroppedByGlobalCap = 5,
+            DroppedByPerRuleCap = 3,
+        };
+
+        var notice = ConsoleReporter.BuildDeliveryNotice(summary);
+
+        Assert.NotNull(notice);
+        Assert.Contains("8 finding(s) not shown", notice);
+        Assert.Contains("5 global cap", notice);
+        Assert.Contains("3 per-rule cap", notice);
+        Assert.Contains("30 raw -> 22 delivered", notice);
+    }
+
+    [Fact]
+    public void BuildDeliveryNotice_NoHiddenFindings_ReturnsNull()
+    {
+        var summary = new FindingDeliverySummary { InputCount = 4, OutputCount = 4 };
+        Assert.Null(ConsoleReporter.BuildDeliveryNotice(summary));
     }
 }
 

--- a/tests/GauntletCI.Tests/McpToolTests.cs
+++ b/tests/GauntletCI.Tests/McpToolTests.cs
@@ -55,6 +55,20 @@ public class McpToolTests
         var doc = JsonDocument.Parse(result);
         Assert.True(doc.RootElement.TryGetProperty("hasFindings", out _));
         Assert.True(doc.RootElement.TryGetProperty("findingCount", out _));
+        Assert.True(doc.RootElement.TryGetProperty("delivery", out _));
+    }
+
+    [Fact]
+    public async Task analyze_diff_WithFindings_IncludesDeliveryCounts()
+    {
+        GauntletTools.SetEngine(new NullLlmEngine());
+        var result = await GauntletTools.analyze_diff(CredentialDiff);
+        var doc = JsonDocument.Parse(result);
+        var delivery = doc.RootElement.GetProperty("delivery");
+
+        Assert.True(delivery.TryGetProperty("inputCount", out var input));
+        Assert.True(delivery.TryGetProperty("outputCount", out var output));
+        Assert.True(input.GetInt32() >= output.GetInt32());
     }
 
     [Fact]

--- a/tests/GauntletCI.Tests/SyntaxGuardTests.cs
+++ b/tests/GauntletCI.Tests/SyntaxGuardTests.cs
@@ -239,6 +239,43 @@ public class SyntaxGuardTests
     }
 
     [Fact]
+    public void HasMemberAccessAtPosition_WhenValueAccessIsLiveCode_ReturnsTrue()
+    {
+        var tree = Parse("var result = maybe.Value;");
+        int valueIndex = "var result = maybe.".Length;
+        Assert.True(SyntaxGuard.HasMemberAccessAtPosition(tree, 1, "Value", valueIndex));
+    }
+
+    [Fact]
+    public void HasMemberAccessAtPosition_WhenValueIsInsideStringLiteral_ReturnsFalse()
+    {
+        var tree = Parse("var hint = \"maybe.Value\";");
+        int valueIndex = tree.GetText().ToString().IndexOf(".Value", StringComparison.Ordinal) + 1;
+        Assert.False(SyntaxGuard.HasMemberAccessAtPosition(tree, 1, "Value", valueIndex));
+    }
+
+    [Fact]
+    public void HasStringLiteralMatching_WhenLiteralMatchesPredicate_ReturnsTrue()
+    {
+        var tree = Parse("var host = \"192.168.1.100\";");
+        Assert.True(SyntaxGuard.HasStringLiteralMatching(tree, 1, l => l.Contains("192.168")));
+    }
+
+    [Fact]
+    public void HasStringLiteralMatching_WhenMatchOnlyInComment_ReturnsFalse()
+    {
+        var tree = Parse("// server at 192.168.1.100");
+        Assert.False(SyntaxGuard.HasStringLiteralMatching(tree, 1, l => l.Contains("192.168")));
+    }
+
+    [Fact]
+    public void SyntaxContext_HasStringLiteralMatching_WhenNoTree_PassesThrough()
+    {
+        var ctx = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>());
+        Assert.True(ctx.HasStringLiteralMatching("missing.cs", 1, _ => false));
+    }
+
+    [Fact]
     public async Task GCI0057_SuppressesFileReadInsideStringLiteral()
     {
         const string addedLine = "    var hint = \"File.ReadAllText(path)\";";

--- a/tests/GauntletCI.Tests/SyntaxGuardTests.cs
+++ b/tests/GauntletCI.Tests/SyntaxGuardTests.cs
@@ -43,6 +43,55 @@ public class SyntaxGuardTests
         Assert.False(SyntaxGuard.HasObjectCreation(tree, 0, "Random"));
     }
 
+    // ── SyntaxGuard.HasSystemIoFileSyncInvocation ─────────────────────────
+
+    [Fact]
+    public void HasSystemIoFileSyncInvocation_WhenSystemIoFileCall_ReturnsTrue()
+    {
+        var tree = Parse("var text = File.ReadAllText(path);");
+        Assert.True(SyntaxGuard.HasSystemIoFileSyncInvocation(tree, 1, "ReadAllText"));
+    }
+
+    [Fact]
+    public void HasSystemIoFileSyncInvocation_WhenQualifiedSystemIoFileCall_ReturnsTrue()
+    {
+        var tree = Parse("var text = System.IO.File.ReadAllText(path);");
+        Assert.True(SyntaxGuard.HasSystemIoFileSyncInvocation(tree, 1, "ReadAllText"));
+    }
+
+    [Fact]
+    public void HasSystemIoFileSyncInvocation_WhenCustomFileType_ReturnsFalse()
+    {
+        const string source = """
+            class LocalFile
+            {
+                public static string ReadAllText(string path) => path;
+            }
+
+            var text = LocalFile.ReadAllText(path);
+            """;
+        var tree = Parse(source);
+        Assert.False(SyntaxGuard.HasSystemIoFileSyncInvocation(tree, 5, "ReadAllText"));
+    }
+
+    [Fact]
+    public void HasSystemIoFileSyncInvocation_WhenNestedShadowFileType_ReturnsFalse()
+    {
+        const string source = """
+            class Store
+            {
+                private class File
+                {
+                    public static string ReadAllText(string path) => path;
+                }
+
+                public void Load() => File.ReadAllText("x");
+            }
+            """;
+        var tree = Parse(source);
+        Assert.False(SyntaxGuard.HasSystemIoFileSyncInvocation(tree, 8, "ReadAllText"));
+    }
+
     // ── SyntaxGuard.IsInCommentOrStringLiteral ────────────────────────────
 
     [Fact]
@@ -186,6 +235,38 @@ public class SyntaxGuardTests
         var diff = MakeDiff("src/Calc.cs", addedLine);
         var rule = new GCI0049_FloatDoubleEqualityComparison(new StubPatternProvider());
         var findings = await rule.EvaluateAsync(diff);
+        Assert.NotEmpty(findings);
+    }
+
+    [Fact]
+    public async Task GCI0057_SuppressesFileReadInsideStringLiteral()
+    {
+        const string addedLine = "    var hint = \"File.ReadAllText(path)\";";
+        var tree = Parse("// existing\n" + addedLine);
+        var ctx = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            ["src/Service.cs"] = tree
+        });
+
+        var diff = MakeDiff("src/Service.cs", addedLine);
+        var rule = new GCI0057_BlockingAsyncViolation(new StubPatternProvider());
+        var findings = await rule.EvaluateAsync(diff, syntax: ctx);
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public async Task GCI0057_FiresWhenSystemIoFileReadIsLiveCode()
+    {
+        const string addedLine = "    var text = File.ReadAllText(path);";
+        var tree = Parse("// existing\n" + addedLine);
+        var ctx = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            ["src/Service.cs"] = tree
+        });
+
+        var diff = MakeDiff("src/Service.cs", addedLine);
+        var rule = new GCI0057_BlockingAsyncViolation(new StubPatternProvider());
+        var findings = await rule.EvaluateAsync(diff, syntax: ctx);
         Assert.NotEmpty(findings);
     }
 


### PR DESCRIPTION
## Summary
- Align packaging, architecture docs, and site copy with 37 active rules and delivery transparency (ConsoleReporter + JSON Delivery block).
- CI dogfoods packaged nupkg instead of dotnet run for PR self-analysis.
- Introduce RegexEvidencePromotion and roll Roslyn-backed evidence validation to GCI0006, GCI0010, GCI0024, GCI0048, GCI0049, and GCI0057.
- Route MCP analyze_staged/analyze_diff/analyze_commit through McpAnalysisPipeline (config, ignore list, StaticAnalysisRunner, delivery caps).

## Test plan
- [x] dotnet build GauntletCI.slnx
- [x] dotnet test GauntletCI.slnx (1966 tests)
- [x] gauntletci analyze on branch diff
- [ ] CI green on PR
- [ ] Optional: corpus re-analyze on ~/.gauntletci/corpus.db for GCI0010/GCI0024 FP delta