### PR TITLE
fix: GCI0024 FP suppression and corpus label overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ docs/benchmarks/
 !tests/GauntletCI.Benchmarks/Fixtures/
 /data/*
 !data/corpus-fixtures.csv
+!data/corpus-label-overrides.json
 
 # BenchmarkDotNet artifacts
 BenchmarkDotNet.Artifacts/

--- a/data/corpus-label-overrides.json
+++ b/data/corpus-label-overrides.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0.0",
+  "description": "Durable expected_findings hygiene applied by scripts/apply-corpus-label-overrides.py",
+  "overrides": [
+    {
+      "fixture_id": "devtoys-app_devtoys_pr1078",
+      "rule_id": "GCI0010",
+      "is_inconclusive": true,
+      "reason": "human_bulk cited demo JWT token string; outside GCI0010 hardcoded authority scope"
+    },
+    {
+      "fixture_id": "azuread_azure-activedirectory-identitymodel-extensions-for-dotnet_pr3410",
+      "rule_id": "GCI0010",
+      "is_inconclusive": true,
+      "reason": "Patch has no login.microsoftonline.com or authority URL in production diff lines; label lacks evidence_excerpt"
+    }
+  ]
+}

--- a/scripts/apply-corpus-label-overrides.py
+++ b/scripts/apply-corpus-label-overrides.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Apply data/corpus-label-overrides.json to expected_findings in agent corpus DB."""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_DB = Path.home() / ".gauntletci" / "corpus.db"
+DEFAULT_OVERRIDES = REPO / "data" / "corpus-label-overrides.json"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", default=str(DEFAULT_DB))
+    parser.add_argument("--overrides", default=str(DEFAULT_OVERRIDES))
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    db_path = Path(args.db)
+    overrides_path = Path(args.overrides)
+    if not overrides_path.exists():
+        raise SystemExit(f"Missing overrides file: {overrides_path}")
+    if not db_path.exists():
+        raise SystemExit(f"Missing corpus DB: {db_path}")
+
+    doc = json.loads(overrides_path.read_text(encoding="utf-8"))
+    rows = doc.get("overrides") or []
+    if not rows:
+        print("No overrides to apply")
+        return
+
+    con = sqlite3.connect(db_path)
+    updated = 0
+    missing = 0
+    try:
+        for row in rows:
+            fixture_id = row["fixture_id"]
+            rule_id = row["rule_id"]
+            inconclusive = 1 if row.get("is_inconclusive") else 0
+            reason = row.get("reason")
+            cur = con.execute(
+                """
+                UPDATE expected_findings
+                SET is_inconclusive = ?, reason = COALESCE(?, reason)
+                WHERE fixture_id = ? AND rule_id = ?
+                """,
+                (inconclusive, reason, fixture_id, rule_id),
+            )
+            if cur.rowcount == 0:
+                missing += 1
+                print(f"WARN no row: {fixture_id} / {rule_id}")
+            else:
+                updated += cur.rowcount
+                print(f"OK {fixture_id} / {rule_id} is_inconclusive={inconclusive}")
+
+        if args.dry_run:
+            con.rollback()
+            print(f"Dry run: would update {updated} row(s); missing {missing}")
+        else:
+            con.commit()
+            print(f"Applied {updated} override(s); missing {missing}")
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh-agent-corpus.ps1
+++ b/scripts/refresh-agent-corpus.ps1
@@ -28,6 +28,10 @@ Write-Log "Ensuring corpus read indexes"
 python (Join-Path $repo "scripts\corpus_db_read.py") 2>&1 |
     ForEach-Object { Write-Log $_ }
 
+Write-Log "Applying corpus label overrides"
+python (Join-Path $repo "scripts\apply-corpus-label-overrides.py") --db $corpus 2>&1 |
+    ForEach-Object { Write-Log $_ }
+
 Write-Log "Starting corpus score"
 dotnet run --project src/GauntletCI.Cli -- corpus score --db $corpus --fixtures ./data/fixtures 2>&1 |
     ForEach-Object { Write-Log $_ }

--- a/src/GauntletCI.Cli/Telemetry/TelemetryConsent.cs
+++ b/src/GauntletCI.Cli/Telemetry/TelemetryConsent.cs
@@ -187,7 +187,29 @@ public static class TelemetryConsent
         var json = JsonSerializer.Serialize(_cache, JsonOptions);
         var tmp = ConfigPath + ".tmp";
         File.WriteAllText(tmp, json);
-        File.Move(tmp, ConfigPath, overwrite: true);
+
+        const int maxAttempts = 5;
+        Exception? lastError = null;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                if (File.Exists(ConfigPath))
+                    File.Replace(tmp, ConfigPath, destinationBackupFileName: null, ignoreMetadataErrors: true);
+                else
+                    File.Move(tmp, ConfigPath);
+
+                return;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                lastError = ex;
+                if (attempt < maxAttempts)
+                    SpinWait.SpinUntil(static () => false, 15 * attempt);
+            }
+        }
+
+        throw lastError ?? new IOException($"Failed to write telemetry config after {maxAttempts} attempts.");
     }
 
     private static TelemetryMode? ParseMode(string? value) => value?.ToLowerInvariant() switch

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
@@ -71,11 +71,11 @@ public class GCI0024_ResourceLifecycle : RuleBase
             var trimmed = content.TrimStart();
             if (trimmed.StartsWith("return ", StringComparison.Ordinal)) continue;
 
-            // Skip: `new X(...)` inside a method/constructor call argument: the callee takes
-            // ownership (e.g. services.AddSingleton(new X()), collection.Add(new X())).
-            // Detect by counting unmatched `(` before the `new` keyword: if opens > closes,
-            // we are inside a parameter list.
-            if (IsInsideMethodCallArg(content, typeName)) continue;
+            // Skip: field/property initializer (instance/DI-managed lifetime).
+            if (IsFieldOrPropertyInitializer(content)) continue;
+
+            // Skip: `new X(...)` inside a method/constructor call argument (incl. multi-line).
+            if (IsInsideMethodCallArg(allLines, i, typeName)) continue;
 
             // Skip: `static readonly X = new X()`: process-lifetime singletons are never disposed
             // by design; flagging them produces only noise with no actionable fix.
@@ -140,18 +140,49 @@ public class GCI0024_ResourceLifecycle : RuleBase
         return (null, false);
     }
 
-    // Returns true when the `new TypeName(` pattern appears inside an open method or constructor
-    // call argument list: i.e., there are more `(` than `)` in the text before the `new` keyword.
-    // In that case the callee owns the object's lifetime, so no `using` is expected here.
-    private static bool IsInsideMethodCallArg(string content, string typeName)
+    private static bool IsFieldOrPropertyInitializer(string content)
     {
-        var needle = "new " + typeName;
-        int idx = content.IndexOf(needle, StringComparison.Ordinal);
-        if (idx <= 0) return false;
-        var before = content[..idx];
+        if (!content.Contains(" = new ", StringComparison.Ordinal)) return false;
+
+        var trimmed = content.TrimStart();
+        return trimmed.StartsWith("private ", StringComparison.Ordinal)
+            || trimmed.StartsWith("internal ", StringComparison.Ordinal)
+            || trimmed.StartsWith("protected ", StringComparison.Ordinal)
+            || trimmed.StartsWith("public ", StringComparison.Ordinal)
+            || trimmed.Contains(" readonly ", StringComparison.Ordinal)
+            || trimmed.Contains(" static ", StringComparison.Ordinal);
+    }
+
+    // Returns true when `new TypeName(` appears inside an open call/ctor argument list.
+    // Looks back across preceding hunk lines (added or context) so multi-line args are covered.
+    private static bool IsInsideMethodCallArg(IReadOnlyList<DiffLine> allLines, int index, string typeName)
+    {
+        const int maxLookback = 8;
         int opens = 0;
         int closes = 0;
-        foreach (char c in before) { if (c == '(') opens++; else if (c == ')') closes++; }
+
+        for (int j = index; j >= Math.Max(0, index - maxLookback); j--)
+        {
+            var line = allLines[j];
+            if (line.Kind == DiffLineKind.Removed) continue;
+
+            var content = line.Content;
+            int end = content.Length;
+            if (j == index)
+            {
+                var needle = "new " + typeName;
+                int idx = content.IndexOf(needle, StringComparison.Ordinal);
+                if (idx < 0) return opens > closes;
+                end = idx;
+            }
+
+            for (int k = 0; k < end; k++)
+            {
+                if (content[k] == '(') opens++;
+                else if (content[k] == ')') closes++;
+            }
+        }
+
         return opens > closes;
     }
 

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
@@ -157,15 +157,22 @@ public class GCI0024_ResourceLifecycle : RuleBase
         for (int j = index - 1; j >= Math.Max(0, index - 3); j--)
         {
             var line = allLines[j];
-            if (line.Kind == DiffLineKind.Removed
-                && line.Content.Contains("new " + typeName, StringComparison.Ordinal)
-                && addedContent.Contains("new " + typeName, StringComparison.Ordinal))
+            if (line.Kind != DiffLineKind.Removed) continue;
+
+            if (!line.Content.Contains("new " + typeName, StringComparison.Ordinal)
+                || !addedContent.Contains("new " + typeName, StringComparison.Ordinal))
             {
-                return true;
+                continue;
             }
 
-            if (line.Kind != DiffLineKind.Added && !string.IsNullOrWhiteSpace(line.Content))
-                break;
+            // using/dispose removed in favor of unguarded allocation: keep the finding.
+            if (line.Content.Contains("using ", StringComparison.Ordinal)
+                || line.Content.Contains(".Dispose()", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         return false;

--- a/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
+++ b/src/GauntletCI.Core/Rules/Implementations/GCI0024_ResourceLifecycle.cs
@@ -60,6 +60,9 @@ public class GCI0024_ResourceLifecycle : RuleBase
             var (typeName, isExplicit) = MatchDisposableType(content);
             if (typeName is null) continue;
 
+            // Skip: options/default-only replacement of an existing new Type(...) allocation.
+            if (IsReplacementOfExistingAllocation(allLines, i, typeName, content)) continue;
+
             if (context.Syntax is { } syntax &&
                 !syntax.IsConfirmedObjectCreation(file.NewPath, line.LineNumber, typeName))
                 continue;
@@ -73,6 +76,9 @@ public class GCI0024_ResourceLifecycle : RuleBase
 
             // Skip: field/property initializer (instance/DI-managed lifetime).
             if (IsFieldOrPropertyInitializer(content)) continue;
+
+            // Skip: local assigned then passed to ctor/method (callee owns lifetime).
+            if (IsAssignedThenPassedToCallee(allLines, i, content)) continue;
 
             // Skip: `new X(...)` inside a method/constructor call argument (incl. multi-line).
             if (IsInsideMethodCallArg(allLines, i, typeName)) continue;
@@ -138,6 +144,58 @@ public class GCI0024_ResourceLifecycle : RuleBase
         }
 
         return (null, false);
+    }
+
+    private static bool IsReplacementOfExistingAllocation(
+        IReadOnlyList<DiffLine> allLines,
+        int index,
+        string typeName,
+        string addedContent)
+    {
+        if (index <= 0) return false;
+
+        for (int j = index - 1; j >= Math.Max(0, index - 3); j--)
+        {
+            var line = allLines[j];
+            if (line.Kind == DiffLineKind.Removed
+                && line.Content.Contains("new " + typeName, StringComparison.Ordinal)
+                && addedContent.Contains("new " + typeName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (line.Kind != DiffLineKind.Added && !string.IsNullOrWhiteSpace(line.Content))
+                break;
+        }
+
+        return false;
+    }
+
+    private static bool IsAssignedThenPassedToCallee(IReadOnlyList<DiffLine> allLines, int index, string content)
+    {
+        var assignMatch = System.Text.RegularExpressions.Regex.Match(
+            content,
+            @"\bvar\s+(\w+)\s*=\s*new\s+");
+        if (!assignMatch.Success) return false;
+
+        var varName = assignMatch.Groups[1].Value;
+        int winEnd = Math.Min(allLines.Count, index + 15);
+        for (int j = index + 1; j < winEnd; j++)
+        {
+            var line = allLines[j];
+            if (line.Kind == DiffLineKind.Removed) continue;
+
+            var next = line.Content;
+            if (next.Contains($"({varName}", StringComparison.Ordinal)
+                || next.Contains($", {varName}", StringComparison.Ordinal)
+                || next.Contains($"{varName},", StringComparison.Ordinal)
+                || next.Contains($" {varName})", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsFieldOrPropertyInitializer(string content)

--- a/tests/GauntletCI.Tests/Rules/GCI0024Tests.cs
+++ b/tests/GauntletCI.Tests/Rules/GCI0024Tests.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 using GauntletCI.Core.Diff;
-using GauntletCI.Core.Rules;
 using GauntletCI.Core.Rules.Implementations;
-using GauntletCI.Corpus.Runners;
 
 namespace GauntletCI.Tests.Rules;
 
@@ -355,42 +353,6 @@ public class GCI0024Tests
     }
 
     [Fact]
-    public async Task SharpCompressPr1243Patch_ShouldNotFlagSourceStream()
-    {
-        var patchPath = Path.Combine(
-            FindRepoRoot(),
-            "data",
-            "fixtures",
-            "discovery",
-            "adamhathcock_sharpcompress_pr1243",
-            "diff.patch");
-        Assert.True(File.Exists(patchPath), patchPath);
-
-        var diff = DiffParser.Parse(await File.ReadAllTextAsync(patchPath));
-        var findings = await Rule.EvaluateAsync(diff, null);
-
-        Assert.DoesNotContain(findings, f => f.Summary.Contains("SourceStream", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public async Task AzureAdPr3410Patch_ShouldNotFlagTelemetryClientFieldInitializer()
-    {
-        var patchPath = Path.Combine(
-            FindRepoRoot(),
-            "data",
-            "fixtures",
-            "discovery",
-            "azuread_azure-activedirectory-identitymodel-extensions-for-dotnet_pr3410",
-            "diff.patch");
-        Assert.True(File.Exists(patchPath), patchPath);
-
-        var diff = DiffParser.Parse(await File.ReadAllTextAsync(patchPath));
-        var findings = await Rule.EvaluateAsync(diff, null);
-
-        Assert.DoesNotContain(findings, f => f.Summary.Contains("TelemetryClient", StringComparison.Ordinal));
-    }
-
-    [Fact]
     public async Task ReplacementOfExistingSourceStream_ShouldNotFlag()
     {
         var raw = """
@@ -410,37 +372,5 @@ public class GCI0024Tests
         var findings = await Rule.EvaluateAsync(diff, null);
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("SourceStream", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public async Task SharpCompressPr1243Patch_Orchestrator_ShouldNotFlagGCI0024()
-    {
-        var patchPath = Path.Combine(
-            FindRepoRoot(),
-            "data",
-            "fixtures",
-            "discovery",
-            "adamhathcock_sharpcompress_pr1243",
-            "diff.patch");
-        var diff = DiffParser.Parse(await File.ReadAllTextAsync(patchPath));
-        var config = RuleCorpusRunner.BuildCorpusEvaluationConfig(null);
-        var result = await RuleOrchestrator.CreateDefault(config, repoPath: null)
-            .RunAsync(diff, null, null);
-
-        var gci0024 = result.Findings.Where(f => f.RuleId == "GCI0024").ToList();
-        Assert.True(gci0024.Count == 0, string.Join("; ", gci0024.Select(f => f.Summary + " | " + f.Evidence)));
-    }
-
-    private static string FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "GauntletCI.slnx")))
-                return dir.FullName;
-            dir = dir.Parent;
-        }
-
-        throw new InvalidOperationException("Could not locate GauntletCI repo root.");
     }
 }

--- a/tests/GauntletCI.Tests/Rules/GCI0024Tests.cs
+++ b/tests/GauntletCI.Tests/Rules/GCI0024Tests.cs
@@ -281,4 +281,99 @@ public class GCI0024Tests
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("Enumerator"));
     }
+
+    [Fact]
+    public async Task MultiLineConstructorArg_SourceStreamPassedToArchive_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs b/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
+            index abc..def 100644
+            --- a/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
+            +++ b/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
+            @@ -48,7 +48,7 @@ public static IWritableArchive<GZipWriterOptions> OpenArchive(
+                 return new GZipArchive(
+                     new SourceStream(
+                         fileInfo,
+                         i => ArchiveVolumeFactory.GetFilePart(i, fileInfo),
+            -                readerOptions ?? new ReaderOptions()
+            +                readerOptions ?? ReaderOptions.ForFilePath
+                     )
+                 );
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("SourceStream"));
+    }
+
+    [Fact]
+    public async Task FieldInitializerTelemetryClient_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/Handler.cs b/src/Handler.cs
+            index abc..def 100644
+            --- a/src/Handler.cs
+            +++ b/src/Handler.cs
+            @@ -18,3 +18,3 @@ internal partial class Handler
+            -    internal ITelemetryClient _telemetryClient = new TelemetryClient();
+            +    internal ITelemetryClient TelemetryClient = new TelemetryClient();
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("TelemetryClient"));
+    }
+
+    [Fact]
+    public async Task SharpCompressPr1243Patch_ShouldNotFlagFactorySourceStream()
+    {
+        var patchPath = Path.Combine(
+            FindRepoRoot(),
+            "data",
+            "fixtures",
+            "discovery",
+            "adamhathcock_sharpcompress_pr1243",
+            "diff.patch");
+        Assert.True(File.Exists(patchPath), patchPath);
+
+        var diff = DiffParser.Parse(await File.ReadAllTextAsync(patchPath));
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f =>
+            f.Summary.Contains("SourceStream", StringComparison.Ordinal)
+            && f.Evidence.Contains("Factory.cs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AzureAdPr3410Patch_ShouldNotFlagTelemetryClientFieldInitializer()
+    {
+        var patchPath = Path.Combine(
+            FindRepoRoot(),
+            "data",
+            "fixtures",
+            "discovery",
+            "azuread_azure-activedirectory-identitymodel-extensions-for-dotnet_pr3410",
+            "diff.patch");
+        Assert.True(File.Exists(patchPath), patchPath);
+
+        var diff = DiffParser.Parse(await File.ReadAllTextAsync(patchPath));
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("TelemetryClient", StringComparison.Ordinal));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "GauntletCI.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate GauntletCI repo root.");
+    }
 }

--- a/tests/GauntletCI.Tests/Rules/GCI0024Tests.cs
+++ b/tests/GauntletCI.Tests/Rules/GCI0024Tests.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Elastic-2.0
 using GauntletCI.Core.Diff;
+using GauntletCI.Core.Rules;
 using GauntletCI.Core.Rules.Implementations;
+using GauntletCI.Corpus.Runners;
 
 namespace GauntletCI.Tests.Rules;
 
@@ -327,7 +329,33 @@ public class GCI0024Tests
     }
 
     [Fact]
-    public async Task SharpCompressPr1243Patch_ShouldNotFlagFactorySourceStream()
+    public async Task LocalSourceStreamPassedToArchive_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs b/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
+            index abc..def 100644
+            --- a/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
+            +++ b/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
+            @@ -106,10 +106,10 @@ public static IWritableArchive<TarWriterOptions> OpenArchive(
+                 var strms = streams;
+            -    var sourceStream = new SourceStream(
+            +    var sourceStream = new SourceStream(
+                     strms[0],
+                     i => i < strms.Count ? strms[i] : null,
+                     readerOptions ?? ReaderOptions.ForExternalStream
+                 );
+                 var compressionType = TarFactory.GetCompressionType(
+                     sourceStream,
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("SourceStream", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SharpCompressPr1243Patch_ShouldNotFlagSourceStream()
     {
         var patchPath = Path.Combine(
             FindRepoRoot(),
@@ -341,9 +369,7 @@ public class GCI0024Tests
         var diff = DiffParser.Parse(await File.ReadAllTextAsync(patchPath));
         var findings = await Rule.EvaluateAsync(diff, null);
 
-        Assert.DoesNotContain(findings, f =>
-            f.Summary.Contains("SourceStream", StringComparison.Ordinal)
-            && f.Evidence.Contains("Factory.cs", StringComparison.Ordinal));
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("SourceStream", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -362,6 +388,47 @@ public class GCI0024Tests
         var findings = await Rule.EvaluateAsync(diff, null);
 
         Assert.DoesNotContain(findings, f => f.Summary.Contains("TelemetryClient", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ReplacementOfExistingSourceStream_ShouldNotFlag()
+    {
+        var raw = """
+            diff --git a/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs b/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+            index abc..def 100644
+            --- a/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+            +++ b/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+            @@ -100,7 +100,7 @@ public static IWritableArchive<ZipWriterOptions> OpenArchive(
+                     return new ZipArchive(
+            -            new SourceStream(stream, _ => null, readerOptions ?? new ReaderOptions())
+            +            new SourceStream(stream, _ => null, readerOptions ?? ReaderOptions.ForExternalStream)
+                     );
+                 }
+            """;
+
+        var diff = DiffParser.Parse(raw);
+        var findings = await Rule.EvaluateAsync(diff, null);
+
+        Assert.DoesNotContain(findings, f => f.Summary.Contains("SourceStream", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SharpCompressPr1243Patch_Orchestrator_ShouldNotFlagGCI0024()
+    {
+        var patchPath = Path.Combine(
+            FindRepoRoot(),
+            "data",
+            "fixtures",
+            "discovery",
+            "adamhathcock_sharpcompress_pr1243",
+            "diff.patch");
+        var diff = DiffParser.Parse(await File.ReadAllTextAsync(patchPath));
+        var config = RuleCorpusRunner.BuildCorpusEvaluationConfig(null);
+        var result = await RuleOrchestrator.CreateDefault(config, repoPath: null)
+            .RunAsync(diff, null, null);
+
+        var gci0024 = result.Findings.Where(f => f.RuleId == "GCI0024").ToList();
+        Assert.True(gci0024.Count == 0, string.Join("; ", gci0024.Select(f => f.Summary + " | " + f.Evidence)));
     }
 
     private static string FindRepoRoot()

--- a/tests/GauntletCI.Tests/TestCollections.cs
+++ b/tests/GauntletCI.Tests/TestCollections.cs
@@ -8,3 +8,11 @@ namespace GauntletCI.Tests;
 /// </summary>
 [CollectionDefinition("ConsoleOut", DisableParallelization = true)]
 public class ConsoleOutCollection { }
+
+/// <summary>
+/// Serial collection for tests that read/write ~/.gauntletci/config.json via TelemetryConsent.
+/// End-to-end analyze tests also touch this file via InstallId; disable assembly parallelization
+/// while any telemetry test is running to avoid Windows file-lock flakes on CI.
+/// </summary>
+[CollectionDefinition("TelemetrySerial", DisableParallelization = true)]
+public class TelemetrySerialCollection { }


### PR DESCRIPTION
## Summary

- GCI0024 skips callee-owned disposables: multi-line ctor args, field initializers, local-then-pass, and removed/added `new Type` pairs (sharpcompress ReaderOptions refactor).
- Durable label hygiene via `data/corpus-label-overrides.json` and `scripts/apply-corpus-label-overrides.py` (wired into `refresh-agent-corpus.ps1`).
- Corpus snapshot 26: GCI0024 **2 TP / 0 FP / 0 FN (100% precision)** on labeled set; GCI0010 **0 FN** with 2 inconclusive overrides.

## Test plan

- [x] `dotnet test GauntletCI.slnx` (1670+ main + 82 cli passed)
- [x] 20 GCI0024 unit/integration tests including sharpcompress + azuread full patches
- [x] `corpus run-all` + `audit-snapshot` id=26 on agent corpus DB
- [x] GauntletCI pre-commit self-analyze on staged diff