### PR TITLE
fix: corpus delivery bypass and GCI0010 authority recall

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,7 +247,7 @@ Several rules use regex only as a **candidate detector**. Before emitting a find
 
 Product claims about precision should cite **labeled corpus metrics** (`corpus audit-snapshot`, `LabeledRuleMetricsReader`), not discovery-tier trigger rates alone.
 
-**Corpus evaluation** (`RuleCorpusRunner`) disables `output.delivery` so labeled TP/FP reflect rule detection, not CLI cap-25 delivery policy.
+**Corpus evaluation** (`RuleCorpusRunner`) disables `output.delivery` and `domain` gating so labeled TP/FP reflect rule detection on the fixture diff, not CLI cap-25 policy or the GauntletCI repo's ClassLibrary profile.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,6 +247,8 @@ Several rules use regex only as a **candidate detector**. Before emitting a find
 
 Product claims about precision should cite **labeled corpus metrics** (`corpus audit-snapshot`, `LabeledRuleMetricsReader`), not discovery-tier trigger rates alone.
 
+**Corpus evaluation** (`RuleCorpusRunner`) disables `output.delivery` so labeled TP/FP reflect rule detection, not CLI cap-25 delivery policy.
+
 ---
 
 Because GauntletCI is analyzed by its own rules during development and in CI, some rules fire on the files that implement other rules. This is called **self-interference**: a rule detecting a pattern inside the implementation of another (or the same) rule.

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0010_HardcodingAndConfiguration.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0010_HardcodingAndConfiguration.cs
@@ -49,6 +49,14 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
     private static readonly string[] EnvironmentNames =
         ["production", "staging", "prod", "dev", "sandbox", "development"];
 
+    private static readonly string[] AuthorityHosts =
+    [
+        "login.microsoftonline.com",
+        "login.microsoft.com",
+        "login.windows.net",
+        "accounts.google.com",
+    ];
+
     private static readonly int[] KnownPorts = [8080, 3306, 5432, 27017, 6379, 1433, 3000, 8443];
 
     public override Task<List<Finding>> EvaluateAsync(
@@ -65,6 +73,7 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
             CheckConnectionString(file, context, findings);
             CheckHardcodedPorts(file, context, findings);
             CheckEnvironmentNames(file, context, findings);
+            CheckHardcodedAuthority(file, context, findings);
         }
 
         AddRoslynFindings(context.StaticAnalysis, findings);
@@ -202,6 +211,34 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
         }
     }
 
+    private void CheckHardcodedAuthority(DiffFile file, AnalysisContext context, List<Finding> findings)
+    {
+        if (WellKnownPatterns.IsTestFile(file.NewPath)) return;
+        if (WellKnownPatterns.PerformancePatterns.IsRuleImplementationFile(file.NewPath)) return;
+
+        foreach (var line in file.AddedLines)
+        {
+            var content = line.Content;
+            var trimmed = content.Trim();
+            if (WellKnownPatterns.IsCommentLine(trimmed)) continue;
+            if (trimmed.Contains("[InlineData(", StringComparison.Ordinal) ||
+                trimmed.Contains("[Theory]", StringComparison.Ordinal) ||
+                trimmed.Contains("[MemberData(", StringComparison.Ordinal))
+                continue;
+
+            if (!HasHardcodedLiteral(context, file, line, IsHardcodedAuthorityLiteral))
+                continue;
+
+            findings.Add(CreateFinding(
+                file,
+                summary: "Hardcoded identity authority URL or host in string literal.",
+                evidence: $"Line {line.LineNumber}: {content.Trim()}",
+                whyItMatters: "Authority endpoints should come from configuration so tenants and environments can change without recompilation.",
+                suggestedAction: "Move authority URL or host list to IConfiguration, OpenIdConnect options, or environment-specific settings.",
+                confidence: Confidence.Medium));
+        }
+    }
+
     private static bool HasHardcodedLiteral(
         AnalysisContext context,
         DiffFile file,
@@ -252,6 +289,29 @@ public class GCI0010_HardcodingAndConfiguration : RuleBase
         string.Equals(literal, env, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(literal, $"ASPNETCORE_ENVIRONMENT={env}", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(literal, $"DOTNET_ENVIRONMENT={env}", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsHardcodedAuthorityLiteral(string literal)
+    {
+        var trimmed = literal.Trim();
+        if (trimmed.Contains("://", StringComparison.Ordinal))
+        {
+            if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+                return false;
+
+            if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            return MatchesAuthorityHost(uri.Host);
+        }
+
+        return MatchesAuthorityHost(trimmed);
+    }
+
+    private static bool MatchesAuthorityHost(string host) =>
+        AuthorityHosts.Any(authority =>
+            host.Equals(authority, StringComparison.OrdinalIgnoreCase) ||
+            host.EndsWith("." + authority, StringComparison.OrdinalIgnoreCase));
 
     private static bool IsLikelyVersionLiteral(string literal)
     {

--- a/src/GauntletCI.Core/StaticAnalysis/RegexEvidencePromotion.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/RegexEvidencePromotion.cs
@@ -57,12 +57,20 @@ public static class RegexEvidencePromotion
         ArgumentNullException.ThrowIfNull(literalPredicate);
 
         if (context.Syntax is { } syntax)
-            return syntax.HasStringLiteralMatching(filePath, line.LineNumber, literalPredicate);
+        {
+            if (syntax.HasSyntaxTreeForFile(filePath))
+                return syntax.HasStringLiteralMatching(filePath, line.LineNumber, literalPredicate);
+
+            if (extractLiteralsWhenNoTree is not null)
+                return extractLiteralsWhenNoTree(line.Content).Any(literalPredicate);
+
+            return false;
+        }
 
         if (extractLiteralsWhenNoTree is not null)
             return extractLiteralsWhenNoTree(line.Content).Any(literalPredicate);
 
-        return true;
+        return false;
     }
 
     private static bool IsWholeLineComment(string content)

--- a/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
+++ b/src/GauntletCI.Core/StaticAnalysis/SyntaxContext.cs
@@ -28,6 +28,13 @@ public sealed class SyntaxContext
     /// <summary>Number of files for which a syntax tree is available.</summary>
     public int TreeCount => _trees.Count;
 
+    /// <summary>Returns <c>true</c> when a syntax tree exists for <paramref name="filePath"/>.</summary>
+    public bool HasSyntaxTreeForFile(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        return TryGetTree(filePath, out _);
+    }
+
     /// <summary>
     /// Returns <c>true</c> when Roslyn confirms an <c>ObjectCreationExpression</c>
     /// of type <paramref name="typeName"/> exists on the given line, or when no

--- a/src/GauntletCI.Corpus/Runners/RuleCorpusRunner.cs
+++ b/src/GauntletCI.Corpus/Runners/RuleCorpusRunner.cs
@@ -25,7 +25,6 @@ public sealed class RuleCorpusRunner
     private readonly IFixtureStore _store;
     private readonly CorpusDb _db;
     private readonly GauntletConfig? _config;
-    private readonly string? _repoPath;
 
     /// <summary>The run ID from the most recent call to <see cref="RunAsync"/>.</summary>
     public string LastRunId { get; private set; } = string.Empty;
@@ -43,7 +42,7 @@ public sealed class RuleCorpusRunner
         _store = store;
         _db = db;
         _config = config;
-        _repoPath = repoPath;
+        _ = repoPath;
     }
 
     public async Task<IReadOnlyList<ActualFinding>> RunAsync(
@@ -55,7 +54,7 @@ public sealed class RuleCorpusRunner
 
         var diff = DiffParser.Parse(diffText);
         var corpusConfig = BuildCorpusEvaluationConfig(_config);
-        var result = await RuleOrchestrator.CreateDefault(corpusConfig, repoPath: _repoPath)
+        var result = await RuleOrchestrator.CreateDefault(corpusConfig, repoPath: null)
             .RunAsync(diff, null, null, cancellationToken)
             .ConfigureAwait(false);
 
@@ -88,8 +87,9 @@ public sealed class RuleCorpusRunner
     }
 
     /// <summary>
-    /// Corpus metrics measure rule detection, not CLI delivery caps. Delivery ranking and
-    /// global limits are disabled so labeled TP/FN are not skewed by cap-25 policy.
+    /// Corpus metrics measure rule detection, not CLI delivery caps or repo-domain suppression.
+    /// Delivery ranking/global limits and domain gating are disabled so labeled TP/FN are not
+    /// skewed by GauntletCI repo profile (e.g. GCI0024 dropped on ClassLibrary).
     /// </summary>
     internal static GauntletConfig BuildCorpusEvaluationConfig(GauntletConfig? source)
     {
@@ -106,6 +106,7 @@ public sealed class RuleCorpusRunner
         }
 
         config.Output.Delivery.Enabled = false;
+        config.Domain.Enabled = false;
         return config;
     }
 

--- a/src/GauntletCI.Corpus/Runners/RuleCorpusRunner.cs
+++ b/src/GauntletCI.Corpus/Runners/RuleCorpusRunner.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using GauntletCI.Core.Configuration;
 using GauntletCI.Core.Diff;
 using GauntletCI.Core.Model;
@@ -15,6 +16,12 @@ namespace GauntletCI.Corpus.Runners;
 /// </summary>
 public sealed class RuleCorpusRunner
 {
+    private static readonly JsonSerializerOptions CorpusConfigCloneOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
     private readonly IFixtureStore _store;
     private readonly CorpusDb _db;
     private readonly GauntletConfig? _config;
@@ -47,7 +54,10 @@ public sealed class RuleCorpusRunner
         LastRunId = runId;
 
         var diff = DiffParser.Parse(diffText);
-        var result = await RuleOrchestrator.CreateDefault(_config, repoPath: _repoPath).RunAsync(diff, null, null, cancellationToken).ConfigureAwait(false);
+        var corpusConfig = BuildCorpusEvaluationConfig(_config);
+        var result = await RuleOrchestrator.CreateDefault(corpusConfig, repoPath: _repoPath)
+            .RunAsync(diff, null, null, cancellationToken)
+            .ConfigureAwait(false);
 
         var findings = result.Findings
             .Select(f => new ActualFinding
@@ -75,6 +85,28 @@ public sealed class RuleCorpusRunner
         await _store.SaveActualFindingsAsync(fixtureId, runId, findings, cancellationToken).ConfigureAwait(false);
 
         return findings;
+    }
+
+    /// <summary>
+    /// Corpus metrics measure rule detection, not CLI delivery caps. Delivery ranking and
+    /// global limits are disabled so labeled TP/FN are not skewed by cap-25 policy.
+    /// </summary>
+    internal static GauntletConfig BuildCorpusEvaluationConfig(GauntletConfig? source)
+    {
+        GauntletConfig config;
+        if (source is null)
+        {
+            config = new GauntletConfig();
+        }
+        else
+        {
+            config = JsonSerializer.Deserialize<GauntletConfig>(
+                JsonSerializer.Serialize(source, CorpusConfigCloneOptions),
+                CorpusConfigCloneOptions) ?? new GauntletConfig();
+        }
+
+        config.Output.Delivery.Enabled = false;
+        return config;
     }
 
     // ── DB helpers ────────────────────────────────────────────────────────────

--- a/tests/GauntletCI.Core.Tests/Rules/GCI0010_HardcodingAndConfigurationTests.cs
+++ b/tests/GauntletCI.Core.Tests/Rules/GCI0010_HardcodingAndConfigurationTests.cs
@@ -96,4 +96,41 @@ public class GCI0010_HardcodingAndConfigurationTests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("IP address"));
     }
+
+    [Fact]
+    public async Task AuthorityUrlLiteral_WithSyntaxTree_ShouldFlag()
+    {
+        const string addedLine = "    var authority = \"https://login.microsoftonline.com/tenant/v2.0\";";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var syntax = CreateSyntaxContext(FilePath, addedLine, 2);
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.Contains(findings, f => f.Summary.Contains("authority"));
+    }
+
+    [Fact]
+    public async Task AuthorityHostInInlineData_ShouldNotFlag()
+    {
+        const string addedLine = "    [InlineData(\"https://login.microsoftonline.com/tenant/v2.0\", \"login.microsoftonline.com\")]";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var syntax = CreateSyntaxContext(FilePath, addedLine, 2);
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("authority"));
+    }
+
+    [Fact]
+    public async Task HardcodedIpLiteral_WithSyntaxTreeForOtherFileOnly_ShouldFlag()
+    {
+        const string addedLine = "    var host = \"192.168.1.100\";";
+        var diff = CreateDiffAtLine(FilePath, 2, addedLine);
+        var otherTree = CSharpSyntaxTree.ParseText(SourceText.From("class Other { }"));
+        var syntax = new SyntaxContext(new Dictionary<string, Microsoft.CodeAnalysis.SyntaxTree>
+        {
+            ["src/Other.cs"] = otherTree
+        });
+        var findings = await _rule.EvaluateAsync(CreateContext(diff, syntax));
+
+        Assert.Contains(findings, f => f.Summary.Contains("IP address"));
+    }
 }

--- a/tests/GauntletCI.Tests/Corpus/CorpusIngestionTests.cs
+++ b/tests/GauntletCI.Tests/Corpus/CorpusIngestionTests.cs
@@ -455,11 +455,14 @@ public sealed class RuleCorpusRunnerTests : IDisposable
         var source = new GauntletConfig();
         source.Output.Delivery.Enabled = true;
         source.Output.Delivery.GlobalMaxFindings = 1;
+        source.Domain.Enabled = true;
 
         var corpus = RuleCorpusRunner.BuildCorpusEvaluationConfig(source);
 
         Assert.False(corpus.Output.Delivery.Enabled);
+        Assert.False(corpus.Domain.Enabled);
         Assert.True(source.Output.Delivery.Enabled);
+        Assert.True(source.Domain.Enabled);
         Assert.Equal(1, source.Output.Delivery.GlobalMaxFindings);
     }
 }

--- a/tests/GauntletCI.Tests/Corpus/CorpusIngestionTests.cs
+++ b/tests/GauntletCI.Tests/Corpus/CorpusIngestionTests.cs
@@ -448,6 +448,20 @@ public sealed class RuleCorpusRunnerTests : IDisposable
 
         Assert.DoesNotContain(findings, f => f.RuleId == "GCI0001");
     }
+
+    [Fact]
+    public void BuildCorpusEvaluationConfig_DisablesDeliveryWithoutMutatingSource()
+    {
+        var source = new GauntletConfig();
+        source.Output.Delivery.Enabled = true;
+        source.Output.Delivery.GlobalMaxFindings = 1;
+
+        var corpus = RuleCorpusRunner.BuildCorpusEvaluationConfig(source);
+
+        Assert.False(corpus.Output.Delivery.Enabled);
+        Assert.True(source.Output.Delivery.Enabled);
+        Assert.Equal(1, source.Output.Delivery.GlobalMaxFindings);
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Corpus metrics fix:** `RuleCorpusRunner` disables delivery caps so labeled TP/FP reflect rule detection, not CLI cap-25 policy. Fixes false FN when rules fire but delivery drops findings (e.g. GCI0024 TlsListener on large diffs).
- **Literal promotion:** When `SyntaxContext` has trees for other files but not the diff file, fall back to `ExtractStringLiterals` instead of blind pass-through.
- **GCI0010 recall:** Detect hardcoded identity authority hosts/URLs (`login.microsoftonline.com`, etc.) with Roslyn literal confirmation, test-attribute suppression, and rule-impl file exclusion.

## Test plan

- [x] Full `dotnet test GauntletCI.slnx` (1970 passed)
- [x] GCI0010 authority + literal fallback unit tests
- [x] `RuleCorpusRunner.BuildCorpusEvaluationConfig` test
- [ ] Re-run `corpus run-all` + `audit-snapshot` after merge for snapshot delta
